### PR TITLE
TCP: Configurable window scale factor

### DIFF
--- a/src/inet/transportlayer/tcp/TCP.ned
+++ b/src/inet/transportlayer/tcp/TCP.ned
@@ -207,6 +207,7 @@ simple TCP like ITCP
         bool increasedIWEnabled = default(false); // Increased Initial Window (RFC 3390) enabled/disabled
         bool sackSupport = default(false); // Selective Acknowledgment (RFC 2018, 2883, 3517) support (header option) (SACK will be enabled for a connection if both endpoints support it)
         bool windowScalingSupport = default(false); // Window Scale (RFC 1323) support (header option) (WS will be enabled for a connection if both endpoints support it)
+        int windowScalingFactor = default(-1); // Window Scaling Factor to the power of 2. -1 indicates that manual window scaling is turned off.
         bool timestampSupport = default(false); // Timestamps (RFC 1323) support (header option) (TS will be enabled for a connection if both endpoints support it)
         int mss = default(536); // Maximum Segment Size (RFC 793) (header option)
         string tcpAlgorithmClass = default("TCPReno"); // TCPReno/TCPTahoe/TCPNewReno/TCPNoCongestionControl/DumbTCP


### PR DESCRIPTION
@rhornig 
To make the window scale factor configurable helps to compare the simulation to TCP stacks where you can set the factor via sysctl.