### PR TITLE
Fix a memory leak with the result of RTPParticipantInfo::ssrcToName()

### DIFF
--- a/src/transport/rtp/RTCP.cc
+++ b/src/transport/rtp/RTCP.cc
@@ -563,8 +563,8 @@ void RTCP::processIncomingRTCPByePacket(RTCPByePacket *rtcpByePacket, IPv4Addres
 
 RTPParticipantInfo *RTCP::findParticipantInfo(uint32 ssrc)
 {
-    char *ssrcString = RTPParticipantInfo::ssrcToName(ssrc);
-    return (RTPParticipantInfo *)(_participantInfos.get(ssrcString));
+    std::string ssrcString = RTPParticipantInfo::ssrcToName(ssrc);
+    return (RTPParticipantInfo *)(_participantInfos.get(ssrcString.c_str()));
 }
 
 void RTCP::calculateAveragePacketSize(int size)

--- a/src/transport/rtp/RTPParticipantInfo.cc
+++ b/src/transport/rtp/RTPParticipantInfo.cc
@@ -29,7 +29,7 @@ RTPParticipantInfo::RTPParticipantInfo(uint32 ssrc) :
     RTPParticipantInfo_Base(),
     _sdesChunk("SDESChunk", ssrc)
 {
-    setName(ssrcToName(ssrc));
+    setName(ssrcToName(ssrc).c_str());
     // because there haven't been sent any RTP packets
     // by this endsystem at all, the number of silent
     // intervals would be undefined; to calculate with
@@ -145,9 +145,9 @@ void RTPParticipantInfo::addSDESItem(SDESItem::SDES_ITEM_TYPE type, const char *
     _sdesChunk.addSDESItem(new SDESItem(type, content));
 }
 
-char *RTPParticipantInfo::ssrcToName(uint32 ssrc)
+std::string RTPParticipantInfo::ssrcToName(uint32 ssrc)
 {
     char name[9];
     sprintf(name, "%08x", ssrc);
-    return opp_strdup(name);
+    return name;
 }

--- a/src/transport/rtp/RTPParticipantInfo.h
+++ b/src/transport/rtp/RTPParticipantInfo.h
@@ -174,7 +174,7 @@ class INET_API RTPParticipantInfo : public RTPParticipantInfo_Base
      * an 8 character hexadecimal number which is used as name
      * of an RTPParticipantInfo object.
      */
-    static char *ssrcToName(uint32 ssrc);
+    static std::string ssrcToName(uint32 ssrc);
 
   private:
     void copy(const RTPParticipantInfo& other);


### PR DESCRIPTION
The string returned by `RTPParticipantInfo::ssrcToName()` is dynamically allocated using `opp_strdup()`, but none of the callers release it. To fix that and avoid future memory leaks, I've changed the result type from `char*` to `std::string` so that the release is handled automatically.