### PR TITLE
Ieee802154: Set rxSetupTime

### DIFF
--- a/src/inet/linklayer/ieee802154/AT86RF231.ned
+++ b/src/inet/linklayer/ieee802154/AT86RF231.ned
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2014 Florian Meier
+// Copyright (C) 2013 OpenSim Ltd.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+package inet.linklayer.ieee802154;
+
+simple AT86RF231 extends Ieee802154NarrowbandMac
+{
+    parameters:
+        // Time needed to switch from sleep to rx
+        // SLEEP -> TRX_OFF 380 us
+        // TRX_OFF -> RX_ON 110 us
+        rxSetupTime = 380us + 110us;
+}

--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.ned
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.ned
@@ -49,7 +49,7 @@ simple Ieee802154Mac extends MacProtocolBase like IMacProtocol
         // Clear Channel Assessment detection time
         double ccaDetectionTime @unit(s) = default(0.000128 s); // 8 symbols
         // Time to setup radio to reception state
-        double rxSetupTime @unit(s) = default(0 s);
+        double rxSetupTime @unit(s);
         // Time to switch radio from Rx to Tx state
         double aTurnaroundTime @unit(s) = default(0.000192 s);    // 12 symbols
 

--- a/src/inet/linklayer/ieee802154/Ieee802154NarrowbandMac.ned
+++ b/src/inet/linklayer/ieee802154/Ieee802154NarrowbandMac.ned
@@ -23,11 +23,6 @@ simple Ieee802154NarrowbandMac extends Ieee802154Mac
     parameters:
         useMACAcks = true;
 
-        // Time needed to switch from sleep to rx.
-        // TODO This is probabily wrong, since it is used to compute
-        //      the time for the CCA (and that might follow an RX state)
-        rxSetupTime = 0s;
-
         // aMaxPHYPacketSize = 127 Octets (802.15.4-2006, page 45)
         // aMinMPDUOverhead = 9 Octets (802.15.4-2006, page 159)
         // aMaxMACPayloadSize = aMaxPHYPacketSize - aMinMPDUOverhead (802.15.4-2006, page 159)


### PR DESCRIPTION
The rxSetupTime for the IEEE 802.15.4 MAC was still set to 0s.
This is now set according to the datasheet of the ATmega256RFR2.

Signed-off-by: Florian Kauer <florian.kauer@koalo.de>