### PR TITLE
Follow up of pull request #42

### DIFF
--- a/src/inet/common/INETMath.h
+++ b/src/inet/common/INETMath.h
@@ -201,8 +201,8 @@ inline double n_choose_k(int n, int k) {
 
     const int       iK     = (k<<1) > n ? n-k : k;
     const double    dNSubK = (n-iK);
-    register int    i      = 1;
-    register double dRes   = i > iK ? 1.0 : (dNSubK+i);
+    int    i      = 1;
+    double dRes   = i > iK ? 1.0 : (dNSubK+i);
 
     for (++i; i <= iK; ++i) {
         dRes *= dNSubK+i;

--- a/src/inet/common/serializer/sctp/SCTPSerializer.cc
+++ b/src/inet/common/serializer/sctp/SCTPSerializer.cc
@@ -1061,8 +1061,8 @@ uint32 SCTPSerializer::checksum(const uint8_t *buf, register uint32 len)
     uint32 h;
     unsigned char byte0, byte1, byte2, byte3;
     uint32 crc32c;
-    register uint32 i;
-    register uint32 res = (~0L);
+    uint32 i;
+    uint32 res = (~0L);
     for (i = 0; i < len; i++)
         CRC32C(res, buf[i]);
     h = ~res;

--- a/src/inet/physicallayer/common/Modulation.cc
+++ b/src/inet/physicallayer/common/Modulation.cc
@@ -47,7 +47,7 @@ double DSSSOQPSK16Modulation::calculateBER(double snir, double bandwidth, double
 	// calculations, formula 7). Here you can see that the factor of 20.0 is correct ;).
 	const double dSNRFct = 20.0 * snir * bandwidth / bitrate; // TODO is this correct?
 	double       dSumK   = 0;
-	register int k       = 2;
+	int k       = 2;
 
 	/* following loop was optimized by using n_choose_k symmetries
 	for (k=2; k <= 16; ++k) {


### PR DESCRIPTION
Finding "register" in a framework that deals with protocols is hard :)
I found two more occurrences of "register" that I missed in pullrequest #42 