### PR TITLE
sctp: "connect without bind" bugfixes

### DIFF
--- a/src/inet/transportlayer/contract/sctp/SCTPSocket.cc
+++ b/src/inet/transportlayer/contract/sctp/SCTPSocket.cc
@@ -45,6 +45,7 @@ SCTPSocket::SCTPSocket(bool type)
 {
     sockstate = NOT_BOUND;
     localPrt = remotePrt = 0;
+    inboundStreams = outboundStreams = 1;
     cb = nullptr;
     yourPtr = nullptr;
     gateToSctp = nullptr;

--- a/src/inet/transportlayer/contract/sctp/SCTPSocket.cc
+++ b/src/inet/transportlayer/contract/sctp/SCTPSocket.cc
@@ -159,7 +159,11 @@ void SCTPSocket::listen(bool fork, bool reset, uint32 requests, uint32 messagesT
 void SCTPSocket::connect(L3Address remoteAddress, int32 remotePort, bool streamReset, int32 prMethod, uint32 numRequests)
 {
     EV_INFO << "Socket connect. Assoc=" << assocId << ", sockstate=" << sockstate << "\n";
-    if (oneToOne && sockstate != NOT_BOUND && sockstate != CLOSED)
+
+    if (oneToOne && sockstate == NOT_BOUND)
+       bind(0);
+
+    if (oneToOne && sockstate != CLOSED)
         throw cRuntimeError("SCTPSocket::connect(): connect() or listen() already called");
 
     if (!oneToOne && sockstate != LISTENING)
@@ -193,10 +197,11 @@ void SCTPSocket::connect(L3Address remoteAddress, int32 remotePort, bool streamR
 void SCTPSocket::connectx(AddressVector remoteAddressList, int32 remotePort, bool streamReset, int32 prMethod, uint32 numRequests)
 {
     EV_INFO << "Socket connectx.  sockstate=" << sockstate << "\n";
-    /*if (sockstate!=NOT_BOUND && sockstate!=CLOSED)
-        throw cRuntimeError( "SCTPSocket::connect(): connect() or listen() already called");*/
 
-    if (oneToOne && sockstate != NOT_BOUND && sockstate != CLOSED)
+    if (oneToOne && sockstate == NOT_BOUND)
+       bind(0);
+
+    if (oneToOne && sockstate != CLOSED)
         throw cRuntimeError("SCTPSocket::connect(): connect() or listen() already called");
 
     if (!oneToOne && sockstate != LISTENING)


### PR DESCRIPTION
sctp: Two fixes in SCTPSocket:

1. Call bind(0) on unbound socket before connect. Otherwise, the local side will have an empty list of local addresses -> segfault in SCTPAssociation::process_ASSOCIATE().

2. Without explicitly setting the number of inbound and outbound streams, the corresponding variables remain uninitialized -> failures during run. Found this bug with Valgrind.