### PR TITLE
fixed tosMask parsing in configureFilters function

### DIFF
--- a/src/networklayer/diffserv/MultiFieldClassifier.cc
+++ b/src/networklayer/diffserv/MultiFieldClassifier.cc
@@ -274,7 +274,7 @@ void MultiFieldClassifier::configureFilters(cXMLElement *config)
             if (tosAttr)
                 filter.tos = parseIntAttribute(tosAttr, "tos");
             if (tosMaskAttr)
-                filter.tosMask = parseIntAttribute(tosAttr, "tosMask");
+                filter.tosMask = parseIntAttribute(tosMaskAttr, "tosMask");
             if (srcPortAttr)
                 filter.srcPortMin = filter.srcPortMax = parseIntAttribute(srcPortAttr, "srcPort");
             if (srcPortMinAttr)


### PR DESCRIPTION
In MultiFieldClassifier::configureFilters line 277, fixed the first argument of parseIntAttribute, wich sometimes were inducing wrong destination when using tos  in XML file to configure classification.
