### PR TITLE
fixed ttl off-by-one error

### DIFF
--- a/src/inet/networklayer/ipv4/IPv4.cc
+++ b/src/inet/networklayer/ipv4/IPv4.cc
@@ -673,7 +673,7 @@ void IPv4::fragmentAndSend(IPv4Datagram *datagram, const InterfaceEntry *ie, IPv
         datagram->setTimeToLive(datagram->getTimeToLive() - 1);
 
     // hop counter check
-    if (datagram->getTimeToLive() < 0) {
+    if (datagram->getTimeToLive() <= 0) {
         // drop datagram, destruction responsibility in ICMP
         EV_WARN << "datagram TTL reached zero, sending ICMP_TIME_EXCEEDED\n";
         icmp->sendErrorMessage(datagram, -1    /*TODO*/, ICMP_TIME_EXCEEDED, 0);


### PR DESCRIPTION
Hi,

I was poking around with traceroute in a little simulation I'm currently playing with and found that routers in inet are forwarding IPv4 packets with ttl==0, which is not correct. It seems that this behavior has been accidentally introduced in de2b2a40ba6788c9d00be7f3265a011749a2fd51 

Best,

Julius
