### PR TITLE
Fixes compiler error when compiling feature IPv6 without feature xMIPv6

### DIFF
--- a/src/inet/networklayer/ipv6/IPv6.cc
+++ b/src/inet/networklayer/ipv6/IPv6.cc
@@ -53,6 +53,7 @@ IPv6::~IPv6()
 {
 }
 
+#ifdef WITH_xMIPv6
 IPv6::ScheduledDatagram::ScheduledDatagram(IPv6Datagram *datagram, const InterfaceEntry *ie, MACAddress macAddr, bool fromHL) :
         datagram(datagram),
         ie(ie),
@@ -65,6 +66,7 @@ IPv6::ScheduledDatagram::~ScheduledDatagram()
 {
     delete datagram;
 }
+#endif /* WITH_xMIPv6 */
 
 void IPv6::initialize(int stage)
 {


### PR DESCRIPTION
This fixes a problem that I experienced when compiling with a custom feature configuration without xMIPv6

Best regards
Till