### PR TITLE
compat.h: check_and_cast should be defined in optional omnetpp namespace not in inet!

### DIFF
--- a/src/inet/common/Compat.h
+++ b/src/inet/common/Compat.h
@@ -92,6 +92,9 @@ inline double fmax(double a, double b)
 } // namespace inet
 
 #if OMNETPP_VERSION < 0x0500
+
+NAMESPACE_BEGIN
+
 /**
  * A check_and_cast<> that accepts pointers other than cObject*, too.
  * For compatibility; OMNeT++ 5.0 and later already contain this.
@@ -139,6 +142,8 @@ T check_and_cast_nullable(P *p)
         return nullptr;
     return check_and_cast<T>(p);
 }
+
+NAMESPACE_END
 
 #endif    // OMNETPP_VERSION < 0x0500
 

--- a/src/inet/common/Compat.h
+++ b/src/inet/common/Compat.h
@@ -89,6 +89,8 @@ inline double fmax(double a, double b)
 
 #endif    // _MSC_VER
 
+} // namespace inet
+
 #if OMNETPP_VERSION < 0x0500
 /**
  * A check_and_cast<> that accepts pointers other than cObject*, too.
@@ -139,8 +141,6 @@ T check_and_cast_nullable(P *p)
 }
 
 #endif    // OMNETPP_VERSION < 0x0500
-
-} // namespace inet
 
 #endif // ifndef __INET_COMPAT_H
 


### PR DESCRIPTION
Please check if it is ok to use NAMESPACE macros in inet.