### PR TITLE
Fix a memory leak when handling undeliverable UDP packets.

### DIFF
--- a/src/transport/udp/UDP.cc
+++ b/src/transport/udp/UDP.cc
@@ -477,6 +477,8 @@ void UDP::processUndeliverablePacket(UDPPacket *udpPacket, cObject *ctrl)
         error("(%s)%s arrived from lower layer with unrecognized control info %s",
                 udpPacket->getClassName(), udpPacket->getName(), ctrl->getClassName());
     }
+
+    delete ctrl;
 }
 
 void UDP::bind(int sockId, int gateIndex, const IPvXAddress& localAddr, int localPort)


### PR DESCRIPTION
The control info associated with UDP packet is removed from it when receiving an undeliverable packet. It and the packet is then given to `UDP::processUndeliverablePacket()`, but this method only releases the packet (which does not release the control info since it is not associated with the packet anymore). The calls to `sendErrorMessage()` (icmp/icmpv6) do not release the control info either, so there's a memory leak.

I don't know if the control info should be released in `UDP::processUndeliverablePacket()` or in `sendErrorMessage()`, but it must be released anyway. I choose the former for this commit.

I'm really surprised that no one has ever found that leak in the past as OMNet++ runs out of memory quickly when using UDP broadcast/multicast streaming, which does not sound like an uncommon scenario.