### PR TITLE
Broadcast

### DIFF
--- a/examples/inet/broadcast/omnetpp.ini
+++ b/examples/inet/broadcast/omnetpp.ini
@@ -17,3 +17,5 @@ network = inet.examples.inet.broadcast.UDPBroadcastNetwork
 **.nonTarget.numApps = 1
 **.nonTarget.app[0].typename = "UdpSink"
 **.nonTarget.app[0].localPort = 1000
+
+*.R2.ipv4.ip.directBroadcast = "eth0"

--- a/src/inet/networklayer/ipv4/Ipv4.h
+++ b/src/inet/networklayer/ipv4/Ipv4.h
@@ -86,8 +86,11 @@ class INET_API Ipv4 : public QueueBase, public NetfilterBase, public ILifecycle,
     int defaultTimeToLive = -1;
     int defaultMCTimeToLive = -1;
     simtime_t fragmentTimeoutTime;
-    bool forceBroadcast = false;
+    bool limitedBroadcast = false;
+    std::string directBroadcast = "";
     bool useProxyARP = false;
+
+    cPatternMatcher interfaceMatcher;
 
     // working vars
     bool isUp = false;

--- a/src/inet/networklayer/ipv4/Ipv4.ned
+++ b/src/inet/networklayer/ipv4/Ipv4.ned
@@ -100,7 +100,8 @@ simple Ipv4 like IIpv4
         int timeToLive = default(32);
         int multicastTimeToLive = default(32);
         double fragmentTimeout @unit(s) = default(60s);
-        bool forceBroadcast = default(false);
+        bool limitedBroadcast = default(false); // send out limited broadcast packets comming from higher layer
+        string directBroadcast = default("");   // list of interfaces that direct broadcast is enabled (by default direct broadcast is disabled on all interfaces)
         bool useProxyARP = default(true);
         @display("i=block/routing");
         @signal[packetSentToUpper](type=cPacket);


### PR DESCRIPTION
We can now selectively enable/disable direct broadcast on each interface. By default, direct broadcast is off on all interfaces due to security reasons (similar to almost all implementations). This PR does not affect the existing fingerprints except `examples/inet/broadcast` that is also updated in this PL.

For a full example, you can refer to the following:

https://github.com/ManiAm/inet/blob/INETex3/examples_INETex/multicasting/omnetpp.ini

