### PR TITLE
initial value of ssthresh

### DIFF
--- a/src/transport/tcp/TCPConnection.h
+++ b/src/transport/tcp/TCPConnection.h
@@ -152,7 +152,7 @@ class INET_API TCPStateVariables : public cObject
     TCPStateVariables();
     virtual std::string info() const;
     virtual std::string detailedInfo() const;
-    virtual void reInitialState() {};
+    virtual void setSendQueueLimit(uint32 newLimit);
   public:
     bool active;         // set if the connection was initiated by an active open
     bool fork;           // if passive and in LISTEN: whether to fork on an incoming connection

--- a/src/transport/tcp/TCPConnection.h
+++ b/src/transport/tcp/TCPConnection.h
@@ -152,6 +152,7 @@ class INET_API TCPStateVariables : public cObject
     TCPStateVariables();
     virtual std::string info() const;
     virtual std::string detailedInfo() const;
+    virtual void reInitialState() {};
   public:
     bool active;         // set if the connection was initiated by an active open
     bool fork;           // if passive and in LISTEN: whether to fork on an incoming connection
@@ -686,7 +687,6 @@ class INET_API TCPConnection
      * Utility: checks if send queue is empty (no data to send).
      */
     virtual bool isSendQueueEmpty();
-
 };
 
 #endif

--- a/src/transport/tcp/TCPConnectionBase.cc
+++ b/src/transport/tcp/TCPConnectionBase.cc
@@ -127,6 +127,11 @@ std::string TCPStateVariables::info() const
     return out.str();
 }
 
+void TCPStateVariables::setSendQueueLimit(uint32 newLimit)
+{
+    sendQueueLimit = newLimit;
+}
+
 std::string TCPStateVariables::detailedInfo() const
 {
     std::stringstream out;

--- a/src/transport/tcp/TCPConnectionEventProc.cc
+++ b/src/transport/tcp/TCPConnectionEventProc.cc
@@ -296,9 +296,8 @@ void TCPConnection::process_QUEUE_BYTES_LIMIT(TCPEventCode& event, TCPCommand *t
     if(state == NULL)
         opp_error("Called process_QUEUE_BYTES_LIMIT on uninitialized TCPConnection!");
 
-    state->sendQueueLimit = tcpCommand->getUserId(); // Set queue size limit
-    // New maximum Queue Size Limit (comparable to a socket systemcall - structure must be reinitialized)
-    state->reInitialState();
+    state->setSendQueueLimit(tcpCommand->getUserId()); // Set queue size limit
+
     tcpEV << "state->sendQueueLimit set to " << state->sendQueueLimit << "\n";
     delete msg;
     delete tcpCommand;

--- a/src/transport/tcp/TCPConnectionEventProc.cc
+++ b/src/transport/tcp/TCPConnectionEventProc.cc
@@ -297,6 +297,8 @@ void TCPConnection::process_QUEUE_BYTES_LIMIT(TCPEventCode& event, TCPCommand *t
         opp_error("Called process_QUEUE_BYTES_LIMIT on uninitialized TCPConnection!");
 
     state->sendQueueLimit = tcpCommand->getUserId(); // Set queue size limit
+    // New maximum Queue Size Limit (comparable to a socket systemcall - structure must be reinitialized)
+    state->reInitialState();
     tcpEV << "state->sendQueueLimit set to " << state->sendQueueLimit << "\n";
     delete msg;
     delete tcpCommand;

--- a/src/transport/tcp/flavours/TCPBaseAlg.h
+++ b/src/transport/tcp/flavours/TCPBaseAlg.h
@@ -33,7 +33,7 @@ class INET_API TCPBaseAlgStateVariables : public TCPStateVariables
     TCPBaseAlgStateVariables();
     virtual std::string info() const;
     virtual std::string detailedInfo() const;
-
+    virtual void reInitialState() {};
     /// retransmit count
     //@{
     int rexmit_count;         ///< number of retransmissions (=1 after first rexmit)

--- a/src/transport/tcp/flavours/TCPBaseAlg.h
+++ b/src/transport/tcp/flavours/TCPBaseAlg.h
@@ -33,7 +33,6 @@ class INET_API TCPBaseAlgStateVariables : public TCPStateVariables
     TCPBaseAlgStateVariables();
     virtual std::string info() const;
     virtual std::string detailedInfo() const;
-    virtual void reInitialState() {};
     /// retransmit count
     //@{
     int rexmit_count;         ///< number of retransmissions (=1 after first rexmit)

--- a/src/transport/tcp/flavours/TCPTahoeRenoFamily.cc
+++ b/src/transport/tcp/flavours/TCPTahoeRenoFamily.cc
@@ -22,7 +22,17 @@
 
 TCPTahoeRenoFamilyStateVariables::TCPTahoeRenoFamilyStateVariables()
 {
-    ssthresh = 65535;
+    // The initial value of ssthresh SHOULD be set arbitrarily high (e.g.,
+    // to the size of the largest possible advertised window)
+    // Without user interaction there is no limit...
+    ssthresh = 0xFFFFFFFF;
+}
+
+void TCPTahoeRenoFamilyStateVariables::reInitialState(){
+    // The initial value of ssthresh SHOULD be set arbitrarily high (e.g.,
+    // to the size of the largest possible advertised window) -> defined by sendQueueLimit
+    if(this->sendQueueLimit)
+        ssthresh = sendQueueLimit;
 }
 
 std::string TCPTahoeRenoFamilyStateVariables::info() const

--- a/src/transport/tcp/flavours/TCPTahoeRenoFamily.cc
+++ b/src/transport/tcp/flavours/TCPTahoeRenoFamily.cc
@@ -28,11 +28,11 @@ TCPTahoeRenoFamilyStateVariables::TCPTahoeRenoFamilyStateVariables()
     ssthresh = 0xFFFFFFFF;
 }
 
-void TCPTahoeRenoFamilyStateVariables::reInitialState(){
+void TCPTahoeRenoFamilyStateVariables::setSendQueueLimit(uint32 newLimit){
     // The initial value of ssthresh SHOULD be set arbitrarily high (e.g.,
     // to the size of the largest possible advertised window) -> defined by sendQueueLimit
-    if(this->sendQueueLimit)
-        ssthresh = sendQueueLimit;
+    sendQueueLimit = newLimit;
+    ssthresh = sendQueueLimit;
 }
 
 std::string TCPTahoeRenoFamilyStateVariables::info() const

--- a/src/transport/tcp/flavours/TCPTahoeRenoFamily.h
+++ b/src/transport/tcp/flavours/TCPTahoeRenoFamily.h
@@ -32,7 +32,7 @@ class INET_API TCPTahoeRenoFamilyStateVariables : public TCPBaseAlgStateVariable
     TCPTahoeRenoFamilyStateVariables();
     virtual std::string info() const;
     virtual std::string detailedInfo() const;
-    virtual void reInitialState();
+    virtual void setSendQueueLimit(uint32 newLimit);
     uint32 ssthresh;  ///< slow start threshold
 };
 

--- a/src/transport/tcp/flavours/TCPTahoeRenoFamily.h
+++ b/src/transport/tcp/flavours/TCPTahoeRenoFamily.h
@@ -32,7 +32,7 @@ class INET_API TCPTahoeRenoFamilyStateVariables : public TCPBaseAlgStateVariable
     TCPTahoeRenoFamilyStateVariables();
     virtual std::string info() const;
     virtual std::string detailedInfo() const;
-
+    virtual void reInitialState();
     uint32 ssthresh;  ///< slow start threshold
 };
 


### PR DESCRIPTION
Two points:

1) the initial value of  ssthresh = 65535 is usually too small. Therefore the slow start is limited too early,
 As long no limit (like send buffer size) is given the sky should be the limit.

rfc5681: The initial value of ssthresh SHOULD be set arbitrarily high (e.g., to the size of the largest possible advertised window)

2) Netperfmeter uses a kind of socketcall to manipulate the max send buffer (sendQueue size) by a dirty workaround ( tcpCommand->getUserId()).
However, after the send buffer is set, the state of the connection should be reinitialized (e.g. to set the initial value of the ssthresh) 