### PR TITLE
Use CONGESTION instead of RETRY_LIMIT_REACHED for backoff limit reached

### DIFF
--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
@@ -421,7 +421,7 @@ void Ieee802154Mac::updateStatusCCA(t_mac_event event, cMessage *msg)
                     txAttempts = 0;
                     nbDroppedFrames++;
                     PacketDropDetails details;
-                    details.setReason(RETRY_LIMIT_REACHED);
+                    details.setReason(CONGESTION);
                     details.setLimit(macMaxCSMABackoffs);
                     emit(packetDroppedSignal, mac, &details);
                     delete mac;

--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.ned
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.ned
@@ -99,4 +99,5 @@ simple Ieee802154Mac extends MacProtocolBase like IMacProtocol
         @statistic[packetDropIncorrectlyReceived](title="packet drop: incorrectly received"; source=packetDropReasonIsIncorrectlyReceived(packetDropped); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetDropQueueOverlow](title="packet drop: queue overflow"; source=packetDropReasonIsQueueOverflow(packetDropped); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetDropRetryLimitReached](title="packet drop: retry limit reached"; source=packetDropReasonIsRetryLimitReached(packetDropped); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
+        @statistic[packetDropBackoffLimitReached](title="packet drop: backoff limit reached"; source=packetDropReasonIsCongestion(packetDropped); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
 }


### PR DESCRIPTION
The retry limit is for a different purpose than the backoff limit for CSMA/CA in IEEE 802.15.4 so they should be tracked separately. I think CONGESTION matches the case of a channel that was sensed busy several times very good. An alternative would be to add a BACKOFF_LIMIT_REACHED.