### PR TITLE
CC function initialisation bugfix: need to initialise function to call before SACK

### DIFF
--- a/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
@@ -1545,6 +1545,7 @@ void SCTPAssociation::stateEntered(int32 status)
             switch (ccModule) {
                 case RFC4960: {
                     ccFunctions.ccInitParams = &SCTPAssociation::initCCParameters;
+                    ccFunctions.ccUpdateBeforeSack = &SCTPAssociation::cwndUpdateBeforeSack;
                     ccFunctions.ccUpdateAfterSack = &SCTPAssociation::cwndUpdateAfterSack;
                     ccFunctions.ccUpdateAfterCwndTimeout = &SCTPAssociation::cwndUpdateAfterCwndTimeout;
                     ccFunctions.ccUpdateAfterRtxTimeout = &SCTPAssociation::cwndUpdateAfterRtxTimeout;


### PR DESCRIPTION
ccFunctions.ccUpdateBeforeSack needs to be initialised with &SCTPAssociation::cwndUpdateBeforeSack. Otherwise, ccFunctions.ccUpdateBeforeSack is nullptr, and the call to this function will fail.