### PR TITLE
Improve the performance of the computeIntersection function of the Prism shape

### DIFF
--- a/src/inet/common/geometry/shape/Prism.cc
+++ b/src/inet/common/geometry/shape/Prism.cc
@@ -119,8 +119,8 @@ void Prism::computeOutwardNormalVectors()
 bool Prism::computeIntersection(const LineSegment& lineSegment, Coord& intersection1, Coord& intersection2, Coord& normal1, Coord& normal2) const
 {
     // Note: based on http://geomalgorithms.com/a13-_intersect-4.html
-    Coord p0 = lineSegment.getPoint1();
-    Coord p1 = lineSegment.getPoint2();
+    Coord const &p0 = lineSegment.getPoint1();
+    Coord const &p1 = lineSegment.getPoint2();
     if (p0 == p1)
     {
         normal1 = normal2 = Coord::NIL;
@@ -131,10 +131,10 @@ bool Prism::computeIntersection(const LineSegment& lineSegment, Coord& intersect
     double tL = 1;
     for (unsigned int i = 0; i < faces.size(); i++)
     {
-        Polygon face = faces[i];
-        Coord normalVec = normalVectorsForFaces[i];
+        Polygon const &face = faces[i];
+        Coord const &normalVec = normalVectorsForFaces[i];
         const std::vector<Coord>& pointList = face.getPoints();
-        Coord f0 = pointList[0];
+        Coord const &f0 = pointList[0];
         double N = (f0 - p0) * normalVec;
         double D = segmentDirection * normalVec;
         if (D < 0)


### PR DESCRIPTION
This function copies the points instead of referencing them.
In this fix, I replace the copies with references.

Using this fix in a large scale system of CAVs simulation,
the simulation time dropped from **357** minutes to **218** minutes.