### PR TITLE
Fixes for the EthernetSerializer

### DIFF
--- a/src/inet/common/serializer/SerializerBase.cc
+++ b/src/inet/common/serializer/SerializerBase.cc
@@ -35,7 +35,7 @@ void SerializerBase::serializePacket(const cPacket *pkt, Buffer &b, Context& c)
 {
     unsigned int startPos = b.getPos();
     serialize(pkt, b, c);
-    if (!b.hasError() && (b.getPos() - startPos != pkt->getByteLength()))
+    if (c.throwOnSerializedSizeMissmatch && !b.hasError() && (b.getPos() - startPos != pkt->getByteLength()))
         throw cRuntimeError("%s serializer error: packet %s (%s) length is %d but serialized length is %d", getClassName(), pkt->getName(), pkt->getClassName(), pkt->getByteLength(), b.getPos() - startPos);
 }
 
@@ -51,7 +51,7 @@ cPacket *SerializerBase::deserializePacket(const Buffer &b, Context& context)
         pkt = serializers.byteArraySerializer.deserialize(b, context);
     }
     ASSERT(pkt);
-    if (!pkt->hasBitError() && !b.hasError() && (b.getPos() - startPos != pkt->getByteLength())) {
+    if (context.throwOnSerializedSizeMissmatch && !pkt->hasBitError() && !b.hasError() && (b.getPos() - startPos != pkt->getByteLength())) {
         const char *encclass = pkt->getEncapsulatedPacket() ? pkt->getEncapsulatedPacket()->getClassName() : "<nullptr>";
         throw cRuntimeError("%s deserializer error: packet %s (%s) length is %d but deserialized length is %d (encapsulated packet is %s)", getClassName(), pkt->getName(), pkt->getClassName(), pkt->getByteLength(), b.getPos() - startPos, encclass);
     }

--- a/src/inet/common/serializer/SerializerBase.h
+++ b/src/inet/common/serializer/SerializerBase.h
@@ -55,7 +55,9 @@ class INET_API Context
     const void *l3AddressesPtr = nullptr;
     unsigned int l3AddressesLength = 0;
     bool throwOnSerializerNotFound = true;
+    bool throwOnSerializedSizeMissmatch = true;
     bool errorOccured = false;
+    bool serializeControlData = false;
 };
 
 /**


### PR DESCRIPTION
Patch for problems mentioned in: https://groups.google.com/d/msg/inetframework-contrib/IHMo0JuI0Pw/z3WUHqc4CQAJ

- Fixed length field
- Fixed CRC
- Fixed padding

- Context feature to disable exception when serialized packet is shorter
than bytelength (Preamble and SFD not being serialized)
- Context feature to enable serialization of preamble and SFD