### PR TITLE
Ipv4config: isolated networks can be configured separately

### DIFF
--- a/src/inet/common/Topology.cc
+++ b/src/inet/common/Topology.cc
@@ -197,12 +197,15 @@ void Topology::extractFromNetwork(bool (*predicate)(cModule *, void *), void *da
 {
     clear();
 
+    int groupCounter = 0;
+
     // Loop through all modules and find those that satisfy the criteria
     for (int modId = 0; modId <= getSimulation()->getLastComponentId(); modId++)
     {
         cModule *module = getSimulation()->getModule(modId);
         if (module && predicate(module, data)) {
             Node *node = createNode(module);
+            node->setGroupId(++groupCounter);
             nodes.push_back(node);
         }
     }
@@ -245,6 +248,9 @@ void Topology::extractFromNetwork(bool (*predicate)(cModule *, void *), void *da
             link->destNode->inLinks.push_back(link);
         }
     }
+
+    for(auto & elem : nodes)
+        findGroups(elem);
 }
 
 int Topology::addNode(Node *node)
@@ -463,6 +469,39 @@ void Topology::calculateWeightedSingleShortestPathsTo(Node *_target)
                         break;
 
                 q.insert(it, src);
+            }
+        }
+    }
+}
+
+void Topology::findGroups(Node *node)
+{
+    if(node->isVisited())
+        return;
+
+    cModule *mod = getSimulation()->getModule(node->moduleId);
+    if(!mod)
+        return;
+
+    for (cModule::GateIterator i(mod); !i.end(); i++) {
+        cGate *gate = *i;
+        if (gate->getType() != cGate::OUTPUT)
+            continue;
+
+        // follow path
+        do {
+            gate = gate->getNextGate();
+        } while (gate && !gate->getOwnerModule());
+
+        // if we arrived at a module in the topology, record it.
+        if (gate) {
+            node->setVisit(true);
+            Node *nextNode = getNodeFor(gate->getOwnerModule());
+            if(nextNode) {
+                if(!nextNode->isVisited()) {
+                    nextNode->setGroupId(node->getGroupId());
+                    findGroups(nextNode);
+                }
             }
         }
     }

--- a/src/inet/common/Topology.h
+++ b/src/inet/common/Topology.h
@@ -75,6 +75,8 @@ class INET_API Topology : public cOwnedObject
         int moduleId;
         double weight;
         bool enabled;
+        bool visited;
+        int groupId;
         std::vector<Link *> inLinks;
         std::vector<Link *> outLinks;
 
@@ -86,7 +88,15 @@ class INET_API Topology : public cOwnedObject
         /**
          * Constructor
          */
-        Node(int moduleId = -1) { this->moduleId = moduleId; weight = 0; enabled = true; dist = INFINITY; outPath = nullptr; }
+        Node(int moduleId = -1) {
+            this->moduleId = moduleId;
+            weight = 0;
+            enabled = true;
+            visited = false;
+            groupId = 0;
+            dist = INFINITY;
+            outPath = nullptr;
+        }
         virtual ~Node() {}
 
         /** @name Node attributes: weight, enabled state, correspondence to modules. */
@@ -113,6 +123,28 @@ class INET_API Topology : public cOwnedObject
          * weighted shortest path finder methods of Topology.
          */
         void setWeight(double d) { weight = d; }
+
+        /**
+         * Returns the ID of the network to which this node corresponds.
+         * All nodes that belong to a connected network have the same group id.
+         */
+        double getGroupId() const { return groupId; }
+
+        /**
+         * Sets the ID of the network to which this node corresponds.
+         * All nodes that belong to a connected network have the same group id.
+         */
+        void setGroupId(int g) { groupId = g; }
+
+        /**
+         * Returns true if the node has been visited before in the group find traversal
+         */
+        bool isVisited() const { return visited; }
+
+        /**
+         * mark this node as visited or not visited in the group traversal
+         */
+        void setVisit(bool v) { visited = v; }
 
         /**
          * Returns true of this node is enabled. This has significance
@@ -339,6 +371,7 @@ class INET_API Topology : public cOwnedObject
 
     void unlinkFromSourceNode(Link *link);
     void unlinkFromDestNode(Link *link);
+    void findGroups(Node *);
 
   public:
     /** @name Constructors, destructor, assignment */

--- a/src/inet/networklayer/configurator/base/NetworkConfiguratorBase.h
+++ b/src/inet/networklayer/configurator/base/NetworkConfiguratorBase.h
@@ -103,6 +103,7 @@ class INET_API NetworkConfiguratorBase : public cSimpleModule, public L3AddressR
       public:
         std::vector<InterfaceInfo *> interfaceInfos;    // interfaces on that LAN or point-to-point link
         InterfaceInfo *gatewayInterfaceInfo = nullptr;    // non-NULL if all hosts have 1 non-loopback interface except one host that has two of them (this will be the gateway)
+        int groupId = 0;
 
       public:
         LinkInfo() { }
@@ -157,6 +158,7 @@ class INET_API NetworkConfiguratorBase : public cSimpleModule, public L3AddressR
   protected:
     // parameters
     double minLinkWeight = NaN;
+    bool configureEachGroupSeparatly = false;
     cXMLElement *configuration = nullptr;
 
   protected:

--- a/src/inet/networklayer/configurator/base/NetworkConfiguratorBase.ned
+++ b/src/inet/networklayer/configurator/base/NetworkConfiguratorBase.ned
@@ -23,4 +23,5 @@ simple NetworkConfiguratorBase like INetworkConfigurator
 {
     parameters:
         double minLinkWeight = default(1E-3);
+        bool configureEachGroupSeparatly = default(false);
 }

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
@@ -403,8 +403,13 @@ void Ipv4NetworkConfigurator::assignAddresses(Topology& topology)
             }
         }
 
-        for(auto group : networkGroups)
+        int groupCount = 1;
+        for(auto group : networkGroups) {
+            EV_DEBUG << "--> configuring group " << groupCount << ". \n";
             assignAddressesPerGroup(group.second);
+            EV_DEBUG << "<-- configuring group " << groupCount << ". \n";
+            groupCount++;
+        }
     }
     else {
         assignAddressesPerGroup(topology.linkInfos);

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h
@@ -229,6 +229,7 @@ class INET_API Ipv4NetworkConfigurator : public NetworkConfiguratorBase
     virtual InterfaceInfo *findInterfaceOnLinkByNodeAddress(LinkInfo *linkInfo, Ipv4Address address);
     virtual LinkInfo *findLinkOfInterface(Topology& topology, InterfaceEntry *interfaceEntry);
     virtual IRoutingTable *findRoutingTable(NetworkConfiguratorBase::Node *node) override;
+    void assignAddressesPerGroup(std::vector<LinkInfo *> links);
 
     // helpers for address assignment
     static bool compareInterfaceInfos(InterfaceInfo *i, InterfaceInfo *j);


### PR DESCRIPTION
IPv4 configurator builds a topology from the network and uses that topology to assign IPv4 addresses to each interface. Imagine the following scenario that consists of two isolated networks: These two networks are completely detached from each other, but the topology class detect it as a single big network. This means that the IPv4 addresses assigned to the second isolated network (on the bottom) will be the continuation of the first network (on the top).

![2018-08-19_22-30-41](https://user-images.githubusercontent.com/5473998/44322032-2f943f00-a400-11e8-8c8e-e7c5972e4bd1.png)

In some scenarios, the user wants to treat these two networks isolated and expects the IPv4 addresses to be completely independent from each other. This commit adds a new parameter to the IP configurator called `configureEachGroupSeparatly`. If it is set to true, then the IPv4 addresses are assigned like the following:

![2018-08-19_22-31-29](https://user-images.githubusercontent.com/5473998/44322086-8ac63180-a400-11e8-8970-144200ae20ed.png)

The topology class can now detect the number of network groups and pass this information to the IPv4 configurator so that it treats each group independently. 

![2018-08-19_22-38-42](https://user-images.githubusercontent.com/5473998/44322141-c3660b00-a400-11e8-988f-1cf626655a34.png)

You can find the above example in `Step9` of the following:

https://github.com/ManiAm/inet/blob/INETex/examples_INETex/routing_protocol_ospf/omnetpp.ini

If the network is like the following:

![2018-08-19_22-43-22](https://user-images.githubusercontent.com/5473998/44322271-6b7bd400-a401-11e8-930c-9ab91f52ca93.png)

Then it says:

![2018-08-19_22-43-51](https://user-images.githubusercontent.com/5473998/44322274-7171b500-a401-11e8-8e2d-4ac3b1fe9629.png)

In this case setting `configureEachGroupSeparatly` to true does not have any effects because there is only one group in the scenario. Also note that this approach works in a mixed wired-wireless scenarios and it only considers the groups in wired portion of the network.

**Update:** well, you can use a better name than `group` that one might misinterpret for IP multicast group! `NumDisjointNetworks` can be another suggestion.