### PR TITLE
ieee80211: support EtherType protocol discrimination in 5.9 GHz band

### DIFF
--- a/examples/wireless/nic/omnetpp.ini
+++ b/examples/wireless/nic/omnetpp.ini
@@ -225,3 +225,17 @@ description = "IEEE 80211 mac with scalar radio"
 extends = AbstractIeee80211Mac, AbstractIeee80211DimensionalRadio
 description = "IEEE 802.11 mac with IEEE 802.11 dimensional radio"
 
+
+[Config Ieee80211MacV2X]
+extends = Ieee80211MacWithIeee80211ScalarRadio
+description = "IEEE 802.11 radios for V2X communication in 5.9 GHz band"
+# NOTE: AIFS and TXOP settings do not comply with IEEE 802.11 OCB mode
+**.wlan*.mgmt.typename = "Ieee80211MgmtAdhoc"
+**.wlan*.agent.typename = ""
+**.wlan*.opMode = "p"
+**.wlan*.mac.qosStation = true
+**.wlan*.mac.*.rateSelection.*Bitrate = 6 Mbps
+**.wlan*.radio.bandName = "5.9 GHz"
+**.wlan*.radio.bandwidth = 10 MHz
+**.wlan*.radio.carrierFrequency = 5.9 GHz
+**.wlan*.radio.channelNumber = 4

--- a/src/inet/common/Protocol.cc
+++ b/src/inet/common/Protocol.cc
@@ -86,6 +86,7 @@ const Protocol Protocol::ethernetPhy("ethernetphy", "Ethernet PHY", Protocol::Ph
 const Protocol Protocol::gpsr("gpsr", "GPSR");
 const Protocol Protocol::icmpv4("icmpv4", "ICMPv4", Protocol::NetworkLayer);
 const Protocol Protocol::icmpv6("icmpv6", "ICMPv6", Protocol::NetworkLayer);
+const Protocol Protocol::ieee80211EtherType("ieee80211ethertype", "IEEE 802.11 LLC (EtherType)", Protocol::LinkLayer);
 const Protocol Protocol::ieee80211Mac("ieee80211mac", "IEEE 802.11 MAC", Protocol::LinkLayer);
 const Protocol Protocol::ieee80211Mgmt("ieee80211mgmt", "IEEE 802.11 MGMT", Protocol::LinkLayer);
 const Protocol Protocol::ieee80211Phy("ieee80211phy", "IEEE 802.11 PHY", Protocol::PhysicalLayer);

--- a/src/inet/common/Protocol.h
+++ b/src/inet/common/Protocol.h
@@ -72,6 +72,7 @@ class INET_API Protocol
     static const Protocol gpsr;
     static const Protocol icmpv4;
     static const Protocol icmpv6;
+    static const Protocol ieee80211EtherType;
     static const Protocol ieee80211Mac;
     static const Protocol ieee80211Mgmt;
     static const Protocol ieee80211Phy;

--- a/src/inet/linklayer/ieee80211/Ieee80211Interface.ned
+++ b/src/inet/linklayer/ieee80211/Ieee80211Interface.ned
@@ -19,10 +19,10 @@ package inet.linklayer.ieee80211;
 
 import inet.linklayer.common.IIeee8021dQosClassifier;
 import inet.linklayer.contract.IWirelessInterface;
+import inet.linklayer.ieee80211.llc.Ieee80211Llc;
 import inet.linklayer.ieee80211.mgmt.IIeee80211Agent;
 import inet.linklayer.ieee80211.mgmt.IIeee80211Mgmt;
 import inet.linklayer.ieee80211.mib.Ieee80211Mib;
-import inet.linklayer.ieee8022.IIeee8022Llc;
 import inet.physicallayer.contract.packetlevel.IRadio;
 
 //
@@ -61,10 +61,6 @@ module Ieee80211Interface like IWirelessInterface
             parameters:
                 @display("p=100,100;is=s");
         }
-        llc: <default("Ieee8022Llc")> like IIeee8022Llc {
-            parameters:
-                @display("p=250,200");
-        }
         classifier: <default("")> like IIeee8021dQosClassifier if typename != "" {
             parameters:
                 @display("p=400,100");
@@ -84,6 +80,10 @@ module Ieee80211Interface like IWirelessInterface
         radio: <default("Ieee80211ScalarRadio")> like IRadio {
             parameters:
                 @display("p=250,500");
+        }
+        llc: <default(radio.bandName == "5.9 GHz" ? "Ieee80211LlcEpd" : "Ieee80211LlcLpd")> like Ieee80211Llc {
+            parameters:
+                @display("p=250,200");
         }
     connections:
         radioIn --> { @display("m=s"); } --> radio.radioIn;

--- a/src/inet/linklayer/ieee80211/Ieee80211Interface.ned
+++ b/src/inet/linklayer/ieee80211/Ieee80211Interface.ned
@@ -61,6 +61,10 @@ module Ieee80211Interface like IWirelessInterface
             parameters:
                 @display("p=100,100;is=s");
         }
+        llc: <default(opMode == "p" ? "Ieee80211LlcEpd" : "Ieee80211LlcLpd")> like Ieee80211Llc {
+            parameters:
+                @display("p=250,200");
+        }
         classifier: <default("")> like IIeee8021dQosClassifier if typename != "" {
             parameters:
                 @display("p=400,100");
@@ -80,10 +84,6 @@ module Ieee80211Interface like IWirelessInterface
         radio: <default("Ieee80211ScalarRadio")> like IRadio {
             parameters:
                 @display("p=250,500");
-        }
-        llc: <default(radio.bandName == "5.9 GHz" ? "Ieee80211LlcEpd" : "Ieee80211LlcLpd")> like Ieee80211Llc {
-            parameters:
-                @display("p=250,200");
         }
     connections:
         radioIn --> { @display("m=s"); } --> radio.radioIn;

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader.msg
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader.msg
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+import inet.common.INETDefs;
+import inet.common.packet.chunk.Chunk;
+
+cplusplus {{
+#include "inet/common/ProtocolGroup.h"
+}}
+
+namespace inet;
+
+// IEEE 802.11 in 5.9 GHz band requires EtherType Protocol Discrimination (EPD)
+class Ieee80211EtherTypeHeader extends FieldsChunk
+{
+    chunkLength = B(2);
+    int etherType = -1; // ~EtherType (2 bytes)
+}
+
+cplusplus(Ieee80211EtherTypeHeader) {{
+    virtual const Protocol* getProtocol() const
+    {
+        return ProtocolGroup::ethertype.findProtocol(getEtherType());
+    }
+}}

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeaderSerializer.cc
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeaderSerializer.cc
@@ -1,0 +1,42 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "inet/common/packet/serializer/ChunkSerializerRegistry.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader_m.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeaderSerializer.h"
+
+namespace inet {
+namespace ieee80211 {
+
+Register_Serializer(Ieee80211EtherTypeHeader, Ieee80211EtherTypeHeaderSerializer);
+
+void Ieee80211EtherTypeHeaderSerializer::serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const
+{
+    const auto& llcHeader = CHK(dynamicPtrCast<const Ieee80211EtherTypeHeader>(chunk));
+    stream.writeUint16Be(llcHeader->getEtherType());
+}
+
+const Ptr<Chunk> Ieee80211EtherTypeHeaderSerializer::deserialize(MemoryInputStream& stream) const
+{
+    Ptr<Ieee80211EtherTypeHeader> llcHeader = makeShared<Ieee80211EtherTypeHeader>();
+    llcHeader->setEtherType(stream.readUint16Be());
+    return llcHeader;
+}
+
+} // namepsace ieee80211
+} // namespace inet
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeaderSerializer.h
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeaderSerializer.h
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_IEEE80211ETHERTYPEHEADERSERIALIZER_H
+#define __INET_IEEE80211ETHERTYPEHEADERSERIALIZER_H
+
+#include "inet/common/packet/serializer/FieldsChunkSerializer.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class INET_API Ieee80211EtherTypeHeaderSerializer : public FieldsChunkSerializer
+{
+  protected:
+    virtual void serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const override;
+    virtual const Ptr<Chunk> deserialize(MemoryInputStream& stream) const override;
+
+  public:
+    Ieee80211EtherTypeHeaderSerializer() : FieldsChunkSerializer() {}
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif // ifndef __INET_IEEE80211ETHERTYPEHEADERSERIALIZER_H
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolDissector.cc
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolDissector.cc
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "inet/common/packet/dissector/ProtocolDissectorRegistry.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader_m.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolDissector.h"
+
+namespace inet {
+namespace ieee80211 {
+
+Register_Protocol_Dissector(&Protocol::ieee80211EtherType, Ieee80211EtherTypeProtocolDissector);
+
+void Ieee80211EtherTypeProtocolDissector::dissect(Packet *packet, ICallback& callback) const
+{
+    const auto& header = packet->popAtFront<inet::Ieee80211EtherTypeHeader>();
+    callback.startProtocolDataUnit(&Protocol::ieee80211EtherType);
+    callback.visitChunk(header, &Protocol::ieee80211EtherType);
+    callback.dissectPacket(packet, header->getProtocol());
+    callback.endProtocolDataUnit(&Protocol::ieee80211EtherType);
+}
+
+} // namespace ieee80211
+} // namespace inet
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolDissector.h
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolDissector.h
@@ -1,0 +1,36 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_IEEE80211ETHERTYPEPROTOCOLDISSECTOR_H_
+#define __INET_IEEE80211ETHERTYPEPROTOCOLDISSECTOR_H_
+
+#include "inet/common/INETDefs.h"
+#include "inet/common/packet/dissector/ProtocolDissector.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class INET_API Ieee80211EtherTypeProtocolDissector : public ProtocolDissector
+{
+  public:
+    virtual void dissect(Packet *packet, ICallback& callback) const override;
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif // __INET_IEEE80211ETHERTYPEPROTOCOLDISSECTOR_H_

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolPrinter.cc
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolPrinter.cc
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolPrinter.h"
+
+#include "inet/common/packet/printer/PacketPrinter.h"
+#include "inet/common/packet/printer/ProtocolPrinterRegistry.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+Register_Protocol_Printer(&Protocol::ieee80211EtherType, Ieee80211EtherTypeProtocolPrinter);
+
+void Ieee80211EtherTypeProtocolPrinter::print(const Ptr<const Chunk>& chunk, const Protocol *protocol, const cMessagePrinter::Options *options, Context& context) const
+{
+    if (auto header = dynamicPtrCast<const Ieee80211EtherTypeHeader>(chunk))
+        context.infoColumn << "etherType: " << header->getEtherType();
+    else
+        context.infoColumn << "(IEEE 802.11 LLC)" << chunk;
+}
+
+} // namespace ieee80211
+} // namespace inet
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolPrinter.h
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211EtherTypeProtocolPrinter.h
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_IEEE80211ETHERTYPEPROTOCOLPRINTER_H
+#define __INET_IEEE80211ETHERTYPEPROTOCOLPRINTER_H
+
+#include "inet/common/INETDefs.h"
+#include "inet/common/packet/printer/ProtocolPrinter.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class INET_API Ieee80211EtherTypeProtocolPrinter : public ProtocolPrinter
+{
+  public:
+    virtual void print(const Ptr<const Chunk>& chunk, const Protocol *protocol, const cMessagePrinter::Options *options, Context& context) const override;
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif // __INET_IEEE80211ETHERTYPEPROTOCOLPRINTER_H
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211Llc.h
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211Llc.h
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_IEEE80211LLC_H
+#define __INET_IEEE80211LLC_H
+
+#include "inet/common/Protocol.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class INET_API Ieee80211Llc
+{
+  public:
+    virtual const Protocol *getProtocol() const = 0;
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif // ifndef __INET_IEEE80211LLC_H

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211Llc.ned
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211Llc.ned
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+package inet.linklayer.ieee80211.llc;
+
+moduleinterface Ieee80211Llc
+{
+    parameters:
+        @display("i=block/layer");
+    gates:
+        input upperLayerIn;
+        output upperLayerOut;
+        input lowerLayerIn;
+        output lowerLayerOut;
+}

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.cc
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.cc
@@ -1,0 +1,87 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "inet/common/ProtocolGroup.h"
+#include "inet/common/ProtocolTag_m.h"
+#include "inet/common/Simsignals.h"
+#include "inet/common/Simsignals_m.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader_m.h"
+#include "inet/linklayer/ieee80211/llc/LlcProtocolTag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+Define_Module(Ieee80211LlcEpd);
+
+void Ieee80211LlcEpd::initialize(int stage)
+{
+}
+
+void Ieee80211LlcEpd::handleMessage(cMessage *message)
+{
+    if (message->arrivedOn("upperLayerIn")) {
+        auto packet = check_and_cast<Packet *>(message);
+        encapsulate(packet);
+        send(packet, "lowerLayerOut");
+    }
+    else if (message->arrivedOn("lowerLayerIn")) {
+        auto packet = check_and_cast<Packet *>(message);
+        decapsulate(packet);
+        if (packet->getTag<PacketProtocolTag>()->getProtocol() != nullptr)
+            send(packet, "upperLayerOut");
+        else {
+            EV_WARN << "Unknown protocol, dropping packet\n";
+            PacketDropDetails details;
+            details.setReason(NO_PROTOCOL_FOUND);
+            emit(packetDroppedSignal, packet, &details);
+            delete packet;
+        }
+    }
+    else
+        throw cRuntimeError("Unknown message");
+}
+
+void Ieee80211LlcEpd::encapsulate(Packet *frame)
+{
+    const Protocol* protocol = frame->getTag<PacketProtocolTag>()->getProtocol();
+    int ethType = ProtocolGroup::ethertype.findProtocolNumber(protocol);
+    if (ethType == -1)
+        throw cRuntimeError("EtherType not found for protocol %s", protocol ? protocol->getName() : "(nullptr)");
+    const auto& llcHeader = makeShared<Ieee80211EtherTypeHeader>();
+    llcHeader->setEtherType(ethType);
+    frame->insertAtFront(llcHeader);
+    frame->addTagIfAbsent<PacketProtocolTag>()->setProtocol(&Protocol::ieee80211EtherType);
+    frame->addTagIfAbsent<LlcProtocolTag>()->setProtocol(&Protocol::ieee80211EtherType);
+}
+
+void Ieee80211LlcEpd::decapsulate(Packet *frame)
+{
+    const auto& llcHeader = frame->popAtFront<Ieee80211EtherTypeHeader>();
+    const Protocol *payloadProtocol = llcHeader->getProtocol();
+    frame->addTagIfAbsent<DispatchProtocolReq>()->setProtocol(payloadProtocol);
+    frame->addTagIfAbsent<PacketProtocolTag>()->setProtocol(payloadProtocol);
+}
+
+const Protocol *Ieee80211LlcEpd::getProtocol() const
+{
+    return &Protocol::ieee80211EtherType;
+}
+
+} // namespace ieee80211
+} // namespace inet
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.h
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.h
@@ -1,0 +1,46 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_IEEE80211LLCEPD_H
+#define __INET_IEEE80211LLCEPD_H
+
+#include "inet/common/packet/Packet.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211EtherTypeHeader_m.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211Llc.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class INET_API Ieee80211LlcEpd : public cSimpleModule, public Ieee80211Llc
+{
+  protected:
+    virtual int numInitStages() const override { return NUM_INIT_STAGES; }
+    virtual void initialize(int stage) override;
+    virtual void handleMessage(cMessage *message) override;
+
+    virtual void encapsulate(Packet *frame);
+    virtual void decapsulate(Packet *frame);
+
+  public:
+    const Protocol *getProtocol() const override;
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif // ifndef __INET_IEEE80211EPDLLC_H
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.ned
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211LlcEpd.ned
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+package inet.linklayer.ieee80211.llc;
+
+simple Ieee80211LlcEpd like Ieee80211Llc
+{
+    parameters:
+        @display("i=block/layer");
+        @signal[packetDropped](type=Packet);
+    gates:
+        input upperLayerIn;
+        output upperLayerOut;
+        input lowerLayerIn;
+        output lowerLayerOut;
+}

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.cc
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.cc
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "inet/common/ProtocolGroup.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.h"
+#include "inet/linklayer/ieee80211/llc/LlcProtocolTag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+Define_Module(Ieee80211LlcLpd);
+
+void Ieee80211LlcLpd::encapsulate(Packet *frame)
+{
+    Ieee8022Llc::encapsulate(frame);
+    frame->addTagIfAbsent<LlcProtocolTag>()->setProtocol(getProtocol());
+}
+
+const Protocol *Ieee80211LlcLpd::getProtocol() const
+{
+    return &Protocol::ieee8022;
+}
+
+} // namespace ieee80211
+} // namespace inet
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.h
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.h
@@ -1,0 +1,41 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_IEEE80211LLCLPD_H
+#define __INET_IEEE80211LLCLPD_H
+
+#include "inet/common/packet/Packet.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211Llc.h"
+#include "inet/linklayer/ieee8022/Ieee8022Llc.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class INET_API Ieee80211LlcLpd : public Ieee8022Llc, public Ieee80211Llc
+{
+  protected:
+    virtual void encapsulate(Packet *frame) override;
+
+  public:
+    const Protocol *getProtocol() const override;
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif // ifndef __INET_IEEE80211LLCLPD_H
+

--- a/src/inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.ned
+++ b/src/inet/linklayer/ieee80211/llc/Ieee80211LlcLpd.ned
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2018 Raphael Riebl, TH Ingolstadt
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+package inet.linklayer.ieee80211.llc;
+
+import inet.linklayer.ieee8022.Ieee8022Llc;
+
+simple Ieee80211LlcLpd extends Ieee8022Llc like Ieee80211Llc
+{
+    @class(Ieee80211LlcLpd);
+}

--- a/src/inet/linklayer/ieee80211/llc/LlcProtocolTag.msg
+++ b/src/inet/linklayer/ieee80211/llc/LlcProtocolTag.msg
@@ -1,0 +1,43 @@
+import inet.common.INETDefs;
+import inet.common.TagBase;
+import inet.common.Units;
+
+cplusplus {{
+#include "inet/common/Protocol.h"
+#include "inet/common/ProtocolGroup.h"
+}}
+
+namespace inet::ieee80211;
+
+//
+// LLC protocols available in IEEE 802.11
+//
+cplusplus {{
+
+static ProtocolGroup llc("llc", {
+    { 0, &Protocol::ieee8022 },
+    { 1, &Protocol::ieee80211EtherType }
+});
+
+}}
+
+enum LlcProtocolId
+{
+    LPD = 0; // IEEE 802.2 LLC header (with SNAP)
+    EPD = 1; // plain EtherType header
+}
+
+//
+// Marks the packet's LLC protocol
+// NOTE: No packet field indicates the LLC protocol, it depends on the used band!
+//
+class LlcProtocolTag extends TagBase
+{
+    int protocolId @enum(LlcProtocolId);
+}
+
+cplusplus(LlcProtocolTag) {{
+    virtual const Protocol *getProtocol() const { return llc.findProtocol(getProtocolId()); }
+    virtual void setProtocol(const Protocol *protocol) { setProtocolId(static_cast<LlcProtocolId>(protocol->getId())); }
+}}
+

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
@@ -23,6 +23,7 @@
 #include "inet/linklayer/common/InterfaceTag_m.h"
 #include "inet/linklayer/common/MacAddressTag_m.h"
 #include "inet/linklayer/common/UserPriorityTag_m.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211Llc.h"
 #include "inet/linklayer/ieee80211/mac/contract/IContention.h"
 #include "inet/linklayer/ieee80211/mac/contract/IFrameSequence.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRx.h"
@@ -65,6 +66,8 @@ void Ieee80211Mac::initialize(int stage)
     else if (stage == INITSTAGE_LINK_LAYER) {
         mib = getModuleFromPar<Ieee80211Mib>(par("mibModule"), this);
         mib->qos = par("qosStation");
+        cModule *llcModule = gate("upperLayerOut")->getNextGate()->getOwnerModule();
+        llc = check_and_cast<Ieee80211Llc *>(llcModule);
         cModule *radioModule = gate("lowerLayerOut")->getNextGate()->getOwnerModule();
         radioModule->subscribe(IRadio::radioModeChangedSignal, this);
         radioModule->subscribe(IRadio::receptionStateChangedSignal, this);
@@ -285,7 +288,7 @@ void Ieee80211Mac::decapsulate(Packet *packet)
     const auto& header = packet->popAtFront<Ieee80211DataOrMgmtHeader>();
     auto packetProtocolTag = packet->addTagIfAbsent<PacketProtocolTag>();
     if (dynamicPtrCast<const Ieee80211DataHeader>(header))
-        packetProtocolTag->setProtocol(&Protocol::ieee8022);
+        packetProtocolTag->setProtocol(llc->getProtocol());
     else if (dynamicPtrCast<const Ieee80211MgmtHeader>(header))
         packetProtocolTag->setProtocol(&Protocol::ieee80211Mgmt);
     auto macAddressInd = packet->addTagIfAbsent<MacAddressInd>();

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.h
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.h
@@ -36,6 +36,7 @@ namespace ieee80211 {
 
 class IContention;
 class IRx;
+class Ieee80211Llc;
 class Ieee80211MacHeader;
 
 /**
@@ -49,6 +50,7 @@ class INET_API Ieee80211Mac : public MacProtocolBase
     FcsMode fcsMode;
 
     Ieee80211Mib *mib = nullptr;
+    Ieee80211Llc *llc = nullptr;
     IDs *ds = nullptr;
 
     IRx *rx = nullptr;

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
@@ -16,7 +16,6 @@
 //
 
 #include "inet/common/ModuleAccess.h"
-#include "inet/linklayer/ieee8022/Ieee8022LlcHeader_m.h"
 #include "inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/DcfFs.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -16,7 +16,6 @@
 //
 
 #include "inet/common/ModuleAccess.h"
-#include "inet/linklayer/ieee8022/Ieee8022LlcHeader_m.h"
 #include "inet/linklayer/ieee80211/mac/blockack/OriginatorBlockAckAgreementHandler.h"
 #include "inet/linklayer/ieee80211/mac/blockack/OriginatorBlockAckProcedure.h"
 #include "inet/linklayer/ieee80211/mac/blockack/RecipientBlockAckAgreementHandler.h"

--- a/src/inet/linklayer/ieee80211/portal/Ieee80211Portal.h
+++ b/src/inet/linklayer/ieee80211/portal/Ieee80211Portal.h
@@ -18,14 +18,16 @@
 #ifndef __INET_IEEE80211PORTAL_H
 #define __INET_IEEE80211PORTAL_H
 
+#include "inet/common/Protocol.h"
 #include "inet/common/packet/Packet.h"
 #include "inet/linklayer/common/FcsMode_m.h"
+#include "inet/linklayer/ieee80211/llc/Ieee80211Llc.h"
 
 namespace inet {
 
 namespace ieee80211 {
 
-class INET_API Ieee80211Portal : public cSimpleModule
+class INET_API Ieee80211Portal : public cSimpleModule, public Ieee80211Llc
 {
   protected:
     FcsMode fcsMode = FCS_MODE_UNDEFINED;
@@ -38,6 +40,9 @@ class INET_API Ieee80211Portal : public cSimpleModule
 
     virtual void encapsulate(Packet *packet);
     virtual void decapsulate(Packet *packet);
+
+  public:
+    const Protocol *getProtocol() const override { return &Protocol::ieee8022; }
 };
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/portal/Ieee80211Portal.ned
+++ b/src/inet/linklayer/ieee80211/portal/Ieee80211Portal.ned
@@ -17,9 +17,10 @@
 
 package inet.linklayer.ieee80211.portal;
 
+import inet.linklayer.ieee80211.llc.Ieee80211Llc;
 import inet.linklayer.ieee8022.IIeee8022Llc;
 
-simple Ieee80211Portal like IIeee8022Llc
+simple Ieee80211Portal like IIeee8022Llc, Ieee80211Llc
 {
     parameters:
         string fcsMode @enum("declared", "computed") = default("declared");


### PR DESCRIPTION
According to E.2.3/E.2.4 of IEEE 802.11-2016, stations in the 5.9 GHz band have to use "EtherType Protocol Discrimination" (EPD) instead of IEEE 802.2 (LPD) commonly used for other bands. Unfortunately, there is no packet field to differentiate them so a `LlcProtocolTag` is added to each packet for dissecting both variants seamlessly. If this tag is missing and there is no information available about the employed band, it falls back to IEEE 802.2.