### PR TITLE
Prevent dereferencing dangling Radio pointer in RadioMedium

### DIFF
--- a/src/inet/physicallayer/common/packetlevel/RadioMedium.cc
+++ b/src/inet/physicallayer/common/packetlevel/RadioMedium.cc
@@ -425,7 +425,7 @@ const IReceptionResult *RadioMedium::getReceptionResult(const IRadio *radio, con
 
 void RadioMedium::addRadio(const IRadio *radio)
 {
-    radios.push_back(radio);
+    radios.insert(radio);
     communicationCache->addRadio(radio);
     if (neighborCache)
         neighborCache->addRadio(radio);
@@ -448,13 +448,7 @@ void RadioMedium::addRadio(const IRadio *radio)
 
 void RadioMedium::removeRadio(const IRadio *radio)
 {
-    int radioIndex = radio->getId() - radios[0]->getId();
-    radios[radioIndex] = nullptr;
-    int radioCount = 0;
-    while (radios[radioCount] == nullptr && radioCount < (int)radios.size())
-        radioCount++;
-    if (radioCount != 0)
-        radios.erase(radios.begin(), radios.begin() + radioCount);
+    radios.erase(radio);
     communicationCache->removeRadio(radio);
     if (neighborCache)
         neighborCache->removeRadio(radio);
@@ -471,7 +465,7 @@ void RadioMedium::removeRadio(const IRadio *radio)
 
 bool RadioMedium::hasRadio(const IRadio *radio) const
 {
-    return std::find(radios.begin(), radios.end(), radio) != radios.end();
+    return radios.find(radio) != radios.end();
 }
 
 void RadioMedium::addTransmission(const IRadio *transmitterRadio, const ITransmission *transmission)

--- a/src/inet/physicallayer/common/packetlevel/RadioMedium.cc
+++ b/src/inet/physicallayer/common/packetlevel/RadioMedium.cc
@@ -469,6 +469,11 @@ void RadioMedium::removeRadio(const IRadio *radio)
     emit(radioRemovedSignal, radioModule);
 }
 
+bool RadioMedium::hasRadio(const IRadio *radio) const
+{
+    return std::find(radios.begin(), radios.end(), radio) != radios.end();
+}
+
 void RadioMedium::addTransmission(const IRadio *transmitterRadio, const ITransmission *transmission)
 {
     transmissionCount++;

--- a/src/inet/physicallayer/common/packetlevel/RadioMedium.h
+++ b/src/inet/physicallayer/common/packetlevel/RadioMedium.h
@@ -29,6 +29,7 @@
 #include "inet/physicallayer/contract/packetlevel/INeighborCache.h"
 #include "inet/physicallayer/contract/packetlevel/IRadioMedium.h"
 #include <algorithm>
+#include <set>
 
 namespace inet {
 
@@ -120,12 +121,11 @@ class INET_API RadioMedium : public cSimpleModule, public cListener, public IRad
     /** @name State */
     //@{
     /**
-     * The list of radios that can transmit and receive radio signals on the
-     * radio medium. The radios follow each other in the order of their unique
-     * id. Radios are only removed from the beginning. This list may contain
-     * nullptr values.
+     * The set of radios that can transmit and receive radio signals on the
+     * radio medium.
      */
-    std::vector<const IRadio *> radios;
+    std::set<const IRadio *> radios;
+
     /**
      * The list of ongoing transmissions on the radio medium. The transmissions
      * follow each other in the order of their unique id. Transmissions are only

--- a/src/inet/physicallayer/common/packetlevel/RadioMedium.h
+++ b/src/inet/physicallayer/common/packetlevel/RadioMedium.h
@@ -331,6 +331,7 @@ class INET_API RadioMedium : public cSimpleModule, public cListener, public IRad
 
     virtual void addRadio(const IRadio *radio) override;
     virtual void removeRadio(const IRadio *radio) override;
+    virtual bool hasRadio(const IRadio *radio) const override;
 
     virtual void sendToRadio(IRadio *trasmitter, const IRadio *receiver, const IRadioFrame *frame);
 

--- a/src/inet/physicallayer/contract/packetlevel/IRadioMedium.h
+++ b/src/inet/physicallayer/contract/packetlevel/IRadioMedium.h
@@ -124,6 +124,12 @@ class INET_API IRadioMedium : public IPrintableObject
     virtual void removeRadio(const IRadio *radio) = 0;
 
     /**
+     * Check if a given radio is known to this radio medium, i.e. it has been
+     * added before and not been removed yet.
+     */
+    virtual bool hasRadio(const IRadio *radio) const = 0;
+
+    /**
      * Returns a new radio frame containing the radio signal transmission that
      * represents the provided MAC frame. A copy of this radio frame is sent
      * to all affected radios. The MAC frame control info must be an instance


### PR DESCRIPTION
This pull request relates to #250.
I have discarded the previous idea to replace IRadio pointers by radio ids for two reasons:
1) Ids from IRadio::getId() cannot be turned into cModule easily because it is not inherited from cModule::getId(). A workaround would require look-ups at RadioMedium.
2) I am not sure if it is possible to create any reasonable return value in DimensionalAnalogModelBase::computeReceptionPower at all when there is no transmitter radio available any more.

Hence, I have picked up and modified the initial idea by Nico Brüttner. For faster lookups, std::set is used instead of std::vector to store IRadio* in RadioMedium. Fingerprints remain unchanged and wireless tests are still running fine.