### PR TITLE
Ieee802154: Add carrierFrequency to mediumLimitCache

### DIFF
--- a/src/inet/physicallayer/ieee802154/packetlevel/Ieee802154NarrowbandScalarRadioMedium.ned
+++ b/src/inet/physicallayer/ieee802154/packetlevel/Ieee802154NarrowbandScalarRadioMedium.ned
@@ -27,6 +27,8 @@ module Ieee802154NarrowbandScalarRadioMedium extends RadioMedium
         analogModelType = default("ScalarAnalogModel");
         backgroundNoiseType = default("IsotropicScalarBackgroundNoise");
 
+        mediumLimitCache.carrierFrequency = 2450 MHz;
+
         // 802.15.4-2006, page 266
         pathLossType = default("BreakpointPathLoss");
         pathLoss.breakpointDistance = 8 m;


### PR DESCRIPTION
For FreeSpacePathLoss, the carrierFrequency of mediumLimitCache is required.

Signed-off-by: Florian Kauer <florian.kauer@koalo.de>