### PR TITLE
Implementation is required for IPv6 feature and cannot be disabled when xMIPv6 is disabled.

### DIFF
--- a/src/inet/networklayer/ipv6/IPv6RoutingTable.cc
+++ b/src/inet/networklayer/ipv6/IPv6RoutingTable.cc
@@ -852,6 +852,22 @@ void IPv6RoutingTable::deletePrefixes(int interfaceID)
     updateDisplayString();
 }
 
+bool IPv6RoutingTable::isOnLinkAddress(const IPv6Address& address)
+{
+    for (int j = 0; j < ift->getNumInterfaces(); j++) {
+        InterfaceEntry *ie = ift->getInterface(j);
+
+        for (int i = 0; i < ie->ipv6Data()->getNumAdvPrefixes(); i++)
+            if (address.matches(ie->ipv6Data()->getAdvPrefix(i).prefix, ie->ipv6Data()->getAdvPrefix(i).prefixLength))
+                return true;
+
+    }
+
+    return false;
+}
+
+#endif /* WITH_xMIPv6 */
+
 void IPv6RoutingTable::deleteInterfaceRoutes(const InterfaceEntry *entry)
 {
     bool changed = false;
@@ -876,22 +892,6 @@ void IPv6RoutingTable::deleteInterfaceRoutes(const InterfaceEntry *entry)
         updateDisplayString();
     }
 }
-
-bool IPv6RoutingTable::isOnLinkAddress(const IPv6Address& address)
-{
-    for (int j = 0; j < ift->getNumInterfaces(); j++) {
-        InterfaceEntry *ie = ift->getInterface(j);
-
-        for (int i = 0; i < ie->ipv6Data()->getNumAdvPrefixes(); i++)
-            if (address.matches(ie->ipv6Data()->getAdvPrefix(i).prefix, ie->ipv6Data()->getAdvPrefix(i).prefixLength))
-                return true;
-
-    }
-
-    return false;
-}
-
-#endif /* WITH_xMIPv6 */
 
 bool IPv6RoutingTable::handleOperationStage(LifecycleOperation *operation, int stage, IDoneCallback *doneCallback)
 {

--- a/src/inet/networklayer/pim/modes/PIMBase.cc
+++ b/src/inet/networklayer/pim/modes/PIMBase.cc
@@ -31,7 +31,7 @@ using namespace std;
 
 const IPv4Address PIMBase::ALL_PIM_ROUTERS_MCAST("224.0.0.13");
 
-const PIMBase::AssertMetric PIMBase::AssertMetric::INFINITE;
+const PIMBase::AssertMetric PIMBase::AssertMetric::PIM_INFINITE;
 
 simsignal_t PIMBase::sentHelloPkSignal = registerSignal("sentHelloPk");
 simsignal_t PIMBase::rcvdHelloPkSignal = registerSignal("rcvdHelloPk");

--- a/src/inet/networklayer/pim/modes/PIMBase.h
+++ b/src/inet/networklayer/pim/modes/PIMBase.h
@@ -44,7 +44,7 @@ class INET_API PIMBase : public OperationalBase
         int metric;
         IPv4Address address;
 
-        static const AssertMetric INFINITE;
+        static const AssertMetric PIM_INFINITE;
 
         AssertMetric() : rptBit(1), preference(-1), metric(0) {}
         AssertMetric(int preference, int metric, IPv4Address address) :
@@ -110,7 +110,7 @@ class INET_API PIMBase : public OperationalBase
         void deleteAssertInfo()
         {
             assertState = NO_ASSERT_INFO;
-            winnerMetric = AssertMetric::INFINITE;
+            winnerMetric = AssertMetric::PIM_INFINITE;
             owner->owner->cancelAndDelete(assertTimer);
             assertTimer = nullptr;
         }

--- a/src/inet/networklayer/pim/modes/PIMSM.cc
+++ b/src/inet/networklayer/pim/modes/PIMSM.cc
@@ -719,7 +719,7 @@ void PIMSM::processAssertSG(PimsmInterface *interface, const AssertMetric& recei
     Route *routeSG = interface->route();
     AssertMetric myMetric = interface->couldAssert() ? // XXX check routeG metric too
         routeSG->metric.setAddress(interface->ie->ipv4Data()->getIPAddress()) :
-        AssertMetric::INFINITE;
+        AssertMetric::PIM_INFINITE;
 
     // A "preferred assert" is one with a better metric than the current winner.
     bool isPreferredAssert = receivedMetric < interface->winnerMetric;
@@ -827,7 +827,7 @@ void PIMSM::processAssertG(PimsmInterface *interface, const AssertMetric& receiv
     Route *routeG = interface->route();
     AssertMetric myMetric = interface->couldAssert() ?
         routeG->metric.setAddress(interface->ie->ipv4Data()->getIPAddress()) :
-        AssertMetric::INFINITE;
+        AssertMetric::PIM_INFINITE;
 
     // A "preferred assert" is one with a better metric than the current winner.
     bool isPreferredAssert = receivedMetric < interface->winnerMetric;


### PR DESCRIPTION
Sorry, this only came up when I started testing with OS X on our jenkins!
Same Issue as previous pull request

Second commit fixes an issue that came up in our windows jenkins slave: See also https://groups.google.com/forum/#!topic/inetframework-contrib/mPweUaLIlyg

Best Till