### PR TITLE
Integration netperfmeter updates 11mar2015

### DIFF
--- a/src/inet/applications/netperfmeter/NetPerfMeter.h
+++ b/src/inet/applications/netperfmeter/NetPerfMeter.h
@@ -80,56 +80,56 @@ class INET_API NetPerfMeter : public cSimpleModule
       UDP  = 2
    };
    enum TimerType {
-      TIMER_CONNECT    = 1,
-      TIMER_START      = 2,
-      TIMER_RESET      = 3,
-      TIMER_STOP       = 4,
-      TIMER_TRANSMIT   = 5,
-      TIMER_DISCONNECT = 6,
-      TIMER_RECONNECT  = 7
+      TIMER_CONNECT  = 1,
+      TIMER_START    = 2,
+      TIMER_RESET    = 3,
+      TIMER_STOP     = 4,
+      TIMER_TRANSMIT = 5,
+      TIMER_OFF      = 6,
+      TIMER_ON       = 7
    };
 
-   Protocol              TransportProtocol;
-   bool                  ActiveMode;
-   bool                  SendingAllowed;
-   bool                  HasFinished;
-   unsigned int          MaxMsgSize;
-   unsigned int          QueueSize;
-   double                UnorderedMode;
-   double                UnreliableMode;
-   bool                  DecoupleSaturatedStreams;
-   simtime_t             ConnectTime;
-   simtime_t             StartTime;
-   simtime_t             ResetTime;
-   simtime_t             StopTime;
-   cMessage*             ConnectTimer;
-   cMessage*             StartTimer;
-   cMessage*             StopTimer;
-   cMessage*             ResetTimer;
-   cMessage*             DisconnectTimer;
-   cMessage*             ReconnectTimer;
-   unsigned int          EstablishedConnections;
-   unsigned int          MaxReconnects;
+   Protocol                TransportProtocol;
+   bool                    ActiveMode;
+   bool                    SendingAllowed;
+   bool                    HasFinished;
+   unsigned int            MaxMsgSize;
+   unsigned int            QueueSize;
+   double                  UnorderedMode;
+   double                  UnreliableMode;
+   bool                    DecoupleSaturatedStreams;
+   simtime_t               ConnectTime;
+   simtime_t               StartTime;
+   simtime_t               ResetTime;
+   simtime_t               StopTime;
+   cMessage*               ConnectTimer;
+   cMessage*               StartTimer;
+   cMessage*               StopTimer;
+   cMessage*               ResetTimer;
+   cMessage*               OffTimer;
+   cMessage*               OnTimer;
+   unsigned int            OnOffCycleCounter;
+   int                     MaxOnOffCycles;
    std::vector<NetPerfMeterTransmitTimer*>
-                         TransmitTimerVector;
+                           TransmitTimerVector;
 
-   unsigned int          RequestedOutboundStreams;
-   unsigned int          MaxInboundStreams;
-   unsigned int          ActualOutboundStreams;
-   unsigned int          ActualInboundStreams;
+   unsigned int            RequestedOutboundStreams;
+   unsigned int            MaxInboundStreams;
+   unsigned int            ActualOutboundStreams;
+   unsigned int            ActualInboundStreams;
    std::vector<cDynamicExpression>
-                         FrameRateExpressionVector;
+                           FrameRateExpressionVector;
    std::vector<cDynamicExpression>
-                         FrameSizeExpressionVector;
+                           FrameSizeExpressionVector;
 
    // ====== Sockets and Connection Information =============================
-   SCTPSocket*           SocketSCTP;
-   SCTPSocket*           IncomingSocketSCTP;
-   TCPSocket*            SocketTCP;
-   TCPSocket*            IncomingSocketTCP;
-   UDPSocket*            SocketUDP;
-   int                   ConnectionID;
-   L3Address             PrimaryPath;
+   SCTPSocket*             SocketSCTP;
+   SCTPSocket*             IncomingSocketSCTP;
+   TCPSocket*              SocketTCP;
+   TCPSocket*              IncomingSocketTCP;
+   UDPSocket*              SocketUDP;
+   int                     ConnectionID;
+   L3Address               PrimaryPath;
 
    // ====== Trace File Handling ============================================
    struct TraceEntry {
@@ -137,19 +137,19 @@ class INET_API NetPerfMeter : public cSimpleModule
       unsigned int FrameSize;
       unsigned int StreamID;
    };
-   std::vector<TraceEntry> TraceVector;                // Frame trace from file
-   size_t                  TraceIndex;                 // Position in trace file
+   std::vector<TraceEntry> TraceVector;                  // Frame trace from file
+   size_t                  TraceIndex;                   // Position in trace file
 
    // ====== Timers =========================================================
-   simtime_t             TransmissionStartTime;        // Absolute transmission start time
-   simtime_t             ConnectionEstablishmentTime;  // Absolute connection establishment time
-   simtime_t             StatisticsResetTime;          // Absolute statistics reset time
+   simtime_t               TransmissionStartTime;        // Absolute transmission start time
+   simtime_t               ConnectionEstablishmentTime;  // Absolute connection establishment time
+   simtime_t               StatisticsResetTime;          // Absolute statistics reset time
 
    // ====== Variables ======================================================
-   unsigned int          LastStreamID;                 // Stream number of last message being sent
+   unsigned int            LastStreamID;                 // Stream number of last message being sent
 
    // ====== Statistics =====================================================
-   simtime_t             StatisticsStartTime;          // Absolute start time of statistics recording
+   simtime_t               StatisticsStartTime;          // Absolute start time of statistics recording
 
    private:
    class SenderStatistics {
@@ -200,6 +200,8 @@ class INET_API NetPerfMeter : public cSimpleModule
    }
    double        getFrameRate(const unsigned int streamID);
    unsigned long getFrameSize(const unsigned int streamID);
+   void startSending();
+   void stopSending();
    void sendDataOfTraceFile(const unsigned long long bytesAvailableInQueue);
    void sendDataOfSaturatedStreams(const unsigned long long   bytesAvailableInQueue,
                                    const SCTPSendQueueAbated* sendQueueAbatedIndication);

--- a/src/inet/applications/netperfmeter/NetPerfMeter.ned
+++ b/src/inet/applications/netperfmeter/NetPerfMeter.ned
@@ -45,7 +45,7 @@ simple NetPerfMeter like INetPerfMeterApp
 
         double          onTime          @unit(s) = default(-1s);       // Online time; disconnect when timer expires
         double          offTime         @unit(s) = default(-1s);       // Offline time; reconnect when timer expires
-        int             maxReconnects            = default(0);         // Maximum number of reconnects
+        int             maxOnOffCycles           = default(0);         // Maximum number of on-off cycles (-1 for unlimited)
 
         int             outboundStreams          = default(1);         // Number of outbound streams (SCTP only)
         int             maxInboundStreams        = default(16);        // Maximum number of inbound streams (SCTP only)

--- a/src/inet/applications/netperfmeter/NetPerfMeterHost.ned
+++ b/src/inet/applications/netperfmeter/NetPerfMeterHost.ned
@@ -27,11 +27,12 @@
 
 package inet.applications.netperfmeter;
 
-import inet.nodes.inet.NodeBase;
 import inet.applications.INetPerfMeterApp;
-import inet.transport.ISCTP;
-import inet.transport.ITCP;
-import inet.transport.IUDP;
+import inet.node.inet.NodeBase;
+import inet.transportlayer.contract.ISCTP;
+import inet.transportlayer.contract.ITCP;
+import inet.transportlayer.contract.IUDP;
+
 
 //
 // NetPerfMeter application host.
@@ -44,7 +45,7 @@ module NetPerfMeterHost extends NodeBase
         string tcpType = default(firstAvailable("TCP", "TCP_lwIP", "TCP_NSC", "TCP_None"));  // tcp implementation (e.g. ~TCP, ~TCP_lwIP, ~TCP_NSC) or ~TCPSpoof
         string udpType = default(firstAvailable("UDP", "UDP_None"));
         string sctpType = default(firstAvailable("SCTP", "SCTP_None"));
-        IPForward = default(false);  // disable routing by default
+        forwarding = default(false);  // disable routing by default
 
     submodules:
         netPerfMeterApp[numNetPerfMeterApps]: <default("NetPerfMeter")> like INetPerfMeterApp {  // T.D. 17.11.09

--- a/src/inet/applications/netperfmeter/NetPerfMeterHost.ned
+++ b/src/inet/applications/netperfmeter/NetPerfMeterHost.ned
@@ -27,12 +27,11 @@
 
 package inet.applications.netperfmeter;
 
+import inet.nodes.inet.NodeBase;
 import inet.applications.INetPerfMeterApp;
-import inet.node.inet.NodeBase;
-import inet.transportlayer.contract.ISCTP;
-import inet.transportlayer.contract.ITCP;
-import inet.transportlayer.contract.IUDP;
-
+import inet.transport.ISCTP;
+import inet.transport.ITCP;
+import inet.transport.IUDP;
 
 //
 // NetPerfMeter application host.
@@ -45,7 +44,7 @@ module NetPerfMeterHost extends NodeBase
         string tcpType = default(firstAvailable("TCP", "TCP_lwIP", "TCP_NSC", "TCP_None"));  // tcp implementation (e.g. ~TCP, ~TCP_lwIP, ~TCP_NSC) or ~TCPSpoof
         string udpType = default(firstAvailable("UDP", "UDP_None"));
         string sctpType = default(firstAvailable("SCTP", "SCTP_None"));
-        forwarding = default(false);  // disable routing by default
+        IPForward = default(false);  // disable routing by default
 
     submodules:
         netPerfMeterApp[numNetPerfMeterApps]: <default("NetPerfMeter")> like INetPerfMeterApp {  // T.D. 17.11.09


### PR DESCRIPTION
A couple of fixes and improvements for the NetPerfMeter model:
- Fixes and code clean-ups for bidirectional data transfer
- UDP fixes
- On/off behaviour is now working like for the real application (https://www.uni-due.de/~be0001/netperfmeter/)
- Added Pareto distribution as NED function, since it is very convenient for modelling background traffic. This may be realized in a better way, e.g. by moving to OMNeT++ directly.