### PR TITLE
Allow initial positions to contain non-integer values.

### DIFF
--- a/src/mobility/common/MobilityBase.cc
+++ b/src/mobility/common/MobilityBase.cc
@@ -31,13 +31,12 @@ static bool parseIntTo(const char *s, double& destValue)
     if (!s || !*s)
         return false;
 
-    char *endptr;
-    int value = strtol(s, &endptr, 10);
-
-    if (*endptr)
+    /* This method is only used to convert positions from the display strings,
+     * which can contain floating point values.
+     */
+    if(sscanf(s, "%lf", &destValue) != 1)
         return false;
 
-    destValue = value;
     return true;
 }
 
@@ -137,8 +136,16 @@ void MobilityBase::updateVisualRepresentation()
     EV_INFO << "current position = " << lastPosition << endl;
     if (ev.isGUI() && visualRepresentation)
     {
-        visualRepresentation->getDisplayString().setTagArg("p", 0, (long)lastPosition.x);
-        visualRepresentation->getDisplayString().setTagArg("p", 1, (long)lastPosition.y);
+        char buf[32];
+
+        /* The display string can handle floating point numbers for positions. */
+        snprintf(buf, sizeof(buf), "%lf", lastPosition.x);
+        buf[sizeof(buf) - 1] = 0;
+        visualRepresentation->getDisplayString().setTagArg("p", 0, buf);
+
+        snprintf(buf, sizeof(buf), "%lf", lastPosition.y);
+        buf[sizeof(buf) - 1] = 0;
+        visualRepresentation->getDisplayString().setTagArg("p", 1, buf);
     }
 }
 


### PR DESCRIPTION
This commit allows the initial positions of nodes (set in omnetpp.ini) to contain non-integer values, and to show the exact positions of nodes in the UI instead of rounding them to nearest integer positions. The UI is already able to handle non-integer positions so why would the mobility module try to feed it with only integer positions?

By integer positions I mean position where `x` and `y` are integers.

Please, consider merging this commit in inet.