### PR TITLE
introduce statistics for 802.11 mac pending queue

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h
@@ -51,6 +51,8 @@ class Ieee80211Mac;
 class INET_API Dcf : public ICoordinationFunction, public IFrameSequenceHandler::ICallback, public IChannelAccess::ICallback, public ITx::ICallback, public IProcedureCallback, public ModeSetListener
 {
     protected:
+        simsignal_t pendingQueueSizeSignal;
+        simsignal_t pendingQueueDroppedSignal;
         Ieee80211Mac *mac = nullptr;
         IRateControl *dataAndMgmtRateControl = nullptr;
 

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
@@ -48,6 +48,10 @@ module Dcf
         @display("i=block/queue");
         @signal[linkBroken](type=Packet);
         @signal[packetDropped](type=Packet);
+        @signal[pendingQueueSize](type="long");
+        @statistic[pendingQueueSize](title="pending queue size"; source="pendingQueueSize"; record=count,sum,vector,stats; interpolationmode=linear);
+        @signal[pendingQueueDropped](type="long");
+        @statistic[pendingQueueDropped](title="pending queue dropped"; source="pendingQueueDropped"; record=count,sum,vector,stats; interpolationmode=none);
 
     submodules:
         channelAccess: Dcaf {


### PR DESCRIPTION
Would be nice to have statistics for the pending queue of the 802.11 mac layer