### PR TITLE
Allow the user to disable RTP logging to file.

### DIFF
--- a/src/transport/rtp/RTPPayloadReceiver.cc
+++ b/src/transport/rtp/RTPPayloadReceiver.cc
@@ -38,7 +38,8 @@ void RTPPayloadReceiver::initialize()
 {
     const char *fileName = par("outputFileName");
     const char *logFileName = par("outputLogFileName");
-    if (strcmp(fileName, "")) openOutputFile(fileName);
+    if (strcmp(fileName, ""))
+        openOutputFile(fileName);
     if (strcmp(logFileName, ""))
     {
         char logName[200];
@@ -75,6 +76,8 @@ void RTPPayloadReceiver::openOutputFile(const char *fileName)
 
 void RTPPayloadReceiver::closeOutputFile()
 {
-    _outputFileStream.close();
-    _outputLogLoss.close();
+    if (_outputFileStream.is_open())
+        _outputFileStream.close();
+    if (_outputLogLoss.is_open())
+        _outputLogLoss.close();
 }

--- a/src/transport/rtp/RTPPayloadReceiver.cc
+++ b/src/transport/rtp/RTPPayloadReceiver.cc
@@ -38,10 +38,13 @@ void RTPPayloadReceiver::initialize()
 {
     const char *fileName = par("outputFileName");
     const char *logFileName = par("outputLogFileName");
-    openOutputFile(fileName);
-    char logName[200];
-    sprintf(logName, logFileName, getId());
-    _outputLogLoss.open(logName);
+    if (strcmp(fileName, "")) openOutputFile(fileName);
+    if (strcmp(logFileName, ""))
+    {
+        char logName[200];
+        sprintf(logName, logFileName, getId());
+        _outputLogLoss.open(logName);
+    }
 }
 
 void RTPPayloadReceiver::handleMessage(cMessage *msg)

--- a/src/transport/rtp/RTPPayloadReceiver.ned
+++ b/src/transport/rtp/RTPPayloadReceiver.ned
@@ -9,8 +9,8 @@ package inet.transport.rtp;
 moduleinterface IRTPPayloadReceiver
 {
     parameters:
-        string outputFileName;
-        string outputLogFileName;
+        string outputFileName;  // use an empty string to disable this logging
+        string outputLogFileName;   // use an empty string to disable this logging
 
     gates:
         input profileIn @labels(RTPInnerPacket);

--- a/src/transport/rtp/profiles/avprofile/RTPAVProfilePayload32Receiver.cc
+++ b/src/transport/rtp/profiles/avprofile/RTPAVProfilePayload32Receiver.cc
@@ -56,9 +56,10 @@ void RTPAVProfilePayload32Receiver::processPacket(RTPPacket *rtpPacket)
     {
         _lowestAllowedTimeStamp = rtpPacket->getTimeStamp();
         _highestSequenceNumber = rtpPacket->getSequenceNumber();
-        _outputLogLoss <<"sequenceNumberBase"<< rtpPacket->getSequenceNumber() << endl;
+        if (_outputLogLoss.is_open())
+            _outputLogLoss <<"sequenceNumberBase"<< rtpPacket->getSequenceNumber() << endl;
     }
-    else
+    else if (_outputLogLoss.is_open())
     {
         for (int i = _highestSequenceNumber+1; i < rtpPacket->getSequenceNumber(); i++ )
         {
@@ -125,7 +126,7 @@ void RTPAVProfilePayload32Receiver::processPacket(RTPPacket *rtpPacket)
             }
 
             // we have calculated a frame
-            if (frameSize > 0)
+            if (frameSize > 0 && _outputFileStream.is_open())
             {
                 char line[100];
                 // what picture type is it


### PR DESCRIPTION
The RTP log files are generated automatically by the `RTPPayloadReceiver` modules, 2 for each nodes. When simulating lots of nodes, you end up with lots of files even if you are not interested by their content.

This commit permits to disable the generation of these files based on the user configuration.

Please consider merging it into the inet framework.
