### PR TITLE
Td sctp cc init bugfix 16mar2015

### DIFF
--- a/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
@@ -1545,6 +1545,10 @@ void SCTPAssociation::stateEntered(int32 status)
             switch (ccModule) {
                 case RFC4960: {
                     ccFunctions.ccInitParams = &SCTPAssociation::initCCParameters;
+<<<<<<< HEAD
+=======
+                    ccFunctions.ccUpdateBeforeSack = &SCTPAssociation::cwndUpdateBeforeSack;
+>>>>>>> 79de7f8... Bugfix: ccFunctions.ccUpdateBeforeSack = &SCTPAssociation::cwndUpdateBeforeSack.
                     ccFunctions.ccUpdateAfterSack = &SCTPAssociation::cwndUpdateAfterSack;
                     ccFunctions.ccUpdateAfterCwndTimeout = &SCTPAssociation::cwndUpdateAfterCwndTimeout;
                     ccFunctions.ccUpdateAfterRtxTimeout = &SCTPAssociation::cwndUpdateAfterRtxTimeout;

--- a/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
@@ -1545,10 +1545,7 @@ void SCTPAssociation::stateEntered(int32 status)
             switch (ccModule) {
                 case RFC4960: {
                     ccFunctions.ccInitParams = &SCTPAssociation::initCCParameters;
-<<<<<<< HEAD
-=======
                     ccFunctions.ccUpdateBeforeSack = &SCTPAssociation::cwndUpdateBeforeSack;
->>>>>>> 79de7f8... Bugfix: ccFunctions.ccUpdateBeforeSack = &SCTPAssociation::cwndUpdateBeforeSack.
                     ccFunctions.ccUpdateAfterSack = &SCTPAssociation::cwndUpdateAfterSack;
                     ccFunctions.ccUpdateAfterCwndTimeout = &SCTPAssociation::cwndUpdateAfterCwndTimeout;
                     ccFunctions.ccUpdateAfterRtxTimeout = &SCTPAssociation::cwndUpdateAfterRtxTimeout;


### PR DESCRIPTION
ccFunctions.ccUpdateBeforeSack needs to be initialised with &SCTPAssociation::cwndUpdateBeforeSack. Otherwise, ccFunctions.ccUpdateBeforeSack is nullptr, and the call to this function will fail.