### PR TITLE
bugfix: corrected memory management issue in radio module

### DIFF
--- a/src/inet/physicallayer/common/packetlevel/Radio.cc
+++ b/src/inet/physicallayer/common/packetlevel/Radio.cc
@@ -477,8 +477,11 @@ void Radio::endReception(cMessage *timer)
         sendUp(macFrame);
         receptionTimer = nullptr;
     }
-    else
+    else {
         EV_INFO << "Reception ended: ignoring " << (IRadioFrame *)radioFrame << " " << IRadioSignal::getSignalPartName(part) << " as " << reception << endl;
+        if (timer == receptionTimer)
+            receptionTimer = nullptr;
+    }
     updateTransceiverState();
     updateTransceiverPart();
     check_and_cast<RadioMedium *>(medium)->emit(IRadioMedium::receptionEndedSignal, check_and_cast<const cObject *>(reception));


### PR DESCRIPTION
Corrected a fatal bug in the radio module that can occur if the separateReceptionParts mode is used.

This fixes an invalid delete(void*) attempt that occurs if a packet reception ends while the radio is still switching from RX --> another mode. Previously the code was trying to use abortReception(cMessage*) on a packet that had already been processed with endReception(cMessage*). If your simulation was unlucky enough to encounter this case the simulator would segfault.