### PR TITLE
Add signal arrival time to the incoming packets

### DIFF
--- a/src/inet/physicallayer/base/packetlevel/ReceiverBase.cc
+++ b/src/inet/physicallayer/base/packetlevel/ReceiverBase.cc
@@ -93,6 +93,8 @@ const IReceptionResult *ReceiverBase::computeReceptionResult(const IListening *l
     auto snirInd = packet->addTagIfAbsent<SnirInd>();
     snirInd->setMinimumSnir(snir->getMin());
     snirInd->setMaximumSnir(snir->getMax());
+    auto signalTimeInd = packet->addTagIfAbsent<SignalTimeInd>();
+    signalTimeInd->setArrivalTime(reception->getStartTime());
     return new ReceptionResult(reception, decisions, packet);
 }
 

--- a/src/inet/physicallayer/common/packetlevel/SignalTag.msg
+++ b/src/inet/physicallayer/common/packetlevel/SignalTag.msg
@@ -115,3 +115,12 @@ class ErrorRateInd extends SignalTagBase
     double bitErrorRate = NaN;    // bit error rate (probability) in the range [0, 1] or NaN if unknown.
     double symbolErrorRate = NaN; // symbol error rate (probability) in the range [0, 1] or NaN if unknown.
 }
+
+//
+// This indication specifies the timing of the received signal.
+// It may be present on a packet from the phyiscal layer to the application.
+//
+class SignalTimeInd extends SignalTagBase
+{
+    simtime_t arrivalTime;
+}


### PR DESCRIPTION
This patch adds a tag carrying the signal arrival time to packets received by the radio.
It is useful when implementing TDMA protocols as it allows the MAC layer get the time of the packet arrival and synchronise precisely with the time slot structure.

This is related to my [question](https://stackoverflow.com/questions/53394411/get-the-time-of-arrival-for-a-wireless-frame) on StackOverflow.