### PR TITLE
Flush cached reception intervals

### DIFF
--- a/src/inet/common/IntervalTree.cc
+++ b/src/inet/common/IntervalTree.cc
@@ -415,6 +415,14 @@ void IntervalTree::deleteFixup(IntervalTreeNode* x)
     x->red = false;
 }
 
+void IntervalTree::deleteAllBefore(simtime_t before)
+{
+    auto intervals = query(simtime_t(), before);
+    for (auto& interval : intervals) {
+        deleteNode(interval);
+    }
+}
+
 void IntervalTree::deleteNode(Interval* ivl)
 {
     IntervalTreeNode* node = recursiveSearch(root, ivl);

--- a/src/inet/common/IntervalTree.h
+++ b/src/inet/common/IntervalTree.h
@@ -133,6 +133,9 @@ class IntervalTree
     /// @brief delete node stored a given interval
     void deleteNode(Interval* ivl);
 
+    /// @brief delete all nodes with intervals ending before given time stamp
+    void deleteAllBefore(simtime_t before);
+
     /// @brief Insert one node of the interval tree
     IntervalTreeNode* insert(Interval* new_interval);
 

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
@@ -86,6 +86,7 @@ Ieee80211Mac::~Ieee80211Mac()
     edcCAFOutVector.clear();
     if (pendingRadioConfigMsg)
         delete pendingRadioConfigMsg;
+    delete classifier;
 }
 
 /****************************************************************

--- a/src/inet/physicallayer/common/RadioMedium.cc
+++ b/src/inet/physicallayer/common/RadioMedium.cc
@@ -661,19 +661,14 @@ void RadioMedium::removeNonInterferingTransmissions()
         transmissionIndex++;
     EV_DEBUG << "Removing " << transmissionIndex << " non interfering transmissions\n";
     baseTransmissionId += transmissionIndex;
+    for (const auto* radio : radios) {
+        if (radio != nullptr) {
+            RadioCacheEntry *radioCacheEntry = getRadioCacheEntry(radio);
+            radioCacheEntry->receptionIntervals->deleteAllBefore(now);
+        }
+    }
     for (std::vector<const ITransmission *>::const_iterator it = transmissions.begin(); it != transmissions.begin() + transmissionIndex; it++) {
         const ITransmission *transmission = *it;
-        for (std::vector<const IRadio *>::const_iterator jt = radios.begin(); jt != radios.end(); jt++) {
-            const IRadio *radio = *jt;
-            if (radio != nullptr) {
-                RadioCacheEntry *radioCacheEntry = getRadioCacheEntry(radio);
-                const IArrival *arrival = getCachedArrival(radio, transmission);
-                if (arrival) {
-                    Interval interval(arrival->getStartTime(), arrival->getEndTime(), (void *)transmission);
-                    radioCacheEntry->receptionIntervals->deleteNode(&interval);
-                }
-            }
-        }
         delete transmission;
     }
     transmissions.erase(transmissions.begin(), transmissions.begin() + transmissionIndex);


### PR DESCRIPTION
Cache with reception intervals never got flushed. Thus, INET heap memory usage was huge, especially when a lot of transmissions occurred.