### PR TITLE
Fixing Ieee802154NarrowbandScalarRadio

### DIFF
--- a/src/inet/physicallayer/ieee802154/packetlevel/Ieee802154NarrowbandScalarRadio.ned
+++ b/src/inet/physicallayer/ieee802154/packetlevel/Ieee802154NarrowbandScalarRadio.ned
@@ -30,20 +30,21 @@ module Ieee802154NarrowbandScalarRadio extends FlatRadioBase
         carrierFrequency = 2450 MHz;
 
         // B_20dB ATmega256RFR2 (page 564)
-        // *.bandwidth = default(2.8 MHz);
-        // what is meant by bandwidth here?
-        // the B_20dB bandwidth would lead to far too low BERs
-        bandwidth = default(0.25 MHz);
+        bandwidth = default(2.8 MHz);
 
         // 802.15.4-2006 (page 28)
         *.bitrate = default(250 kbps);
 
-        // PHY Header, 802.15.4-2006 (page 43)
-        // 4 octets Preamble
+        // PHY Header (without preamble), 802.15.4-2006 (page 43)
         // 1 octet SFD
         // 7 bit Frame length
         // 1 bit Reserved
-        *.headerBitLength = (4*8 + 1*8 + 7 + 1) * 1 b;
+        *.headerBitLength = (1*8 + 7 + 1) * 1 b;
+
+        // Preamble
+        // 4 octets Preamble
+        // 1 symbol of 16us -> 4 bit
+        transmitter.preambleDuration = (4*8/4) * 16 us;
 
         // RSSI sensitivity (ATmega256RFR2, page 566)
         receiver.energyDetection = default(-90dBm);
@@ -67,5 +68,5 @@ module Ieee802154NarrowbandScalarRadio extends FlatRadioBase
         // TX Output power (typ. 3.5 dBm, ATmega256RFR2, page 564)
         transmitter.power = default(2.24mW);
 
-        @class(Radio);
+        @class(FlatRadioBase);
 }


### PR DESCRIPTION
In the past, there has been confusion regarding the `bandwith` parameter of _Ieee802154NarrowbandScalarRadio_.

In the current form, the module is unusable because the default bandwith of _0.25 MHz_ does not even satisfy the assert in [DSSSOQPSK16Modulation.cc:42](https://github.com/inet-framework/inet/blob/master/src/inet/physicallayer/modulation/DSSSOQPSK16Modulation.cc#L42).
This is related to the issue discussed in the commit 
[e062cb7c7d0c5c10eedf154f303ad692ba1ba458](https://github.com/inet-framework/inet/commit/e062cb7c7d0c5c10eedf154f303ad692ba1ba458).

Later, the BER calculation in _DSSSOQPSK16Modulation.cc_ was fixed but the required change to _Ieee802154NarrowbandScalarRadio_ has not been merged, leading to the current incompatibility.

This pull request would introduce the required changes into `master` again.

Commit-message:
> Several minor fixes to the ned file:
> - The bandwidth was not correct, leading to incorrect channel allocation
> - The PHY header was calculated wrong
> - The base type was wrong
> 
> Signed-off-by: Florian Kauer <florian.kauer@koalo.de>