### PR TITLE
featuretool: Do not fail if submodules are not checked out

### DIFF
--- a/inet_featuretool
+++ b/inet_featuretool
@@ -484,7 +484,8 @@ root directory where the following files are present:
         ok = True
         for fid, feature in self.sortedFeatures:
             if not self.checkFeatureNedFolders(feature):
-                ok = False
+                if 'showcases' not in fid and 'tutorial' not in fid:
+                    ok = False
         if not ok:
             fail("Check whether all NED folders are set properly (in the {} file) and all directories corresponding to the NED packages defined in the {} file do exist.".format(NEDFOLDERSFILE, FEATURESFILE))
 


### PR DESCRIPTION
Before, calling inet_featuretool repair without the submodules
showcases and tutorial checked out lead to a failure and the
repair action was aborted. Since both submodules are VERY large
and are often not required, this commit avoids the failure
so it is not required to download these submodules.