### PR TITLE
Added INET_API Macro to serializers

### DIFF
--- a/src/inet/common/serializer/headerserializers/arp/ARPSerializer.h
+++ b/src/inet/common/serializer/headerserializers/arp/ARPSerializer.h
@@ -28,7 +28,7 @@ namespace serializer {
 /**
  * Converts between ARPPacket and binary (network byte order)  ARP header.
  */
-class ARPSerializer : public SerializerBase
+class INET_API ARPSerializer : public SerializerBase
 {
   protected:
     /**

--- a/src/inet/common/serializer/headerserializers/ethernet/EthernetSerializer.h
+++ b/src/inet/common/serializer/headerserializers/ethernet/EthernetSerializer.h
@@ -27,7 +27,7 @@ namespace serializer {
 /**
  * Converts between EtherFrame and binary (network byte order) Ethernet header.
  */
-class EthernetSerializer : public SerializerBase
+class INET_API EthernetSerializer : public SerializerBase
 {
   protected:
     /**

--- a/src/inet/common/serializer/ipv4/ICMPSerializer.h
+++ b/src/inet/common/serializer/ipv4/ICMPSerializer.h
@@ -28,7 +28,7 @@ namespace serializer {
 /**
  * Converts between ICMPMessage and binary (network byte order) ICMP header.
  */
-class ICMPSerializer : public SerializerBase
+class INET_API ICMPSerializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;

--- a/src/inet/common/serializer/ipv4/IGMPSerializer.h
+++ b/src/inet/common/serializer/ipv4/IGMPSerializer.h
@@ -28,7 +28,7 @@ namespace serializer {
 /**
  * Converts between IGMPMessage and binary (network byte order) IGMP header.
  */
-class IGMPSerializer : public SerializerBase
+class INET_API IGMPSerializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;

--- a/src/inet/common/serializer/ipv4/IPv4Serializer.h
+++ b/src/inet/common/serializer/ipv4/IPv4Serializer.h
@@ -25,7 +25,7 @@ namespace inet {
 
 namespace serializer {
 
-class IPv4OptionSerializerBase : public cOwnedObject
+class INET_API IPv4OptionSerializerBase : public cOwnedObject
 {
   public:
     IPv4OptionSerializerBase(const char *name = nullptr) : cOwnedObject(name, false) {}

--- a/src/inet/common/serializer/ipv6/ICMPv6Serializer.h
+++ b/src/inet/common/serializer/ipv6/ICMPv6Serializer.h
@@ -28,7 +28,7 @@ namespace serializer {
 /**
  * Converts between ICMPMessage and binary (network byte order) ICMP header.
  */
-class ICMPv6Serializer : public SerializerBase
+class INET_API ICMPv6Serializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;

--- a/src/inet/common/serializer/ipv6/IPv6Serializer.h
+++ b/src/inet/common/serializer/ipv6/IPv6Serializer.h
@@ -27,7 +27,7 @@ namespace serializer {
 /**
  * Converts between IPv6Datagram and binary (network byte order) IPv6 header.
  */
-class IPv6Serializer : public SerializerBase
+class INET_API IPv6Serializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;

--- a/src/inet/common/serializer/sctp/SCTPSerializer.h
+++ b/src/inet/common/serializer/sctp/SCTPSerializer.h
@@ -28,7 +28,7 @@ namespace serializer {
 /**
  * Converts between SCTPMessage and binary (network byte order) SCTP header.
  */
-class SCTPSerializer : public SerializerBase
+class INET_API SCTPSerializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;

--- a/src/inet/common/serializer/tcp/TCPSerializer.h
+++ b/src/inet/common/serializer/tcp/TCPSerializer.h
@@ -34,7 +34,7 @@ namespace serializer {
 /**
  * Converts between TCPSegment and binary (network byte order) TCP header.
  */
-class TCPSerializer : public SerializerBase
+class INET_API TCPSerializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;

--- a/src/inet/common/serializer/udp/UDPSerializer.h
+++ b/src/inet/common/serializer/udp/UDPSerializer.h
@@ -28,7 +28,7 @@ namespace serializer {
 /**
  * Converts between UDPPacket and binary (network byte order) UDP header.
  */
-class UDPSerializer : public SerializerBase
+class INET_API UDPSerializer : public SerializerBase
 {
   protected:
     virtual void serialize(const cPacket *pkt, Buffer &b, Context& context) override;


### PR DESCRIPTION
This fixes the "undefined reference to vtable" problem under windows.

I'm not completely in the picture with all this INET_API thing, but it seems like it is recently often forgotten in new code. Is there a way we can prevent these problems?