### PR TITLE
improve implementation of TwoRayInterference path loss

### DIFF
--- a/src/inet/physicallayer/pathloss/TwoRayInterference.cc
+++ b/src/inet/physicallayer/pathloss/TwoRayInterference.cc
@@ -6,8 +6,17 @@ namespace physicallayer {
 
 Define_Module(TwoRayInterference);
 
+// shortcut for squaring numbers (should be faster than pow(x, 2.0))
+namespace { constexpr double squared(double x) { return x * x; } }
+
+/**
+ * Literature referenced here:
+ * Rappaport, Theodore: Wireless Communications - Principles and Practice, 2nd edition, 2002
+ * Jakes, William C.: "Microwave Mobile Communications", 1974
+ */
+
 TwoRayInterference::TwoRayInterference() :
-    epsilon_r(1.0)
+    epsilon_r(1.0), polarization('h')
 {
 }
 
@@ -15,6 +24,14 @@ void TwoRayInterference::initialize(int stage)
 {
     if (stage == INITSTAGE_LOCAL) {
         epsilon_r = par("epsilon_r");
+        const std::string polarization_str = par("polarization");
+        if (polarization_str == "horizontal") {
+            polarization = 'h';
+        } else if (polarization_str == "vertical") {
+            polarization = 'v';
+        } else {
+            throw cRuntimeError("Invalid antenna polarization %s", polarization_str.c_str());
+        }
     }
 }
 
@@ -22,7 +39,7 @@ std::ostream& TwoRayInterference::printToStream(std::ostream& os, int level) con
 {
     os << "TwoRayInterference";
     if (level >= PRINT_LEVEL_TRACE)
-        os << ", epsilon_r = " << epsilon_r;
+        os << ", epsilon_r = " << epsilon_r << ", polarization = " << polarization;
     return os;
 }
 
@@ -39,21 +56,43 @@ double TwoRayInterference::computePathLoss(const ITransmission* transmission, co
 
 double TwoRayInterference::computeTwoRayInterference(const Coord& pos_t, const Coord& pos_r, m lambda) const
 {
-    const m distance { pos_r.distance(pos_t) };
-    const m h_sum { pos_t.z + pos_r.z };
-    const m h_dif { pos_t.z - pos_r.z };
-    const m d_los = sqrt(distance * distance + h_dif * h_dif);
-    const m d_ref = sqrt(distance * distance + h_sum * h_sum);
+    const double h_sum = pos_t.z + pos_r.z;
+    const double h_diff = pos_t.z - pos_r.z;
 
-    const double phi = 2 * M_PI * unit((d_los - d_ref) / lambda).get();
-    const double sin_theta = unit(h_sum / d_ref).get();
-    const double cos_theta = unit(distance / d_ref).get();
-    const double gamma = sqrt(epsilon_r - cos_theta * cos_theta);
-    const double Gamma = (sin_theta - gamma) / (sin_theta + gamma);
+    // direct line of sight between Tx and Rx antenna
+    const double d_los = pos_r.distance(pos_t);
+    // distance on flat ground between Tx and Rx
+    const double d_grnd = sqrt(squared(d_los) - squared(h_diff));
+    // length of reflection path between antennas
+    const double d_refl = sqrt(squared(d_grnd) + squared(h_sum));
 
-    const double space = 4 * M_PI * unit(distance / lambda).get();
-    const double rays = sqrt(pow(1 + Gamma * cos(phi), 2) + Gamma * Gamma * pow(sin(phi), 2));
-    return pow(space / rays, -2);
+    // phi is phase difference of LOS and reflected signal
+    const double phi = 2.0 * M_PI * (d_refl - d_los) / lambda.get();
+    // theta is the angle between reflected ray and ground (angle of incidence)
+    const double sin_theta = h_sum / d_refl;
+    const double cos_theta = d_grnd / d_refl;
+    // reflection coefficient depending on polarization and relative permittivity (epsilon_r)
+    const double Gamma = reflectionCoefficient(cos_theta, sin_theta);
+
+    /*
+     * Original equation from Jakes (eq 2.1-2) adapted to our variable names:
+     *
+     * P_r = P_t * G_t * G_r * (lambda / (4*pi*d_los))^2 * |1 + Gamma * e^(i phi)|^2
+     *
+     * Notes:
+     * - return value by IPathLoss equals P_r / (P_t * G_t * G_r)
+     * - (lambda / (4*pi*d_los))^2 is the free space path loss (part of Friis equation)
+     * - squared absolute value term could be named "interference term"
+     *   - "1" accounts for direct wave (LOS)
+     *   - "Gamma * e^(i phi)" accounts for ground reflected wave
+     *
+     * |1 + Gamma * e^(i phi)|^2 = (applying Euler's formula)
+     * (1 + Gamma * cos(phi))^2 - Gamma^2 * sin(phi)^2
+     */
+
+    const double friis_term = squared(lambda.get() / (4.0 * M_PI * d_los));
+    const double interference_term = squared(1.0 + Gamma * cos(phi)) + squared(Gamma * sin(phi));
+    return friis_term * interference_term;
 }
 
 double TwoRayInterference::computePathLoss(mps propagationSpeed, Hz frequency, m distance) const
@@ -64,6 +103,27 @@ double TwoRayInterference::computePathLoss(mps propagationSpeed, Hz frequency, m
 m TwoRayInterference::computeRange(mps propagationSpeed, Hz frequency, double loss) const
 {
     return m(NaN);
+}
+
+double TwoRayInterference::reflectionCoefficient(double cos_theta, double sin_theta) const
+{
+    double Gamma = 0.0;
+    // sqrt_term is named "z" by Jakes (eq 2.1-3)
+    const double sqrt_term = sqrt(epsilon_r - squared(cos_theta));
+    switch (polarization)
+    {
+        case 'h':
+            // equation 4.25 in Rappaport (Gamma orthogonal)
+            Gamma = (sin_theta - sqrt_term) / (sin_theta + sqrt_term);
+            break;
+        case 'v':
+            // equation 4.24 in Rappaport (Gamma parallel)
+            Gamma = (-epsilon_r * sin_theta + sqrt_term) / (epsilon_r * sin_theta + sqrt_term);
+            break;
+        default:
+            throw cRuntimeError("Unknown polarization");
+    }
+    return Gamma;
 }
 
 } // namespace physicallayer

--- a/src/inet/physicallayer/pathloss/TwoRayInterference.h
+++ b/src/inet/physicallayer/pathloss/TwoRayInterference.h
@@ -26,9 +26,11 @@ public:
 
 protected:
     double epsilon_r;
+    char polarization;
 
 protected:
     virtual double computeTwoRayInterference(const Coord& posTx, const Coord& posRx, m waveLength) const;
+    virtual double reflectionCoefficient(double cos_theta, double sin_theta) const;
 };
 
 } // namespace physicallayer

--- a/src/inet/physicallayer/pathloss/TwoRayInterference.ned
+++ b/src/inet/physicallayer/pathloss/TwoRayInterference.ned
@@ -25,5 +25,6 @@ module TwoRayInterference like IPathLoss
         @class(TwoRayInterference);
         @display("i=block/control");
         double epsilon_r = default(1.02);
+        string polarization = default("horizontal");
 }
 


### PR DESCRIPTION
I have revisited my initial port (from Veins to INET) of the TwoRayInterference path loss model. It can handle now vertical as well as horizontal antenna polarization. Furthermore, I believe it is far more readable now due to restructured code and a lot more comments.