### PR TITLE
Fixes infinite looping in GPSR which led to zeno simulation behavior

### DIFF
--- a/src/inet/routing/gpsr/GPSR.cc
+++ b/src/inet/routing/gpsr/GPSR.cc
@@ -544,9 +544,19 @@ L3Address GPSR::findPerimeterRoutingNextHop(INetworkDatagram *datagram, const L3
             if (nextNeighborAddress.isUnspecified())
                 break;
             EV_DEBUG << "Intersecting towards next hop: nextNeighbor = " << nextNeighborAddress << ", firstSender = " << firstSenderAddress << ", firstReceiver = " << firstReceiverAddress << ", destination = " << destination << endl;
+
             Coord nextNeighborPosition = getNeighborPosition(nextNeighborAddress);
-            Coord intersection = intersectSections(perimeterRoutingStartPosition, destinationPosition, selfPosition, nextNeighborPosition);
-            hasIntersection = !std::isnan(intersection.x);
+            Coord intersection(NaN, NaN, NaN);
+
+            // Don't intersect if our selfPosition is equal to the perimeter start position (the first check could be done earlier)
+            if (perimeterRoutingStartPosition != selfPosition       // Only occurs on start... No need to find intersection (if so, we should not have switched to perimeter routing)
+                && destinationPosition != nextNeighborPosition) {   // If next neighbor is destination go for it and break loop
+                intersection = intersectSections(perimeterRoutingStartPosition, destinationPosition, selfPosition, nextNeighborPosition);
+                hasIntersection = !std::isnan(intersection.x);
+            } else {
+                hasIntersection = false;
+            }
+
             if (hasIntersection) {
                 EV_DEBUG << "Edge to next hop intersects: intersection = " << intersection << ", nextNeighbor = " << nextNeighborAddress << ", firstSender = " << firstSenderAddress << ", firstReceiver = " << firstReceiverAddress << ", destination = " << destination << endl;
                 gpsrOption->setCurrentFaceFirstSenderAddress(selfAddress);


### PR DESCRIPTION
During my work with the INET framework I have experienced another problem -- this time in the GPSR routing. In certain situations it can happen that the immediate neighborhood table does not contain a close neighbor which leads to entering the perimeter routing mode that loops infinitely searching the next hop.


To illustrate the problem I will introduce the steps that can lead to such a situation:

1. Every node sends GPSR beacons (with some jitter)

2. Every node in the immediate neighborhood receives these beacons and knows the position of its neighbors

3. Unfortunately subsequent beacons of node DEST to node START get lost due to channel noise

4. Since node START did not receive another beacon, node DEST is removed from the immediate neighborhood table (however, node VIA's table still contains DEST)

5. Now, a udp application on node START tries to send a datagram to the L3 address of DEST (L3_DEST)

5.1 The GPSR greedy routing cannot find L3_DEST in its neighborhood table

5.2 GPSR inspects the distances of all known neighbors to the target location but does not find any neighbor closer to it (reducing the distance i.e. START<->DEST <= KNOWN_NEIGHBORS<->DEST)

5.3 GPSR falls back to perimeter routing
 5.3.1 GPSR starts inspecting neighbors in counter-clockwise direction -- starting to the right from the line START<->DEST
 5.3.2 GPSR finds a neighbor and USES the intersection test in the loop of method "L3Address GPSR::findPerimeterRoutingNextHop(INetworkDatagram *datagram, const L3Address& destination)"
 
Here the problem starts!


~(This behavior I barely remember...)
~GPSR relies on perimeter routing until an intersection of PERIMETER_START_POS<->DEST and CURRENT_NODES_POS<->NEXT_NEIGHBOR_POS occurs.
~(or: there seems to be the shortcut to switch back to greedy if (selfDistance < perimeterRoutingStartDistance) -- however, does not eliminate this problem)
~Such an itersection usually signals that the perimeter routing successfully routed around the empty surface and GPSR can switch back to greedy routing.


Since calling "Coord intersection = intersectSections(perimeterRoutingStartPosition, destinationPosition, selfPosition, nextNeighborPosition);" does not check whether "perimeterRoutingStartPosition != selfPosition", it is possible that there will always be an intersection and the loop will not quit.
This is due to the fact that node START, which originally created the packet, set "perimeterRoutingStartPosition" to its own. Therefore an intersection occurs for any inspected neighbor at the node START itself!



Proper checks are needed.
In this pull request a workaround is proposed that should be checked by a second pair of eyes. However, it did solve the problem for me.