### PR TITLE
Extended run_inet script with option to run Valgrind

### DIFF
--- a/src/run_inet
+++ b/src/run_inet
@@ -1,8 +1,17 @@
 #! /bin/sh
 DIR=`dirname $0`
 
+VALGRIND=""
+VALGRIND_OPTIONS="-v --tool=memcheck --leak-check=yes --show-reachable=no --leak-resolution=high --num-callers=40 --freelist-vol=4000000"
+
+if [ "$1" = "--valgrind" ] ; then
+   echo "##### Running with Valgrind! ######"
+   VALGRIND="/usr/bin/valgrind $VALGRIND_OPTIONS"
+   shift
+fi
+
 if [ -f $DIR/INET -o -f $DIR/INET.exe ]; then
-  $DIR/INET -n $DIR/../examples:$DIR $*
+  $VALGRIND $DIR/INET -n $DIR/../examples:$DIR $*
 else
   opp_run -l $DIR/INET -n $DIR/../examples:$DIR $*
 fi


### PR DESCRIPTION
Extended run_inet script with option "--valgrind" as first parameter. If given, the simulation (executable only) is started with Valgrind (http://valgrind.org/) using memcheck parameters => convenient for debugging issues like uninitialized variables and memory problems.