### PR TITLE
Fixes Windows build error when including ModuleAccess.h

### DIFF
--- a/src/inet/common/ModuleAccess.h
+++ b/src/inet/common/ModuleAccess.h
@@ -63,7 +63,10 @@ INET_API cModule *findModuleUnderContainingNode(cModule *from);
  * or type mismatch.
  */
 template<typename T>
-INET_API T *findModuleFromPar(cPar& par, cModule *from)
+INET_API T *findModuleFromPar(cPar& par, cModule *from);
+
+template<typename T>
+T *findModuleFromPar(cPar& par, cModule *from)
 {
     const char *path = par.stringValue();
     if (path && *path) {
@@ -85,7 +88,10 @@ INET_API T *findModuleFromPar(cPar& par, cModule *from)
  * or type mismatch.
  */
 template<typename T>
-INET_API T *getModuleFromPar(cPar& par, cModule *from)
+INET_API T *getModuleFromPar(cPar& par, cModule *from);
+
+template<typename T>
+T *getModuleFromPar(cPar& par, cModule *from)
 {
     const char *path = par.stringValue();
     cModule *mod = from->getModuleByPath(path);


### PR DESCRIPTION
I'm sorry this pops up right after the 3.0 release!

We saw a problem when including ModuleAccess.h under Windows due to the way the INET_API Macro works:
13:40:42 In file included from applications/api/AS6802/CoRE4INET_TTEAPIApplicationBase.cc:25:0:
13:40:42 ../../inet/src/inet/common/ModuleAccess.h:66:13: error: function 'T* inet::findModuleFromPar(cPar&, cModule*)' definition is marked dllimport
13:40:42  INET_API T *findModuleFromPar(cPar& par, cModule *from)
13:40:42              ^
13:40:42 In file included from applications/api/AS6802/CoRE4INET_TTEAPIApplicationBase.cc:25:0:
13:40:42 ../../inet/src/inet/common/ModuleAccess.h:88:13: error: function 'T* inet::getModuleFromPar(cPar&, cModule*)' definition is marked dllimport
13:40:42  INET_API T *getModuleFromPar(cPar& par, cModule *from)

This patch fixes the problem with the templates by separating declaration and definition. I'm afraid there might be more places in INET where this has to be fixed. I hope my patch does not have any side effects that I did not find in my tests.