### PR TITLE
Radio: Fix handling of macMaxCSMABackoffs and macMaxFrameRetries

### DIFF
--- a/src/linklayer/csma/CSMA.cc
+++ b/src/linklayer/csma/CSMA.cc
@@ -406,7 +406,7 @@ void CSMA::updateStatusCCA(t_mac_event event, cMessage *msg)
                 //BE = std::min(BE+1, macMaxBE);
 
                 // decide if we go for another backoff or if we drop the frame.
-                if (NB > macMaxCSMABackoffs) {
+                if (NB > macMaxCSMABackoffs - 1) {
                     // drop the frame
                     EV_DETAIL << "Tried " << NB << " backoffs, all reported a busy "
                               << "channel. Dropping the packet." << endl;
@@ -559,7 +559,7 @@ void CSMA::updateStatusWaitAck(t_mac_event event, cMessage *msg)
 
 void CSMA::manageMissingAck(t_mac_event    /*event*/, cMessage *    /*msg*/)
 {
-    if (txAttempts < macMaxFrameRetries + 1) {
+    if (txAttempts < macMaxFrameRetries) {
         // increment counter
         txAttempts++;
         EV_DETAIL << "I will retransmit this packet (I already tried "


### PR DESCRIPTION
Both parameters were off by one, since txAttempts as well as NB start with 0.

I am not 100% sure about this patch, but when I mentally step through the code,
the values are always off by one. Is there anything that I have overlooked?

Levente: Just for reference, we have just talked at the OMNeT++ Community Summit.

Greetings,
Florian
