### PR TITLE
Set the correct size for resources in random browsing mode.

### DIFF
--- a/src/applications/httptools/HttpServerBase.cc
+++ b/src/applications/httptools/HttpServerBase.cc
@@ -359,6 +359,16 @@ HttpReplyMessage* HttpServerBase::generateResourceMessage(HttpRequestMessage *re
     else if (category==CT_IMAGE)
         imgResourcesServed++;
 
+    int size;
+    if (scriptedMode)
+        size = resources[resource];
+    else if (category==CT_TEXT)
+        size = (int) rdTextResourceSize->draw();
+    else if (category==CT_IMAGE)
+        size = (int) rdImageResourceSize->draw();
+    else
+        error("Invalid resource category");
+
     char szReply[512];
     sprintf(szReply, "HTTP/1.1 200 OK (%s)", resource.c_str());
     HttpReplyMessage* replymsg = new HttpReplyMessage(szReply);
@@ -369,7 +379,7 @@ HttpReplyMessage* HttpServerBase::generateResourceMessage(HttpRequestMessage *re
     replymsg->setSerial(request->serial());
     replymsg->setResult(200);
     replymsg->setContentType(category); // Emulates the content-type header field
-    replymsg->setByteLength(resources[resource]); // Set the resource size
+    replymsg->setByteLength(size); // Set the resource size
     replymsg->setKind(HTTPT_RESPONSE_MESSAGE);
 
     sprintf(szReply, "RESOURCE-BODY:%s", resource.c_str());


### PR DESCRIPTION
The size of resources sent when using random mode (i.e., non-scripted mode) does not match the size configured by the user. This commit fix that.