### PR TITLE
sctp: Fixed wrong usage of cPacket by replacing with cMessage

### DIFF
--- a/src/inet/transportlayer/contract/sctp/SCTPCommand.msg
+++ b/src/inet/transportlayer/contract/sctp/SCTPCommand.msg
@@ -43,10 +43,10 @@ enum SCTPErrorCode
 
 
 //
-// Control info for SCTP connections. This class is to be set as control info
+// Control info for SCTP connections. This message is to be set as control info
 // (see cMessage::setControlInfo()) on all messages exchanged between ~SCTP and
 // application, in both directions. Some commands and indications
-// (SCTP_C_OPEN_xxx, SCTP_I_STATUS) use subclasses.
+// (SCTP_C_OPEN_xxx, SCTP_I_STATUS) use submessagees.
 //
 // connId identifies the connection locally within the application (internally,
 // ~SCTP uses the (app gate index, connId) pair to identify the socket).
@@ -54,7 +54,7 @@ enum SCTPErrorCode
 //
 // @see ~TcpCommandCode, ~TcpStatusInd, ~SCTPOpenCommand, ~SCTPStatusInfo, SCTPMain
 //
-class SCTPCommand extends cPacket
+packet SCTPCommand
 {
     int assocId = -1;   // identifies the socket within the application
     int sid = -1;
@@ -72,7 +72,7 @@ class SCTPCommand extends cPacket
 //
 // Currently not in use.
 //
-class SCTPErrorInfo extends SCTPCommand
+message SCTPErrorInfo extends SCTPCommand
 {
     int errorCode @enum(SCTPErrorCode);
     string messageText;
@@ -89,7 +89,7 @@ class SCTPErrorInfo extends SCTPCommand
 //
 // The sendQueueClass, receiveQueueClass and sctpAlgorithmClass fields
 // allow per-connection ~SCTP configuration. These fields may contain
-// names of classes subclassed from SCTPSendQueue, SCTPReceiveQueue
+// names of messagees submessageed from SCTPSendQueue, SCTPReceiveQueue
 // and SCTPAlgorithm, respectively. If not set, module parameters with
 // similar names are used.
 //
@@ -104,7 +104,7 @@ class SCTPErrorInfo extends SCTPCommand
 //
 // @see ~TcpCommandCode, ~SCTP
 //
-class SCTPOpenCommand extends SCTPCommand
+message SCTPOpenCommand extends SCTPCommand
 {
     AddressVector localAddresses;
     L3Address remoteAddr;            // required for active open
@@ -126,7 +126,7 @@ class SCTPOpenCommand extends SCTPCommand
 //
 // @see ~TcpCommandCode, ~SCTP
 //
-class SCTPSendCommand extends SCTPCommand
+message SCTPSendCommand extends SCTPCommand
 {
     unsigned int prMethod;
     bool last;
@@ -142,7 +142,7 @@ class SCTPSendCommand extends SCTPCommand
 //
 // @see ~TcpCommandCode, ~SCTP
 //
-class SCTPConnectInfo extends SCTPCommand
+message SCTPConnectInfo extends SCTPCommand
 {
     AddressVector remoteAddresses;
     int status;
@@ -158,7 +158,7 @@ class SCTPConnectInfo extends SCTPCommand
 //
 // @see ~TcpStatusInd, ~TcpCommandCode, ~SCTP
 //
-class SCTPStatusInfo extends SCTPCommand
+message SCTPStatusInfo extends SCTPCommand
 {
     int state;
     string stateName;
@@ -166,31 +166,31 @@ class SCTPStatusInfo extends SCTPCommand
     bool active;
 }
 
-class SCTPPathInfo extends SCTPCommand
+message SCTPPathInfo extends SCTPCommand
 {
     L3Address remoteAddress;
 }
 
-class SCTPResetInfo extends SCTPCommand
+message SCTPResetInfo extends SCTPCommand
 {
     L3Address remoteAddr;
     unsigned short requestType = 0;
     char streams[];
 }
 
-class SCTPInfo extends SCTPCommand
+message SCTPInfo extends SCTPCommand
 {
     int text = 0;
 }
 
-class SCTPRcvCommand extends SCTPCommand
+message SCTPRcvCommand extends SCTPCommand
 {
     uint32 ppid;
     uint32 tsn;
     uint32 cumTsn;
 }
 
-class SCTPSendQueueAbated extends SCTPCommand
+message SCTPSendQueueAbated extends SCTPCommand
 {
     uint64 bytesAvailable;
     uint64 bytesQueued;
@@ -198,11 +198,10 @@ class SCTPSendQueueAbated extends SCTPCommand
     uint64 queuedForStream[];
 }
 
-message SCTPSimpleMessage extends cPacket
+packet SCTPSimpleMessage
 {
     uint32 dataLen;     //TODO remove it, use set/getDataArraySize() functions only
     char data[];
     simtime_t creationTime = 0;
     bool encaps = false;
 }
-

--- a/src/inet/transportlayer/contract/sctp/SCTPSocket.cc
+++ b/src/inet/transportlayer/contract/sctp/SCTPSocket.cc
@@ -81,7 +81,7 @@ const char *SCTPSocket::stateName(int state)
 #undef CASE
 }
 
-void SCTPSocket::sendToSCTP(cPacket *msg)
+void SCTPSocket::sendToSCTP(cMessage *msg)
 {
     if (!gateToSctp)
         throw cRuntimeError("SCTPSocket: setOutputGate() must be invoked before socket can be used");
@@ -133,7 +133,7 @@ void SCTPSocket::listen(bool fork, bool reset, uint32 requests, uint32 messagesT
         throw cRuntimeError(sockstate == NOT_BOUND ? "SCTPSocket: must call bind() before listen()"
                 : "SCTPSocket::listen(): connect() or listen() already called");
 
-    cPacket *msg = new cPacket("PassiveOPEN", SCTP_C_OPEN_PASSIVE);
+    cMessage *msg = new cMessage("PassiveOPEN", SCTP_C_OPEN_PASSIVE);
 
     SCTPOpenCommand *openCmd = new SCTPOpenCommand();
     //openCmd->setLocalAddr(localAddr);
@@ -165,7 +165,7 @@ void SCTPSocket::connect(L3Address remoteAddress, int32 remotePort, bool streamR
     if (!oneToOne && sockstate != LISTENING)
         throw cRuntimeError("SCTPSocket::connect: One-to-many style socket must be listening");
 
-    cPacket *msg = new cPacket("Associate", SCTP_C_ASSOCIATE);
+    cMessage *msg = new cMessage("Associate", SCTP_C_ASSOCIATE);
     remoteAddr = remoteAddress;
     remotePrt = remotePort;
     SCTPOpenCommand *openCmd = new SCTPOpenCommand();
@@ -202,7 +202,7 @@ void SCTPSocket::connectx(AddressVector remoteAddressList, int32 remotePort, boo
     if (!oneToOne && sockstate != LISTENING)
         throw cRuntimeError("SCTPSocket::connect: One-to-many style socket must be listening");
 
-    cPacket *msg = new cPacket("Associate", SCTP_C_ASSOCIATE);
+    cMessage *msg = new cMessage("Associate", SCTP_C_ASSOCIATE);
     remoteAddresses = remoteAddressList;
     remoteAddr = remoteAddresses.front();
     remotePrt = remotePort;
@@ -224,7 +224,7 @@ void SCTPSocket::connectx(AddressVector remoteAddressList, int32 remotePort, boo
         sockstate = CONNECTING;
 }
 
-void SCTPSocket::send(cPacket *msg, bool last, bool primary)
+void SCTPSocket::send(cMessage *msg, bool last, bool primary)
 {
     if (oneToOne && sockstate != CONNECTED && sockstate != CONNECTING && sockstate != PEER_CLOSED) {
         throw cRuntimeError("SCTPSocket::send(): not connected or connecting");
@@ -248,12 +248,12 @@ void SCTPSocket::send(cPacket *msg, bool last, bool primary)
     sendToSCTP(msg);
 }
 
-void SCTPSocket::send(cPacket *msg, int32 prMethod, double prValue, bool last)
+void SCTPSocket::send(cMessage *msg, int32 prMethod, double prValue, bool last)
 {
     send(msg, prMethod, prValue, last, -1);
 }
 
-void SCTPSocket::send(cPacket *msg, int32 prMethod, double prValue, bool last, int32 streamId)
+void SCTPSocket::send(cMessage *msg, int32 prMethod, double prValue, bool last, int32 streamId)
 {
     if (oneToOne && sockstate != CONNECTED && sockstate != CONNECTING && sockstate != PEER_CLOSED) {
         throw cRuntimeError("SCTPSocket::send(): not connected or connecting");
@@ -283,7 +283,7 @@ void SCTPSocket::send(cPacket *msg, int32 prMethod, double prValue, bool last, i
     sendToSCTP(msg);
 }
 
-void SCTPSocket::sendNotification(cPacket *msg)
+void SCTPSocket::sendNotification(cMessage *msg)
 {
     if (oneToOne && sockstate != CONNECTED && sockstate != CONNECTING && sockstate != PEER_CLOSED) {
         throw cRuntimeError("SCTPSocket::sendNotification(%s): not connected or connecting", msg->getName());
@@ -295,7 +295,7 @@ void SCTPSocket::sendNotification(cPacket *msg)
     sendToSCTP(msg);
 }
 
-void SCTPSocket::sendRequest(cPacket *msg)
+void SCTPSocket::sendRequest(cMessage *msg)
 {
     sendToSCTP(msg);
 }
@@ -304,7 +304,7 @@ void SCTPSocket::close()
 {
     EV_INFO << "SCTPSocket: close\n";
 
-    cPacket *msg = new cPacket("CLOSE", SCTP_C_CLOSE);
+    cMessage *msg = new cMessage("CLOSE", SCTP_C_CLOSE);
     SCTPCommand *cmd = new SCTPCommand();
     cmd->setAssocId(assocId);
     msg->setControlInfo(cmd);
@@ -316,7 +316,7 @@ void SCTPSocket::shutdown()
 {
     EV << "SCTPSocket: shutdown\n";
 
-    cPacket *msg = new cPacket("Shutdown", SCTP_C_SHUTDOWN);
+    cMessage *msg = new cMessage("Shutdown", SCTP_C_SHUTDOWN);
     SCTPCommand *cmd = new SCTPCommand();
     cmd->setAssocId(assocId);
     msg->setControlInfo(cmd);
@@ -326,7 +326,7 @@ void SCTPSocket::shutdown()
 void SCTPSocket::abort()
 {
     if (sockstate != NOT_BOUND && sockstate != CLOSED && sockstate != SOCKERROR) {
-        cPacket *msg = new cPacket("ABORT", SCTP_C_ABORT);
+        cMessage *msg = new cMessage("ABORT", SCTP_C_ABORT);
         SCTPCommand *cmd = new SCTPCommand();
         //sctpEV3<<"Message cmd="<<&cmd<<"\n";
         cmd->setAssocId(assocId);
@@ -338,14 +338,14 @@ void SCTPSocket::abort()
 
 void SCTPSocket::requestStatus()
 {
-    cPacket *msg = new cPacket("STATUS", SCTP_C_STATUS);
+    cMessage *msg = new cMessage("STATUS", SCTP_C_STATUS);
     SCTPCommand *cmd = new SCTPCommand();
     cmd->setAssocId(assocId);
     msg->setControlInfo(cmd);
     sendToSCTP(msg);
 }
 
-bool SCTPSocket::belongsToSocket(cPacket *msg)
+bool SCTPSocket::belongsToSocket(cMessage *msg)
 {
     bool ret = dynamic_cast<SCTPCommand *>(msg->getControlInfo()) &&
         ((SCTPCommand *)(msg->getControlInfo()))->getAssocId() == assocId;
@@ -353,7 +353,7 @@ bool SCTPSocket::belongsToSocket(cPacket *msg)
     return ret;
 }
 
-bool SCTPSocket::belongsToAnySCTPSocket(cPacket *msg)
+bool SCTPSocket::belongsToAnySCTPSocket(cMessage *msg)
 {
     return dynamic_cast<SCTPCommand *>(msg->getControlInfo());
 }
@@ -364,20 +364,20 @@ void SCTPSocket::setCallbackObject(CallbackInterface *callback, void *yourPointe
     yourPtr = yourPointer;
 }
 
-void SCTPSocket::processMessage(cPacket *msg)
+void SCTPSocket::processMessage(cMessage *msg)
 {
     SCTPStatusInfo *status;
     switch (msg->getKind()) {
         case SCTP_I_DATA:
             EV_INFO << "SCTP_I_DATA\n";
             if (cb)
-                cb->socketDataArrived(assocId, yourPtr, msg, false);
+                cb->socketDataArrived(assocId, yourPtr, PK(msg), false);
             break;
 
         case SCTP_I_DATA_NOTIFICATION:
             EV_INFO << "SCTP_I_NOTIFICATION\n";
             if (cb)
-                cb->socketDataNotificationArrived(assocId, yourPtr, msg);
+                cb->socketDataNotificationArrived(assocId, yourPtr, PK(msg));
             break;
 
         case SCTP_I_SEND_MSG:
@@ -487,7 +487,7 @@ void SCTPSocket::processMessage(cPacket *msg)
 
 void SCTPSocket::setStreamPriority(uint32 stream, uint32 priority)
 {
-    cPacket *msg = new cPacket("SET_STREAM_PRIO", SCTP_C_SET_STREAM_PRIO);
+    cMessage *msg = new cMessage("SET_STREAM_PRIO", SCTP_C_SET_STREAM_PRIO);
     SCTPSendCommand *cmd = new SCTPSendCommand();
     cmd->setAssocId(assocId);
     cmd->setSid(stream);

--- a/src/inet/transportlayer/contract/sctp/SCTPSocket.h
+++ b/src/inet/transportlayer/contract/sctp/SCTPSocket.h
@@ -85,7 +85,7 @@ class INET_API SCTPSocket
     void *yourPtr;
 
   protected:
-    void sendToSCTP(cPacket *msg);
+    void sendToSCTP(cMessage *msg);
 
   public:
     cGate *gateToSctp;
@@ -190,12 +190,12 @@ class INET_API SCTPSocket
     /**
      * Sends data packet.
      */
-    void send(cPacket *msg, bool last = true, bool primary = true);
-    void send(cPacket *msg, int prMethod, double prValue, bool last);
-    void send(cPacket *msg, int prMethod, double prValue, bool last, int32 streamId);
+    void send(cMessage *msg, bool last = true, bool primary = true);
+    void send(cMessage *msg, int prMethod, double prValue, bool last);
+    void send(cMessage *msg, int prMethod, double prValue, bool last, int32 streamId);
 
-    void sendNotification(cPacket *msg);
-    void sendRequest(cPacket *msg);
+    void sendNotification(cMessage *msg);
+    void sendRequest(cMessage *msg);
     /**
      * Closes the local end of the connection. With SCTP, a CLOSE operation
      * means "I have no more data to send", and thus results in a one-way
@@ -226,14 +226,14 @@ class INET_API SCTPSocket
      * has a SCTPCommand as controlInfo(), and the assocId in it matches
      * that of the socket.)
      */
-    bool belongsToSocket(cPacket *msg);
+    bool belongsToSocket(cMessage *msg);
 
     /**
      * Returns true if the message belongs to any SCTPSocket instance.
      * (This basically checks if the message has a SCTPCommand attached to
      * it as controlInfo().)
      */
-    static bool belongsToAnySCTPSocket(cPacket *msg);
+    static bool belongsToAnySCTPSocket(cMessage *msg);
 
     /**
      * Sets a callback object, to be used with processMessage().
@@ -274,7 +274,7 @@ class INET_API SCTPSocket
      * the message belongs to this socket, i.e. belongsToSocket(msg) would
      * return true!
      */
-    void processMessage(cPacket *msg);
+    void processMessage(cMessage *msg);
     //@}
 
     void setState(int state) { sockstate = state; };

--- a/src/inet/transportlayer/sctp/SCTP.cc
+++ b/src/inet/transportlayer/sctp/SCTP.cc
@@ -271,7 +271,7 @@ void SCTP::handleMessage(cMessage *msg)
                     key.assocId = assocId;
                     sctpAppAssocMap[key] = assoc;
                     EV_INFO << "SCTP association created for appGateIndex " << appGateIndex << " and assoc " << assocId << "\n";
-                    bool ret = assoc->processAppCommand(PK(msg));
+                    bool ret = assoc->processAppCommand(msg);
                     if (!ret) {
                         removeAssociation(assoc);
                     }
@@ -280,7 +280,7 @@ void SCTP::handleMessage(cMessage *msg)
         }
         else {
             EV_INFO << "assoc found\n";
-            bool ret = assoc->processAppCommand(PK(msg));
+            bool ret = assoc->processAppCommand(msg);
 
             if (!ret)
                 removeAssociation(assoc);

--- a/src/inet/transportlayer/sctp/SCTPAssociation.h
+++ b/src/inet/transportlayer/sctp/SCTPAssociation.h
@@ -307,7 +307,7 @@ class INET_API SCTPPathVariables : public cObject
     cMessage *CwndTimer;
     cMessage *T3_RtxTimer;
     cMessage *BlockingTimer;
-    cPacket *ResetTimer;
+    cMessage *ResetTimer;
     cMessage *AsconfTimer;
     // ====== High-Speed CC ===============================================
     unsigned int highSpeedCCThresholdIdx;
@@ -983,7 +983,7 @@ class INET_API SCTPAssociation : public cObject
      * Normally returns true. A return value of false means that the
      * connection structure must be deleted by the caller (SCTP).
      */
-    bool processAppCommand(cPacket *msg);
+    bool processAppCommand(cMessage *msg);
     void removePath();
     void removePath(const L3Address& addr);
     void deleteStreams();
@@ -1022,12 +1022,12 @@ class INET_API SCTPAssociation : public cObject
     //@}
     /** @name Processing app commands. Invoked from processAppCommand(). */
     //@{
-    void process_ASSOCIATE(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg);
-    void process_OPEN_PASSIVE(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg);
-    void process_SEND(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg);
+    void process_ASSOCIATE(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg);
+    void process_OPEN_PASSIVE(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg);
+    void process_SEND(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg);
     void process_CLOSE(SCTPEventCode& event);
     void process_ABORT(SCTPEventCode& event);
-    void process_STATUS(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg);
+    void process_STATUS(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg);
     void process_RECEIVE_REQUEST(SCTPEventCode& event, SCTPCommand *sctpCommand);
     void process_PRIMARY(SCTPEventCode& event, SCTPCommand *sctpCommand);
     void process_STREAM_RESET(SCTPCommand *sctpCommand);
@@ -1123,7 +1123,7 @@ class INET_API SCTPAssociation : public cObject
     }
 
     /** Utility: sends packet to application */
-    void sendToApp(cPacket *msg);
+    void sendToApp(cMessage *msg);
 
     /** Utility: sends status indication (SCTP_I_xxx) to application */
     void sendIndicationToApp(const int32 code, const int32 value = 0);

--- a/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationBase.cc
@@ -922,7 +922,7 @@ SCTPEventCode SCTPAssociation::preanalyseAppCommandEvent(int32 commandCode)
     }
 }
 
-bool SCTPAssociation::processAppCommand(cPacket *msg)
+bool SCTPAssociation::processAppCommand(cMessage *msg)
 {
     printAssocBrief();
 

--- a/src/inet/transportlayer/sctp/SCTPAssociationEventProc.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationEventProc.cc
@@ -30,7 +30,7 @@ namespace sctp {
 // Event processing code
 //
 
-void SCTPAssociation::process_ASSOCIATE(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg)
+void SCTPAssociation::process_ASSOCIATE(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg)
 {
     L3Address lAddr, rAddr;
 
@@ -74,7 +74,7 @@ void SCTPAssociation::process_ASSOCIATE(SCTPEventCode& event, SCTPCommand *sctpC
     }
 }
 
-void SCTPAssociation::process_OPEN_PASSIVE(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg)
+void SCTPAssociation::process_OPEN_PASSIVE(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg)
 {
     L3Address lAddr;
     int16 localPort;
@@ -112,7 +112,7 @@ void SCTPAssociation::process_OPEN_PASSIVE(SCTPEventCode& event, SCTPCommand *sc
     }
 }
 
-void SCTPAssociation::process_SEND(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg)
+void SCTPAssociation::process_SEND(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg)
 {
     SCTPSendCommand *sendCommand = check_and_cast<SCTPSendCommand *>(sctpCommand);
 
@@ -132,7 +132,7 @@ void SCTPAssociation::process_SEND(SCTPEventCode& event, SCTPCommand *sctpComman
              << " appGateIndex=" << appGateIndex
              << " streamId=" << sendCommand->getSid() << endl;
 
-    SCTPSimpleMessage *smsg = check_and_cast<SCTPSimpleMessage *>((msg->decapsulate()));
+    SCTPSimpleMessage *smsg = check_and_cast<SCTPSimpleMessage *>((PK(msg)->decapsulate()));
     auto iter = sctpMain->assocStatMap.find(assocId);
     iter->second.sentBytes += smsg->getBitLength() / 8;
 
@@ -175,7 +175,7 @@ void SCTPAssociation::process_SEND(SCTPEventCode& event, SCTPCommand *sctpComman
 
         case PR_PRIO:
             datMsg->setPriority((uint32)sendCommand->getPrValue());
-            state->queuedDroppableBytes += msg->getByteLength();
+            state->queuedDroppableBytes += PK(msg)->getByteLength();
             break;
     }
 
@@ -209,7 +209,7 @@ void SCTPAssociation::process_SEND(SCTPEventCode& event, SCTPCommand *sctpComman
             if (datMsg->getPriority() > lowestPriority) {
                 EV_DEBUG << "msg will be abandoned, buffer is full and priority too low ("
                          << datMsg->getPriority() << ")\n";
-                state->queuedDroppableBytes -= msg->getByteLength();
+                state->queuedDroppableBytes -= PK(msg)->getByteLength();
                 delete smsg;
                 delete msg;
                 sendIndicationToApp(SCTP_I_ABANDONED);
@@ -358,7 +358,7 @@ void SCTPAssociation::process_ABORT(SCTPEventCode& event)
     }
 }
 
-void SCTPAssociation::process_STATUS(SCTPEventCode& event, SCTPCommand *sctpCommand, cPacket *msg)
+void SCTPAssociation::process_STATUS(SCTPEventCode& event, SCTPCommand *sctpCommand, cMessage *msg)
 {
     SCTPStatusInfo *statusInfo = new SCTPStatusInfo();
     statusInfo->setState(fsm->getState());

--- a/src/inet/transportlayer/sctp/SCTPAssociationUtil.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationUtil.cc
@@ -391,7 +391,7 @@ void SCTPAssociation::sendEstabIndicationToApp()
     EV_INFO << "sendEstabIndicationToApp: localPort="
             << localPort << " remotePort=" << remotePort << endl;
 
-    cPacket *msg = new cPacket(indicationName(SCTP_I_ESTABLISHED));
+    cMessage *msg = new cMessage(indicationName(SCTP_I_ESTABLISHED));
     msg->setKind(SCTP_I_ESTABLISHED);
 
     SCTPConnectInfo *establishIndication = new SCTPConnectInfo("CI");
@@ -414,7 +414,7 @@ void SCTPAssociation::sendEstabIndicationToApp()
     }
 }
 
-void SCTPAssociation::sendToApp(cPacket *msg)
+void SCTPAssociation::sendToApp(cMessage *msg)
 {
     sctpMain->send(msg, "to_appl", appGateIndex);
 }
@@ -1749,7 +1749,7 @@ void SCTPAssociation::sendDataArrivedNotification(uint16 sid)
 {
     EV_INFO << "SendDataArrivedNotification\n";
 
-    cPacket *cmsg = new cPacket("DataArrivedNotification");
+    cMessage *cmsg = new cMessage("DataArrivedNotification");
     cmsg->setKind(SCTP_I_DATA_NOTIFICATION);
     SCTPCommand *cmd = new SCTPCommand("notification");
     cmd->setAssocId(assocId);
@@ -1891,7 +1891,7 @@ void SCTPAssociation::pushUlp()
             }
             EV_DETAIL << "Push TSN " << chunk->tsn
                       << ": sid=" << chunk->sid << " ssn=" << chunk->ssn << endl;
-            cPacket *msg = (cPacket *)chunk->userData;
+            cMessage *msg = (cMessage *)chunk->userData;
             msg->setKind(SCTP_I_DATA);
             SCTPRcvCommand *cmd = new SCTPRcvCommand("push");
             cmd->setAssocId(assocId);


### PR DESCRIPTION
sctp: Fixed wrong usage of cPacket by replacing with cMessage.