### PR TITLE
fixed invalid TTL reuse for ICMP Echo Reply

### DIFF
--- a/src/inet/networklayer/ipv4/ICMP.cc
+++ b/src/inet/networklayer/ipv4/ICMP.cc
@@ -240,6 +240,7 @@ void ICMP::processEchoRequest(ICMPMessage *request)
     ctrl->setInterfaceId(-1);
     ctrl->setSrcAddr(dest);
     ctrl->setDestAddr(src);
+    ctrl->setTimeToLive(0); // if the TTL is set to 0 here, IP resets it to the default TTL
 
     sendToIP(reply);
 }


### PR DESCRIPTION
Hi,

I found that when creating ICMP Echo Replys, inet would simply reuse the old IPv4ControlInfo from the request with swapped SRC and DST addresses.
This means that the packet would be sent with the TTL it has seen on the request packet. 
By setting it to 0, the IPv4 layer correctly resets it to the default TTL.

Best,

Julius
 