### PR TITLE
ipv4config: reserving all host ids inside a network

### DIFF
--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
@@ -530,6 +530,7 @@ void Ipv4NetworkConfigurator::assignAddresses(Topology& topology)
                     if(itt == assignedAddressToInterfaceEntryMap.end()) {
                         assignedAddressToInterfaceEntryMap[completeAddress] = nullptr;
                         assignedInterfaceAddresses.push_back(completeAddress);
+                        EV_DEBUG << "reserving Ipv4 address " << Ipv4Address(completeAddress) << ".\n";
                     }
                 }
             }

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
@@ -68,6 +68,7 @@ void Ipv4NetworkConfigurator::initialize(int stage)
     if (stage == INITSTAGE_LOCAL) {
         assignAddressesParameter = par("assignAddresses");
         assignDisjunctSubnetAddressesParameter = par("assignDisjunctSubnetAddresses");
+        useStrictDisjunctSubnetAddressParameter = par("useStrictDisjunctSubnetAddress");
         addStaticRoutesParameter = par("addStaticRoutes");
         addSubnetRoutesParameter = par("addSubnetRoutes");
         addDefaultRoutesParameter = par("addDefaultRoutes");
@@ -520,6 +521,17 @@ void Ipv4NetworkConfigurator::assignAddresses(Topology& topology)
 
                 // remove configured interface
                 unconfiguredInterfaces.erase(find(unconfiguredInterfaces, compatibleInterface));
+            }
+
+            if(assignDisjunctSubnetAddressesParameter && useStrictDisjunctSubnetAddressParameter) {
+                for(int n = 1; n < (1 << (32-netmaskLength))-1; n++) {
+                    uint32 completeAddress = networkAddress + n;
+                    auto itt = assignedAddressToInterfaceEntryMap.find(completeAddress);
+                    if(itt == assignedAddressToInterfaceEntryMap.end()) {
+                        assignedAddressToInterfaceEntryMap[completeAddress] = nullptr;
+                        assignedInterfaceAddresses.push_back(completeAddress);
+                    }
+                }
             }
 
             // register the network address and netmask as being used

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h
@@ -124,6 +124,7 @@ class INET_API Ipv4NetworkConfigurator : public NetworkConfiguratorBase
     // parameters
     bool assignAddressesParameter = false;
     bool assignDisjunctSubnetAddressesParameter = false;
+    bool useStrictDisjunctSubnetAddressParameter = false;
     bool addStaticRoutesParameter = false;
     bool addSubnetRoutesParameter = false;
     bool addDefaultRoutesParameter = false;

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.ned
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.ned
@@ -416,6 +416,7 @@ simple Ipv4NetworkConfigurator extends NetworkConfiguratorBase
         xml config = default(xml("<config><interface hosts='**' address='10.x.x.x' netmask='255.x.x.x'/></config>")); // XML configuration parameters for IP address assignment and adding manual routes
         bool assignAddresses = default(true); // assign IP addresses to all interfaces in the network
         bool assignDisjunctSubnetAddresses = default(true); // avoid using the same address prefix and netmask on different links when assigning IP addresses to interfaces
+        bool useStrictDisjunctSubnetAddress = default(false); // reserve all host bits in a network (used only if assignDisjunctSubnetAddresses is true)
         bool addStaticRoutes = default(true);  // add static routes to the routing tables of all nodes to route to all destination interfaces (only where applicable; turn off when config file contains manual routes)
         bool addDefaultRoutes = default(true); // add default routes if all routes from a source node go through the same gateway (used only if addStaticRoutes is true)
         bool addSubnetRoutes = default(true);  // add subnet routes instead of destination interface routes (only where applicable; used only if addStaticRoutes is true)


### PR DESCRIPTION
**Issue 1:** 

Consider the following network:

```
network sampleNetwork
{
    @display("bgb=1915.2001,741.60004");

    types:
        channel PppLink100M extends DatarateChannel
        {
            delay = 5us;
            datarate = 100Mbps;
        }

        channel PppLink10M extends DatarateChannel
        {
            delay = 5us;
            datarate = 10Mbps;
        }

    submodules:
        configurator: Ipv4NetworkConfigurator {
            @display("p=160.35374,123.55125");
        }
        visualizer: IntegratedCanvasVisualizer {
            @display("p=425.85748,123.55125");
        }
        scenarioManager: ScenarioManager {
            @display("p=712.39124,123.55125");
        }
        R2: Router {
            @display("p=959.4937,573.0675");
        }
        switch3: EtherSwitch {
            @display("p=160.35374,570.4387");
        }
        R4: Router {
            @display("p=410.085,573.0675");
        }
        R3: Router {
            @display("p=709.7625,573.0675");
        }

        switch2: EtherSwitch {
            @display("p=1264.4287,570.4387");
        }
        switch5: EtherSwitch {
            @display("p=709.7625,378.54");
        }
        R1: Router {
            @display("p=1519.4175,573.0675");
        }
        switch4: EtherSwitch {
            @display("p=959.4937,378.54");
        }
        switch1: EtherSwitch {
            @display("p=1782.2925,567.81");
        }
        R5: Router {
            @display("p=1264.1412,379.0025");
        }
    connections:
        R2.pppg++ <--> PppLink100M <--> R3.pppg++;
        R3.pppg++ <--> PppLink100M <--> R4.pppg++;
        R4.ethg++ <--> Eth100M <--> switch3.ethg++;
        R3.ethg++ <--> Eth100M <--> switch5.ethg++;
        R2.ethg++ <--> Eth100M <--> switch2.ethg++;
        R1.ethg++ <--> Eth100M <--> switch2.ethg++;
        switch4.ethg++ <--> Eth100M <--> R2.ethg++;
        switch1.ethg++ <--> Eth100M <--> R1.ethg++;
        switch2.ethg++ <--> Eth100M <--> R5.ethg++;
}
```
With following configuration:

```
[Config Step9]
description = "sample example"
network = sampleNetwork

*.configurator.addStaticRoutes = false

# Enable OSPF on all routers
*.R*.hasOspf = true

# Visualizer settings
*.visualizer.interfaceTableVisualizer.displayInterfaceTables = true
```
The static IPv4 assigned to subnets are overlapping:

![2018-08-17_23-26-24](https://user-images.githubusercontent.com/5473998/44296512-6c7ffa80-a275-11e8-92da-8049ae273945.png)

The LAN formed by switch2 is assigned network id of 10.0.0.8/29 that covers IP addresses of 10.0.0.9 to 10.0.0.15 (broadcast). This range overlaps with the network 10.0.0.12/30 assigned to interface eth1 of router R2 that covers 10.0.0.13 to 10.0.0.15 (broadcast). This is not wrong, but can be problematic in some scenarios (please check motivation section). 

If I add a host into the 10.0.0.8/29 network, then eth1 interface of R2 is assigned address of 10.0.0.17/30. 

![2018-08-18_9-35-54](https://user-images.githubusercontent.com/5473998/44301372-4c2e5b00-a2ca-11e8-88c3-0a2e4609e471.png)

The user might need to reserve all host ids inside a network even though there are not enough interfaces inside that network. For example if host id is 3 bits, then we can assign IPv4 addresses to maximum of 2^3-2=6. Now if there is only 3 interfaces on that network, we assign IPv4 address to those three interfaces, but I want to reserve the remaining three addresses. In other words, I want to instruct the IPv4configurator to assume that those three addresses are also taken and it should not use them in other neighboring networks.

**Motivation:** 

I noticed that OSPF does not add a newly-discovered remote route into the routing table because the new route overlaps with an existing route in the routing table that has IPv4 overlap. Because of these lines:

https://github.com/inet-framework/inet/blob/a817ccda8db4c89c14f1a3d04b9c36c8926cd831/src/inet/routing/ospfv2/router/OspfArea.cc#L1746

More specifically, the newly-discovered route is 10.0.0.12/30, but there exist route 10.0.0.8/29 in the routing table. Since 10.0.0.12/30 overlaps with the existing route, OSPF will not add it, which is wrong!

This PL adds the feature to the ipv4 configurator using the `useStrictDisjunctSubnetAddressParameter ` parameter. For example, consider the following example, consisting of a subnet of 4 nodes. Subnet mask is /29 thus 6 IPv4 addresses can be assigned in total. 4 of them are assigned to the existing interfaces and since `useStrictDisjunctSubnetAddressParameter` is true, the two remaining IPv4 addresses are reserved.

![2018-08-20_9-09-10](https://user-images.githubusercontent.com/5473998/44365293-3b264b00-a47e-11e8-97ba-5d871371ae20.png)

Here are a few simulation scenarios to test the new parameter:

https://github.com/ManiAm/inet/tree/INETex/examples_INETex/ipv4configurator

**Issue 2:** 

the interface eth1 of router R2 should be assigned an IPv4 address of the form x.x.x.x/32 because that is the only interface on that network. I guess the ipv4configurator thinks that switch4 is also part of the network and hence uses /30 as network mask, but switch is transparent to IP.
