### PR TITLE
consider sensitivity for computeIsReceptionPossible in APSKScalarReceiver

### DIFF
--- a/src/inet/physicallayer/apskradio/packetlevel/APSKScalarReceiver.cc
+++ b/src/inet/physicallayer/apskradio/packetlevel/APSKScalarReceiver.cc
@@ -48,7 +48,7 @@ bool APSKScalarReceiver::computeIsReceptionPossible(const IListening *listening,
 bool APSKScalarReceiver::computeIsReceptionPossible(const IListening *listening, const IReception *reception, IRadioSignal::SignalPart part) const
 {
     auto apksTransmission = dynamic_cast<const APSKScalarTransmission *>(reception->getTransmission());
-    return apksTransmission && NarrowbandReceiverBase::computeIsReceptionPossible(listening, reception, part);
+    return apksTransmission && FlatReceiverBase::computeIsReceptionPossible(listening, reception, part);
 }
 
 } // namespace physicallayer

--- a/tests/module/APSKScalarRadio_Sensitivity.test
+++ b/tests/module/APSKScalarRadio_Sensitivity.test
@@ -1,0 +1,95 @@
+%description:
+
+This is a test for APSKScalarRadio sensitivity threshold checking.
+The signal is stronger than the reception energy detection threshold.
+The signal is weaker than the reception sensitivity threshold.
+The signal is weaker than the reception snir threshold.
+The signal is expected to be listened to.
+No signals are expected to be possible to be received.
+No signals are expected to be received.
+
+%file: test.ned
+
+import inet.networklayer.configurator.ipv4.IPv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.apskradio.packetlevel.APSKScalarRadioMedium;
+
+network Test
+{
+    submodules:
+        radioMedium: APSKScalarRadioMedium;
+        configurator: IPv4NetworkConfigurator;
+        hostSender: WirelessHost;
+        hostReceiver: WirelessHost;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Test
+sim-time-limit = 500us
+record-eventlog = true
+ned-path = .;../../../../src
+
+#omnetpp 5.0 - 5.1 compatibility:
+eventlog-file = "${resultdir}/${configname}-${runnumber}.elog"
+output-scalar-file = "${resultdir}/${configname}-${runnumber}.sca"
+output-vector-file = "${resultdir}/${configname}-${runnumber}.vec"
+snapshot-file = "${resultdir}/${configname}-${runnumber}.sna"
+
+**.arpType = "GlobalARP"
+
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMaxX = 1000m
+**.mobility.constraintAreaMaxY = 1000m
+**.mobility.constraintAreaMaxZ = 0m
+**.mobility.initFromDisplayString = false
+**.mobility.initialY = 500m
+**.mobility.initialZ = 0m
+*.host*.mobilityType = "StationaryMobility"
+*.hostSender.mobility.initialX = 200m
+*.hostReceiver.mobility.initialX = 400m
+
+# radio medium
+*.radioMedium.backgroundNoise.power = -110dBm
+
+# nic
+*.host*.wlan[*].typename = "IdealWirelessNic"
+*.host*.wlan[*].bitrate = 2Mbps
+*.host*.wlan[*].mac.headerLength = 10B
+*.host*.wlan[*].mac.fullDuplex = false
+*.host*.wlan[*].radioType = "APSKScalarRadio"
+*.host*.wlan[*].radio.transmitter.bitrate = 2Mbps
+*.host*.wlan[*].radio.transmitter.preambleDuration = 0s
+*.host*.wlan[*].radio.transmitter.headerBitLength = 100b
+*.host*.wlan[*].radio.carrierFrequency = 2.4GHz
+*.host*.wlan[*].radio.bandwidth = 2MHz
+*.host*.wlan[*].radio.receiver.energyDetection = -120dBm
+*.host*.wlan[*].radio.receiver.sensitivity = -80dBm
+*.host*.wlan[*].radio.receiver.snirThreshold = 250dB
+*.hostSender.wlan[*].radio.transmitter.power = 1mW
+*.hostReceiver.wlan[*].radio.transmitter.power = 100W
+
+# ping app
+*.hostSender*.numPingApps = 1
+*.hostSender*.pingApp[0].count = 1
+*.hostSender*.pingApp[0].printPing = true
+*.hostSender*.pingApp[0].destAddr = "hostReceiver"
+*.hostSender*.pingApp[0].startTime = 0s
+
+%contains: results/General-0.elog
+listening is possible
+%contains: results/General-0.elog
+reception is impossible
+%contains: results/General-0.elog
+Reception started: not attempting
+%not-contains: results/General-0.elog
+Passing up contained packet `ping0' to higher layer
+%#--------------------------------------------------------------------------------------------------------------
+%not-contains: stdout
+undisposed object:
+%not-contains: stdout
+-- check module destructor
+%#--------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The `APSKScalarReceiver` is using the `NarrowbandReceiverBase` to determine whether a reception is possible. This is only checking whether the carrier frequency and bandwidth are equal. The `FlatReceiverBase` has a more advanced check whether a reception is possible by checking against the `sensitivity` parameter of the receiver.
I changed the call to the parent module and added a test that checks whether the `sensitivity` is considered when deciding if a reception is gonna be attempted.
Let me know what you think!