### PR TITLE
sctp: added default parameter settings to connect() call of SCTPSocket

### DIFF
--- a/src/inet/transportlayer/contract/sctp/SCTPSocket.h
+++ b/src/inet/transportlayer/contract/sctp/SCTPSocket.h
@@ -183,7 +183,7 @@ class INET_API SCTPSocket
     /**
      * Active OPEN to the given remote socket.
      */
-    void connect(L3Address remoteAddress, int32 remotePort, bool streamReset, int32 prMethod, uint32 numRequests);
+    void connect(L3Address remoteAddress, int32 remotePort, bool streamReset = false, int32 prMethod = 0, uint32 numRequests = 0);
 
     void connectx(AddressVector remoteAddresses, int32 remotePort, bool streamReset = false, int32 prMethod = 0, uint32 numRequests = 0);
 


### PR DESCRIPTION
sctp: added default parameter settings to connect() call of SCTPSocket. Then, in the usual case, a connect() just takes address and port (like it is for TCP).