### PR TITLE
Added target "makefiles-static" to Makefile => easy static builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,15 @@ cleanall: checkmakefiles
 	cd src && $(MAKE) MODE=debug clean
 	rm -f src/Makefile
 
+
+MAKEMAKE_OPTIONS := -f --deep -o INET -O out -pINET --no-deep-includes -Xinet/applications/voipstream -Xinet/linklayer/ext -Xinet/transportlayer/tcp_lwip -Xinet/transportlayer/tcp_nsc -I../src -DWITH_TCP_COMMON -DWITH_TCP_INET -DWITH_IPv4 -DWITH_IPv6 -DWITH_xMIPv6 -DWITH_UDP -DWITH_RTP -DWITH_SCTP -DWITH_DHCP -DWITH_ETHERNET -DWITH_PPP -DWITH_MPLS -DWITH_OSPFv2 -DWITH_BGPv4 -DWITH_MANET -DWITH_TRACI -DWITH_AODV -DWITH_RIP -DWITH_RADIO -DWITH_POWER -DWITH_IEEE80211 -DWITH_GENERIC -DWITH_IDEALWIRELESS -DWITH_FLOOD -DWITH_PIM -DWITH_IEEE802154 -DWITH_APSKRADIO -DWITH_TUN -DWITH_BMAC -DWITH_LMAC -DWITH_CSMA
+	
 makefiles:
-	cd src && opp_makemake -f --deep --make-so -o INET -O out -pINET --no-deep-includes -Xinet/applications/voipstream -Xinet/linklayer/ext -Xinet/transportlayer/tcp_lwip -Xinet/transportlayer/tcp_nsc -I../src -DWITH_TCP_COMMON -DWITH_TCP_INET -DWITH_IPv4 -DWITH_IPv6 -DWITH_xMIPv6 -DWITH_UDP -DWITH_RTP -DWITH_SCTP -DWITH_DHCP -DWITH_ETHERNET -DWITH_PPP -DWITH_MPLS -DWITH_OSPFv2 -DWITH_BGPv4 -DWITH_MANET -DWITH_TRACI -DWITH_AODV -DWITH_RIP -DWITH_RADIO -DWITH_POWER -DWITH_IEEE80211 -DWITH_GENERIC -DWITH_IDEALWIRELESS -DWITH_FLOOD -DWITH_PIM -DWITH_IEEE802154 -DWITH_APSKRADIO -DWITH_TUN -DWITH_BMAC -DWITH_LMAC -DWITH_CSMA
+	cd src && opp_makemake --make-so $(MAKEMAKE_OPTIONS) 
+
+makefiles-static:
+	cd src && opp_makemake $(MAKEMAKE_OPTIONS) 
+
 
 checkmakefiles:
 	@if [ ! -f src/Makefile ]; then \


### PR DESCRIPTION
I frequently do static builds instead of shared object builds. Therefore, I just moved the opp_makemake options into a separate options line and added another build target "makefiles-static" for the static build. So, creating a static build can be done with "make makefiles-static && make". The old behaviour as default remains unchanged (i.e. shared-object builds with "make makefiles && make").