### PR TITLE
Fix parsing and units in RTPAVProfilePayload32Sender::sendPacket().

### DIFF
--- a/src/transport/rtp/profiles/avprofile/RTPAVProfilePayload32Sender.cc
+++ b/src/transport/rtp/profiles/avprofile/RTPAVProfilePayload32Sender.cc
@@ -87,7 +87,7 @@ bool RTPAVProfilePayload32Sender::sendPacket()
     int pictureType;
     char *ptr;
 
-    for (ptr = description; *ptr == ' '; ptr++)
+    for (ptr = description; *ptr == ' ' || *ptr == '\t' ; ptr++)
         ;
     switch (*ptr)
     {
@@ -111,7 +111,7 @@ bool RTPAVProfilePayload32Sender::sendPacket()
             mpegPacket->setPictureType(pictureType);
 
             // the maximum number of real data bytes
-            int maxDataSize = _mtu - rtpPacket->getBitLength() - mpegPacket->getBitLength();
+            int maxDataSize = _mtu - rtpPacket->getByteLength() - mpegPacket->getByteLength();
 
             if (bytesRemaining > maxDataSize)
             {
@@ -121,7 +121,8 @@ bool RTPAVProfilePayload32Sender::sendPacket()
                 // has a length of 64 bytes
                 int slicedDataSize = (maxDataSize / 64) * 64;
 
-                mpegPacket->addBitLength(slicedDataSize);
+                mpegPacket->setPayloadLength(slicedDataSize);
+                mpegPacket->addByteLength(slicedDataSize);
 
 
                 rtpPacket->encapsulate(mpegPacket);
@@ -130,7 +131,8 @@ bool RTPAVProfilePayload32Sender::sendPacket()
             }
             else
             {
-                mpegPacket->addBitLength(bytesRemaining);
+                mpegPacket->setPayloadLength(bytesRemaining);
+                mpegPacket->addByteLength(bytesRemaining);
                 rtpPacket->encapsulate(mpegPacket);
                 // set marker because this is
                 // the last packet of the frame


### PR DESCRIPTION
This commit fixes multiple things:
* the parsing of GDF files which only detects space characters as correct fields separators. All the example GDF files use tabulations as separators, so the parsing does not work correctly even for official examples (the type of video frames is wrongly parsed).
* there's a mistake between bits and bytes when computing the size of MPEG packets. The quantities in GDF files are in bits, but they are converted to bytes before the splitting loop.
* the payload size of MPEG packets is never set while the RTP receiver needs it.

With this commit, the RTP examples work correctly now...