### PR TITLE
tcp: serializer: Fix checksum computation

### DIFF
--- a/src/inet/common/serializer/TCPIPchecksum.cc
+++ b/src/inet/common/serializer/TCPIPchecksum.cc
@@ -34,8 +34,10 @@ uint16_t TCPIPchecksum::_checksum(const void *_addr, unsigned int count)
         count -= 2;
     }
 
-    if (count)
-        sum += *(const uint8_t *)addr;
+    if (count) {
+        uint16_t last_byte = (uint16_t) *(const uint8_t *)addr;
+        sum += last_byte << 8;
+    }
 
     while (sum >> 16)
         sum = (sum & 0xFFFF) + (sum >> 16);


### PR DESCRIPTION
RFC 793, page 16, depicts that

> If a segment contains an odd number of header and text octets to be checksummed, the last octet is padded on the right with zeros to form a 16 bit word for checksum purposes.

The former implementation did not add the additional octed, which causes the computed checksum to be wrong.

Signed-off-by: Robert Noack <robert.noack@u-blox.com>