### PR TITLE
sctp: Bugfix for SCTPAssociation::process_RCV_Message():

### DIFF
--- a/src/inet/transportlayer/sctp/SCTPAssociationRcvMessage.cc
+++ b/src/inet/transportlayer/sctp/SCTPAssociationRcvMessage.cc
@@ -198,6 +198,7 @@ bool SCTPAssociation::process_RCV_Message(SCTPMessage *sctpmsg,
                     else if (initAckChunk->getInitTag() == 0) {
                         sendAbort();
                         sctpMain->removeAssociation(this);
+                        return true;
                     }
                     i = numberOfChunks - 1;
                     delete initAckChunk;
@@ -237,8 +238,7 @@ bool SCTPAssociation::process_RCV_Message(SCTPMessage *sctpmsg,
                     delete header;
                     sendAbort();
                     sctpMain->removeAssociation(this);
-                    trans = true;
-                    break;
+                    return true;
                 }
                 if (!(fsm->getState() == SCTP_S_SHUTDOWN_RECEIVED || fsm->getState() == SCTP_S_SHUTDOWN_ACK_SENT)) {
                     SCTPDataChunk *dataChunk;
@@ -272,6 +272,7 @@ bool SCTPAssociation::process_RCV_Message(SCTPMessage *sctpmsg,
                     else {
                         sendAbort();
                         sctpMain->removeAssociation(this);
+                        return true;
                     }
                     delete dataChunk;
                 }


### PR DESCRIPTION
After "sctpMain->removeAssociation(this);", a return is necessary. Otherwise, the not-any-longer-existing association will cause a segfault due to access to already-free'd memory at the end of the method.