### PR TITLE
fixes build without ieee80211

### DIFF
--- a/.oppfeatures
+++ b/.oppfeatures
@@ -723,6 +723,7 @@
         nedPackages = "
                        inet.linklayer.ieee80211
                        inet.physicallayer.ieee80211
+                       inet.common.serializer.headerserializers.ieee80211
                        inet.node.wireless
                       "
         extraSourceFolders = ""

--- a/src/inet/common/serializer/ipv6/IPv6Serializer.cc
+++ b/src/inet/common/serializer/ipv6/IPv6Serializer.cc
@@ -55,7 +55,9 @@ namespace inet {
 namespace serializer {
 
 using namespace tcp;
+#ifdef WITH_SCTP
 using namespace sctp;
+#endif // ifdef WITH_SCTP
 
 int IPv6Serializer::serialize(const IPv6Datagram *dgram, unsigned char *buf, unsigned int bufsize)
 {


### PR DESCRIPTION
Hi everyone!
We build net only with wired physical layer. This fixes a dependency problem when ieee80211 is disabled.

Best regards
Till