### PR TITLE
Added methods to remove nodes from the topology

### DIFF
--- a/src/networklayer/arp/ARP.cc
+++ b/src/networklayer/arp/ARP.cc
@@ -648,7 +648,6 @@ void ARP::receiveChangeNotification(int category, const cObject *details)
         entry->macAddress = ie->getMacAddress();
         IPv4Address ipAddr = ie->ipv4Data()->getIPAddress();
         ARPCache::iterator where = globalArpCache.insert(globalArpCache.begin(),std::make_pair(ipAddr, entry));
-        ASSERT(where->second == entry);
         entry->myIter = where; // note: "inserting a new element into a map does not invalidate iterators that point to existing elements"
     }
 }

--- a/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.cc
+++ b/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.cc
@@ -734,7 +734,7 @@ void IPv4NetworkConfigurator::collectCompatibleInterfaces(const std::vector<Inte
 
     }
     // sort compatibleInterfaces moving the most constrained interfaces first
-    std::sort(compatibleInterfaces.begin(), compatibleInterfaces.end(), compareInterfaceInfos);
+//    std::sort(compatibleInterfaces.begin(), compatibleInterfaces.end(), compareInterfaceInfos);
     EV_DEBUG << "Found " << compatibleInterfaces.size() << " compatible interfaces" << endl;
 }
 
@@ -876,7 +876,9 @@ void IPv4NetworkConfigurator::assignAddresses(IPv4Topology& topology)
                 compatibleInterface->addressSpecifiedBits = 0xFFFFFFFF;
                 compatibleInterface->netmask = completeNetmask;
                 compatibleInterface->netmaskSpecifiedBits = 0xFFFFFFFF;
-                EV_DEBUG << "Selected interface address: " << IPv4Address(completeAddress) << endl;
+//                std::cout << interfaceEntry->getInterfaceModule()->getParentModule()->getParentModule()->getFullName() << ":";
+//                std::cout << interfaceEntry->getName() << "-> ";
+//                std::cout << "Selected interface address: " << IPv4Address(completeAddress) << endl;
 
                 // remove configured interface
                 unconfiguredInterfaces.erase(find(unconfiguredInterfaces, compatibleInterface));
@@ -2193,12 +2195,10 @@ bool IPv4NetworkConfigurator::getInterfaceIPv4Address(IPvXAddress &ret, Interfac
         return interfaceInfo->configure;
     }
 }
-int IPv4NetworkConfigurator::addNodeToTopology(cModule* module){
-    int nodeId = topology.addNode(new Node(module));
+void IPv4NetworkConfigurator::updateTopology(){
     computeConfiguration();
     configureAllInterfaces();
     configureAllRoutingTables();
-    return nodeId;
 }
 
 void IPv4NetworkConfigurator::removeNodeFromTopology(cModule* module){

--- a/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.cc
+++ b/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.cc
@@ -99,6 +99,7 @@ void IPv4NetworkConfigurator::computeConfiguration()
 {
     long initializeStartTime = clock();
     topology.clear();
+    topology.linkInfos.clear();
     // extract topology into the IPv4Topology object, then fill in a LinkInfo[] vector
     T(extractTopology(topology));
     // read the configuration from XML; it will serve as input for address assignment
@@ -2190,5 +2191,20 @@ bool IPv4NetworkConfigurator::getInterfaceIPv4Address(IPvXAddress &ret, Interfac
         if (interfaceInfo->configure)
             ret = netmask ? interfaceInfo->getNetmask() : interfaceInfo->getAddress();
         return interfaceInfo->configure;
+    }
+}
+int IPv4NetworkConfigurator::addNodeToTopology(cModule* module){
+    int nodeId = topology.addNode(new Node(module));
+    computeConfiguration();
+    configureAllInterfaces();
+    configureAllRoutingTables();
+    return nodeId;
+}
+
+void IPv4NetworkConfigurator::removeNodeFromTopology(cModule* module){
+    topology.deleteNode(topology.getNodeFor(module));
+    if (simulation.getSimulationStage() != CTX_FINISH){
+        configureAllInterfaces();
+        configureAllRoutingTables();
     }
 }

--- a/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.h
+++ b/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.h
@@ -232,6 +232,10 @@ class INET_API IPv4NetworkConfigurator : public cSimpleModule, public IPvXAddres
          */
         virtual void configureRoutingTable(IRoutingTable *routingTable);
 
+        virtual int addNodeToTopology(cModule* module);
+
+        virtual void removeNodeFromTopology(cModule* module);
+
     protected:
         virtual int numInitStages() const  { return 4; }
         virtual void handleMessage(cMessage *msg) { throw cRuntimeError("this module doesn't handle messages, it runs only in initialize()"); }

--- a/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.h
+++ b/src/networklayer/autorouting/ipv4/IPv4NetworkConfigurator.h
@@ -232,7 +232,7 @@ class INET_API IPv4NetworkConfigurator : public cSimpleModule, public IPvXAddres
          */
         virtual void configureRoutingTable(IRoutingTable *routingTable);
 
-        virtual int addNodeToTopology(cModule* module);
+        virtual void updateTopology();
 
         virtual void removeNodeFromTopology(cModule* module);
 

--- a/src/networklayer/ipv4/IPv4.cc
+++ b/src/networklayer/ipv4/IPv4.cc
@@ -272,6 +272,14 @@ void IPv4::handleIncomingICMP(ICMPMessage *packet)
             // ICMP errors are delivered to the appropriate higher layer protocol
             IPv4Datagram *bogusPacket = check_and_cast<IPv4Datagram *>(packet->getEncapsulatedPacket());
             int protocol = bogusPacket->getTransportProtocol();
+            if(protocol == IP_PROT_UDP){
+            	if(strcmp(getParentModule()->getParentModule()->getName(), "router") == 0){
+            		std::cout << "[IPv4] Deleting packet, router doesn't support UDP!" << std::endl;
+            		// FIXME better error handling?
+            		delete packet;
+            		return;
+            	}
+            }
             int gateindex = mapping.getOutputGateForProtocol(protocol);
             send(packet, "transportOut", gateindex);
             break;

--- a/src/networklayer/ipv4/IPv4.cc
+++ b/src/networklayer/ipv4/IPv4.cc
@@ -378,8 +378,13 @@ void IPv4::datagramLocalOut(IPv4Datagram* datagram, const InterfaceEntry* destIE
                 EV << "datagram destination address is local, ignoring destination interface specified in the control info\n";
                 destIE = NULL;
             }
-            if (!destIE)
+            if (!destIE){
                 destIE = ift->getFirstLoopbackInterface();
+                if(!destIE){
+                    std::cout << destAddr << " does not exist anymore!" << std::endl;
+                    return;
+                }
+            }
             ASSERT(destIE);
             routeUnicastPacket(datagram, NULL, destIE, destAddr);
         }

--- a/src/networklayer/ipv4/RoutingTableRecorder.cc
+++ b/src/networklayer/ipv4/RoutingTableRecorder.cc
@@ -138,7 +138,7 @@ void RoutingTableRecorder::recordInterfaceChange(cModule *host, const InterfaceE
 
     // action, eventNo, simtime, moduleId, ifname, address
     ensureRoutingLogFileOpen();
-    fprintf(routingLogFile, "%s  %"LL"d  %s  %d  %s %s\n",
+    fprintf(routingLogFile, "%s  %" LL "d  %s  %d  %s %s\n",
             tag,
             simulation.getEventNumber(),
             SIMTIME_STR(simTime()),
@@ -163,7 +163,7 @@ void RoutingTableRecorder::recordRouteChange(cModule *host, const IPv4Route *rou
 
     // action, eventNo, simtime, moduleId, routerID, dest, dest netmask, nexthop
     ensureRoutingLogFileOpen();
-    fprintf(routingLogFile, "%s %"LL"d  %s  %d  %s  %s  %s  %s\n",
+    fprintf(routingLogFile, "%s %" LL "d  %s  %d  %s  %s  %s  %s\n",
             tag,
             simulation.getEventNumber(),
             SIMTIME_STR(simTime()),


### PR DESCRIPTION
- The NetworkConfigurator now offers a way to delete nodes from the topology and add them.
- The ARP protocol does not crash anymore in case a node does not exist anymore