### PR TITLE
fix: remove radio from medium at destruction

### DIFF
--- a/src/inet/physicallayer/common/Radio.cc
+++ b/src/inet/physicallayer/common/Radio.cc
@@ -55,6 +55,8 @@ Radio::Radio() :
 
 Radio::~Radio()
 {
+    if (medium)
+        medium->removeRadio(this);
     cancelAndDelete(endTransmissionTimer);
     cancelAndDelete(endSwitchTimer);
 }


### PR DESCRIPTION
Without removal a SEGFAULT is caused in RadioMedium::computeMaxSpeed for dynamic radios, e.g. those controlled via TraCIScenarioManager