### PR TITLE
aodv: responding properly to the D (destination only flag) flag

### DIFF
--- a/src/inet/routing/aodv/Aodv.cc
+++ b/src/inet/routing/aodv/Aodv.cc
@@ -52,6 +52,7 @@ void Aodv::initialize(int stage)
         aodvUDPPort = par("udpPort");
         askGratuitousRREP = par("askGratuitousRREP");
         useHelloMessages = par("useHelloMessages");
+        destinationOnlyFlag = par("destinationOnlyFlag");
         activeRouteTimeout = par("activeRouteTimeout");
         helloInterval = par("helloInterval");
         allowedHelloLoss = par("allowedHelloLoss");
@@ -415,6 +416,10 @@ const Ptr<Rreq> Aodv::createRREQ(const L3Address& destAddr)
 
     // The Hop Count field is set to zero.
     rreqPacket->setHopCount(0);
+
+    // Destination only flag (D) indicates that only the
+    // destination may respond to this RREQ.
+    rreqPacket->setDestOnlyFlag(destinationOnlyFlag);
 
     // Before broadcasting the RREQ, the originating node buffers the RREQ
     // ID and the Originator IP address (its own address) of the RREQ for
@@ -903,25 +908,32 @@ void Aodv::handleRREQ(const Ptr<Rreq>& rreq, const L3Address& sourceAddr, unsign
             return;
         }
 
-        // create RREP
-        auto rrep = createRREP(rreq, destRoute, reverseRoute, sourceAddr);
+        // we respond to the RREQ, if the D (destination only) flag is not set
+        if(!rreq->getDestOnlyFlag())
+        {
+            // create RREP
+            auto rrep = createRREP(rreq, destRoute, reverseRoute, sourceAddr);
 
-        // send to the originator
-        sendRREP(rrep, rreq->getOriginatorAddr(), 255);
+            // send to the originator
+            sendRREP(rrep, rreq->getOriginatorAddr(), 255);
 
-        if (rreq->getGratuitousRREPFlag()) {
-            // The gratuitous RREP is then sent to the next hop along the path to
-            // the destination node, just as if the destination node had already
-            // issued a RREQ for the originating node and this RREP was produced in
-            // response to that (fictitious) RREQ.
+            if (rreq->getGratuitousRREPFlag()) {
+                // The gratuitous RREP is then sent to the next hop along the path to
+                // the destination node, just as if the destination node had already
+                // issued a RREQ for the originating node and this RREP was produced in
+                // response to that (fictitious) RREQ.
 
-            IRoute *originatorRoute = routingTable->findBestMatchingRoute(rreq->getOriginatorAddr());
-            auto grrep = createGratuitousRREP(rreq, originatorRoute);
-            sendGRREP(grrep, rreq->getDestAddr(), 100);
+                IRoute *originatorRoute = routingTable->findBestMatchingRoute(rreq->getOriginatorAddr());
+                auto grrep = createGratuitousRREP(rreq, originatorRoute);
+                sendGRREP(grrep, rreq->getDestAddr(), 100);
+            }
+
+            return;    // discard RREQ, in this case, we also do not forward it.
         }
-
-        return;    // discard RREQ, in this case, we also do not forward it.
+        else
+            EV_INFO << "The originator indicated that only the destination may respond to this RREQ (D flag is set). Forwarding ..." << endl;
     }
+
     // If a node does not generate a RREP (following the processing rules in
     // section 6.6), and if the incoming IP header has TTL larger than 1,
     // the node updates and broadcasts the RREQ to address 255.255.255.255

--- a/src/inet/routing/aodv/Aodv.h
+++ b/src/inet/routing/aodv/Aodv.h
@@ -82,6 +82,7 @@ class INET_API Aodv : public cSimpleModule, public ILifecycle, public NetfilterB
     unsigned int aodvUDPPort = 0;
     bool askGratuitousRREP = false;
     bool useHelloMessages = false;
+    bool destinationOnlyFlag = false;
     simtime_t maxJitter;
     simtime_t activeRouteTimeout;
     simtime_t helloInterval;

--- a/src/inet/routing/aodv/Aodv.ned
+++ b/src/inet/routing/aodv/Aodv.ned
@@ -48,6 +48,7 @@ simple Aodv like IManetRouting
         bool askGratuitousRREP = default(false); // see RFC 3561: 6.6.3
         bool useHelloMessages = default(false); // see RFC 3561: 6.9
         bool useLocalRepair = default(false); // see RFC 3561: 6.12 *not implemented yet*
+        bool destinationOnlyFlag = default(false); // see RFC 3561: 5.1
         int udpPort = default(654);
 
         double maxPeriodicJitter @unit(s) = default(helloInterval / 4); // it MUST NOT be negative; it MUST NOT be greater than MESSAGE_INTERVAL/2; it SHOULD NOT be greater than MESSAGE_INTERVAL/4.


### PR DESCRIPTION
The user can set/unset the D flag in a RREQ message through the destinationOnlyFlag parameter. It is 'false' by default meaning that an intermediate route can respond to a RREQ message if it has a fresh route to the destination. If 'destinationOnlyFlag ' is 'true' then the intermediate node will not respond to the RREQ (even if it has a valid fresh route to the destination), and forwards the RREQ message. Here is the output log of a sample scenario:

![2018-04-07_19-41-54](https://user-images.githubusercontent.com/5473998/38463938-8f0f0330-3ab9-11e8-80a7-37c93af3f87d.png)

aodvRouter5 is an intermediate node that receives a RREQ message with D flag set, thus it will forward the message.

