### PR TITLE
Added the version define that is already present in INET 2.6.0

### DIFF
--- a/src/inet/common/INETDefs.h
+++ b/src/inet/common/INETDefs.h
@@ -29,6 +29,8 @@
 #  error At least OMNeT++/OMNEST version 4.6 required
 #endif // if OMNETPP_VERSION < 0x0406
 
+#define INET_VERSION 0x0299
+
 #if defined(INET_EXPORT)
 #  define INET_API    OPP_DLLEXPORT
 #elif defined(INET_IMPORT)


### PR DESCRIPTION
This is almost obsolete with the merge! But can we set the INET_VERSION to 0299?