### PR TITLE
removed depricated register to resolve the warnings with LLVM version 6....

### DIFF
--- a/src/inet/common/INETMath.h
+++ b/src/inet/common/INETMath.h
@@ -201,8 +201,8 @@ inline double n_choose_k(int n, int k) {
 
     const int       iK     = (k<<1) > n ? n-k : k;
     const double    dNSubK = (n-iK);
-    register int    i      = 1;
-    register double dRes   = i > iK ? 1.0 : (dNSubK+i);
+    int    i      = 1;
+    double dRes   = i > iK ? 1.0 : (dNSubK+i);
 
     for (++i; i <= iK; ++i) {
         dRes *= dNSubK+i;


### PR DESCRIPTION
...0 when compiling using c++11 (see also http://en.cppreference.com/w/cpp/language/storage_duration). This should be done in OMNeT++ as well!

Best regards
Till