### PR TITLE
Specifying join/leave time to/from a multicast group

### DIFF
--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
@@ -88,16 +88,16 @@ void Ipv4NetworkConfigurator::handleMessage(cMessage *msg)
             ASSERT(joinContextPtr);
             if(joinContextPtr->interfaceData)
                 joinContextPtr->interfaceData->joinMulticastGroup(joinContextPtr->multicastGroup);
-            free(joinContextPtr);
-            cancelEvent(msg);
+            delete(joinContextPtr);
+            cancelAndDelete(msg);
         }
         else if(msg->getKind() == MCAST_LEAVE_TIMER) {
             InterfaceInfo::contextPtr_t *leaveContextPtr = (InterfaceInfo::contextPtr_t *)msg->getContextPointer();
             ASSERT(leaveContextPtr);
             if(leaveContextPtr->interfaceData)
                 leaveContextPtr->interfaceData->leaveMulticastGroup(leaveContextPtr->multicastGroup);
-            free(leaveContextPtr);
-            cancelEvent(msg);
+            delete(leaveContextPtr);
+            cancelAndDelete(msg);
         }
         else
             throw cRuntimeError("unsupported self message in Ipv4NetworkConfigurator.");

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
@@ -991,6 +991,9 @@ void Ipv4NetworkConfigurator::readMulticastGroupConfiguration(Topology& topology
                 leaveTime = std::stod (leaveTimeAttr, &sz);
             }
 
+            if(leaveTime != 0 && leaveTime <= joinTime)
+                throw cRuntimeError("The 'leaveTime' from multicast address %s should be after 'joinTime' at %s", addressAttr, multicastGroupElement->getSourceLocation());
+
             for (auto & linkInfo : topology.linkInfos) {
                 for (size_t k = 0; k < linkInfo->interfaceInfos.size(); k++) {
                     InterfaceInfo *interfaceInfo = static_cast<InterfaceInfo *>(linkInfo->interfaceInfos[k]);

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h
@@ -73,7 +73,20 @@ class INET_API Ipv4NetworkConfigurator : public NetworkConfiguratorBase
         uint32 addressSpecifiedBits;    // 1 means the bit is specified, 0 means the bit is unspecified
         uint32 netmask;    // the bits
         uint32 netmaskSpecifiedBits;    // 1 means the bit is specified, 0 means the bit is unspecified
-        std::vector<Ipv4Address> multicastGroups;
+        struct multicastGroupTuple_t {
+            Ipv4Address multicastGroup;
+            simtime_t joinTime;
+            simtime_t leaveTime;
+        };
+        std::vector<multicastGroupTuple_t> multicastGroups;
+        struct contextPtr_t {
+            Ipv4InterfaceData *interfaceData;
+            Ipv4Address multicastGroup;
+            contextPtr_t(Ipv4InterfaceData *interfaceData, Ipv4Address multicastGroup) {
+                this->interfaceData = interfaceData;
+                this->multicastGroup = multicastGroup;
+            }
+        };
 
       public:
         InterfaceInfo(Node *node, LinkInfo *linkInfo, InterfaceEntry *interfaceEntry);
@@ -133,6 +146,11 @@ class INET_API Ipv4NetworkConfigurator : public NetworkConfiguratorBase
     // internal state
     Topology topology;
 
+    enum Ipv4NetworkConfiguratorTimerKind {
+        MCAST_JOIN_TIMER,
+        MCAST_LEAVE_TIMER
+    };
+
   public:
     /**
      * Computes the Ipv4 network configuration for all nodes in the network.
@@ -162,7 +180,7 @@ class INET_API Ipv4NetworkConfigurator : public NetworkConfiguratorBase
 
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
-    virtual void handleMessage(cMessage *msg) override { throw cRuntimeError("this module doesn't handle messages, it runs only in initialize()"); }
+    virtual void handleMessage(cMessage *msg) override;
     virtual void initialize(int stage) override;
 
     /**

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.ned
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.ned
@@ -283,6 +283,14 @@ import inet.networklayer.configurator.base.NetworkConfiguratorBase;
 //      of multicast addresses.
 //      e.g. "224.0.0.1 224.0.1.33"
 //
+//    - @joinTime
+//      Optional selector attribute that specifies the join time.
+//      If missing, the joinTime is zero by default.
+//
+//    - @leaveTime
+//      Optional selector attribute that specifies the leave time.
+//      If missing, the leaveTime is infinity by default.
+//
 //  - <route>
 //    The route element provides routing table entries for multiple nodes
 //    in the network. The selector attributes limit the scope where the route


### PR DESCRIPTION
The Ipv4NetworkConfigurator is not only responsible for assigning IPv4 addresses to network interfaces, but also assigns multicast address. However, the current implementation only supports joining to a multicast address at the beginning of the simulation. 

In general, a node can join a multicast address at time t1 and leave the same multicast address at time t2. This PL adds two new parameters to the Ipv4NetworkConfigurator module. `joinTime` and `leaveTime`. The user can use these two parameters to specify when a node should join or leave a group. 

[Config Step5] shows an example:

https://github.com/ManiAm/inet/blob/INETex/examples_INETex/multicasting/omnetpp.ini

```
*.configurator.config = xml("<config> \
			<interface among='host* R0' address='10.x.x.x' netmask='255.x.x.x'/> \
			<interface hosts='**' address='x.x.x.x' netmask='255.x.x.x'/> \
  			<multicast-group hosts='host0' address='224.0.1.1' joinTime='5' leaveTime='20' /> \
  			<multicast-group hosts='host2' address='224.0.1.2' joinTime='12' leaveTime='25' /> \
       </config>")
```

Note that existing INET examples that use the multicast-group will not get affected. Because if joinTime is not specified, then 0s is assumed (node joins the group at the beginning of the simulation) and if leaveTime is not specified, then infinity is assumed (node never leaves the multicast group).

**Edit:** It is obvious that the leaveTime should always be after the joinTime. In the above configuration, one can set leaveTime before the joinTime. We get the following cryptic error:

![2018-11-24_22-14-26](https://user-images.githubusercontent.com/5473998/48976152-9431ec00-f036-11e8-98c9-51fd2e246a47.png)

Calling groupLeave on an interface when that interface has not joined to that group, should show a more meaningful error. In general, it is not the job of the Ipv4NetworkConfigurator to handle this though.

Update: I finally fix my local master. No more garbage commits.
