### PR TITLE
Proxy ARP

### DIFF
--- a/examples/bgpv4/BgpOpen/BGPRouterSimple.ned
+++ b/examples/bgpv4/BgpOpen/BGPRouterSimple.ned
@@ -74,7 +74,6 @@ module BGPRouterSimple
         }
         ipv4: Ipv4NetworkLayer {
             parameters:
-                proxyARP = true;
                 @display("p=325,400;i=block/layer;q=queue");
         }
         nl: MessageDispatcher {

--- a/examples/bgpv4/BgpUpdate/BGPRouterEx.ned
+++ b/examples/bgpv4/BgpUpdate/BGPRouterEx.ned
@@ -78,7 +78,6 @@ module BGPRouterEx
         }
         ipv4: Ipv4NetworkLayer {
             parameters:
-                proxyARP = true;
                 routingTable.routerId = "auto";
                 @display("p=250,400;i=block/layer;q=queue");
         }

--- a/examples/httptools/socket/pairsocket/omnetpp.ini
+++ b/examples/httptools/socket/pairsocket/omnetpp.ini
@@ -81,7 +81,7 @@ sim-time-limit = 100d
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/examples/httptools/socket/pairsocket/omnetpp.ini
+++ b/examples/httptools/socket/pairsocket/omnetpp.ini
@@ -81,7 +81,7 @@ sim-time-limit = 100d
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/examples/httptools/socket/simpleddos/omnetpp.ini
+++ b/examples/httptools/socket/simpleddos/omnetpp.ini
@@ -97,4 +97,4 @@ network = HttpNnodes
 **.tcp.recordStats = true
 
 # Arp configuration
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"

--- a/examples/httptools/socket/simpleddos/omnetpp.ini
+++ b/examples/httptools/socket/simpleddos/omnetpp.ini
@@ -97,4 +97,4 @@ network = HttpNnodes
 **.tcp.recordStats = true
 
 # Arp configuration
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"

--- a/examples/httptools/socket/tenserverssocket/omnetpp.ini
+++ b/examples/httptools/socket/tenserverssocket/omnetpp.ini
@@ -83,7 +83,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/examples/httptools/socket/tenserverssocket/omnetpp.ini
+++ b/examples/httptools/socket/tenserverssocket/omnetpp.ini
@@ -83,7 +83,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/examples/mobileipv6/omnetpp.ini
+++ b/examples/mobileipv6/omnetpp.ini
@@ -150,7 +150,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # Ppp NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/examples/mobileipv6/omnetpp.ini
+++ b/examples/mobileipv6/omnetpp.ini
@@ -150,7 +150,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # Ppp NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/examples/voipstream/VoIPStreamLargeNet/omnetpp.ini
+++ b/examples/voipstream/VoIPStreamLargeNet/omnetpp.ini
@@ -57,7 +57,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # Ethernet NIC configuration
 **.eth[*].encap.writeScalars = false

--- a/examples/voipstream/VoIPStreamLargeNet/omnetpp.ini
+++ b/examples/voipstream/VoIPStreamLargeNet/omnetpp.ini
@@ -57,7 +57,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # Ethernet NIC configuration
 **.eth[*].encap.writeScalars = false

--- a/examples/voipstream/VoIPStreamTest/omnetpp.ini
+++ b/examples/voipstream/VoIPStreamTest/omnetpp.ini
@@ -98,7 +98,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # Ethernet NIC configuration
 **.eth[*].encap.writeScalars = false

--- a/examples/voipstream/VoIPStreamTest/omnetpp.ini
+++ b/examples/voipstream/VoIPStreamTest/omnetpp.ini
@@ -98,7 +98,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # Ethernet NIC configuration
 **.eth[*].encap.writeScalars = false

--- a/examples/voipstream/VoIPStreamTrafficTest/omnetpp.ini
+++ b/examples/voipstream/VoIPStreamTrafficTest/omnetpp.ini
@@ -79,7 +79,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # Ethernet NIC configuration
 **.eth[*].encap.writeScalars = false

--- a/examples/voipstream/VoIPStreamTrafficTest/omnetpp.ini
+++ b/examples/voipstream/VoIPStreamTrafficTest/omnetpp.ini
@@ -79,7 +79,7 @@ cmdenv-express-mode = true
 **.arp.retryTimeout = 1s
 **.arp.retryCount = 3
 **.arp.cacheTimeout = 100s
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # Ethernet NIC configuration
 **.eth[*].encap.writeScalars = false

--- a/src/inet/networklayer/arp/ipv4/Arp.cc
+++ b/src/inet/networklayer/arp/ipv4/Arp.cc
@@ -61,7 +61,7 @@ void Arp::initialize(int stage)
         retryTimeout = par("retryTimeout");
         retryCount = par("retryCount");
         cacheTimeout = par("cacheTimeout");
-        respondToProxyArp = par("respondToProxyARP");
+        proxyARP = par("proxyARP");
 
         // init statistics
         numRequestsSent = numRepliesSent = 0;
@@ -219,9 +219,9 @@ bool Arp::addressRecognized(Ipv4Address destAddr, InterfaceEntry *ie)
     if (rt->isLocalAddress(destAddr)) {
         return true;
     }
-    else if (respondToProxyArp) {
-        // respond to Proxy ARP request: if we can route this packet (and the
-        // output port is different from this one), say yes
+    else if (proxyARP) {
+        // if we can route this packet, and the output port is
+        // different from this one, then say yes
         InterfaceEntry *rtie = rt->getInterfaceForDestAddr(destAddr);
         return rtie != nullptr && rtie != ie;
     }

--- a/src/inet/networklayer/arp/ipv4/Arp.h
+++ b/src/inet/networklayer/arp/ipv4/Arp.h
@@ -69,7 +69,7 @@ class INET_API Arp : public OperationalBase, public IArp
     simtime_t retryTimeout;
     int retryCount = 0;
     simtime_t cacheTimeout;
-    bool respondToProxyArp = false;
+    bool proxyARP = false;
     long numResolutions = 0;
     long numFailedResolutions = 0;
     long numRequestsSent = 0;

--- a/src/inet/networklayer/arp/ipv4/Arp.h
+++ b/src/inet/networklayer/arp/ipv4/Arp.h
@@ -99,7 +99,8 @@ class INET_API Arp : public OperationalBase, public IArp
     virtual L3Address getL3AddressFor(const MacAddress& addr) const override;
     /// @}
 
-    void sendArpGratuitous(const InterfaceEntry *ie, MacAddress srcAddr, Ipv4Address ipAddr, ArpOpcode opCode);
+    void sendArpGratuitous(const InterfaceEntry *ie, MacAddress srcAddr, Ipv4Address ipAddr, ArpOpcode opCode = ARP_REQUEST);
+    void sendArpProbe(const InterfaceEntry *ie, MacAddress srcAddr, Ipv4Address probedAddr);
 
   protected:
     virtual void initialize(int stage) override;

--- a/src/inet/networklayer/arp/ipv4/Arp.h
+++ b/src/inet/networklayer/arp/ipv4/Arp.h
@@ -69,11 +69,13 @@ class INET_API Arp : public OperationalBase, public IArp
     simtime_t retryTimeout;
     int retryCount = 0;
     simtime_t cacheTimeout;
-    bool proxyARP = false;
+    std::string proxyArpInterfaces = "";
     long numResolutions = 0;
     long numFailedResolutions = 0;
     long numRequestsSent = 0;
     long numRepliesSent = 0;
+
+    cPatternMatcher proxyArpInterfacesMatcher;
 
     static simsignal_t arpRequestSentSignal;
     static simsignal_t arpReplySentSignal;

--- a/src/inet/networklayer/arp/ipv4/Arp.ned
+++ b/src/inet/networklayer/arp/ipv4/Arp.ned
@@ -47,10 +47,10 @@ simple Arp like IArp
     parameters:
         string interfaceTableModule;   // The path to the InterfaceTable module
         string routingTableModule;
-        double retryTimeout @unit(s) = default(1s); // number seconds ARP waits between retries to resolve an IPv4 address
-        int retryCount = default(3);   // number of times ARP will attempt to resolve an IPv4 address
+        double retryTimeout @unit(s) = default(1s);   // number seconds ARP waits between retries to resolve an IPv4 address
+        int retryCount = default(3);                  // number of times ARP will attempt to resolve an IPv4 address
         double cacheTimeout @unit(s) = default(120s); // number seconds unused entries in the cache will time out
-        bool respondToProxyARP = default(true);        // reply to proxy ARP requests (i.e. for IP addresses that this node can route)
+        bool proxyARP = default(true);                // enable proxy ARP on this node
         @display("i=block/layer");
         @signal[arpRequestSent](type=inet::Packet);
         @signal[arpReplySent](type=inet::Packet);

--- a/src/inet/networklayer/arp/ipv4/Arp.ned
+++ b/src/inet/networklayer/arp/ipv4/Arp.ned
@@ -50,7 +50,7 @@ simple Arp like IArp
         double retryTimeout @unit(s) = default(1s);   // number seconds ARP waits between retries to resolve an IPv4 address
         int retryCount = default(3);                  // number of times ARP will attempt to resolve an IPv4 address
         double cacheTimeout @unit(s) = default(120s); // number seconds unused entries in the cache will time out
-        bool proxyARP = default(true);                // enable proxy ARP on this node
+        string proxyArpInterfaces = default("*");     // list of interfaces that proxy ARP is enabled (all interfaces by default)
         @display("i=block/layer");
         @signal[arpRequestSent](type=inet::Packet);
         @signal[arpReplySent](type=inet::Packet);

--- a/src/inet/networklayer/ipv4/Ipv4.h
+++ b/src/inet/networklayer/ipv4/Ipv4.h
@@ -88,7 +88,6 @@ class INET_API Ipv4 : public OperationalBase, public NetfilterBase, public INetw
     simtime_t fragmentTimeoutTime;
     bool limitedBroadcast = false;
     std::string directBroadcastInterfaces = "";
-    bool useProxyARP = false;
 
     cPatternMatcher directBroadcastInterfaceMatcher;
 

--- a/src/inet/networklayer/ipv4/Ipv4.ned
+++ b/src/inet/networklayer/ipv4/Ipv4.ned
@@ -102,7 +102,6 @@ simple Ipv4 like IIpv4
         double fragmentTimeout @unit(s) = default(60s);
         bool limitedBroadcast = default(false); // send out limited broadcast packets comming from higher layer
         string directBroadcastInterfaces = default("");   // list of interfaces that direct broadcast is enabled (by default direct broadcast is disabled on all interfaces)
-        bool useProxyARP = default(true);
         @display("i=block/routing");
         @signal[packetSentToUpper](type=cPacket);
         @signal[packetReceivedFromUpper](type=cPacket);

--- a/src/inet/networklayer/ipv4/Ipv4NetworkLayer.ned
+++ b/src/inet/networklayer/ipv4/Ipv4NetworkLayer.ned
@@ -30,7 +30,6 @@ import inet.networklayer.contract.INetworkLayer;
 module Ipv4NetworkLayer like INetworkLayer
 {
     parameters:
-        bool proxyARP = default(true);
         bool forwarding = default(false);
         bool multicastForwarding = default(false);
         string interfaceTableModule;
@@ -40,8 +39,6 @@ module Ipv4NetworkLayer like INetworkLayer
         *.routingTableModule = default(absPath(".routingTable"));
         *.arpModule = default(absPath(".arp"));
         *.icmpModule = default(absPath(".icmp"));
-        arp.respondToProxyARP = proxyARP;
-        ip.useProxyARP = true; // as routes with unspecified next-hop addr are quite common
         @display("i=block/fork");
 
     gates:

--- a/src/inet/node/inet/StandardHost.ned
+++ b/src/inet/node/inet/StandardHost.ned
@@ -42,7 +42,7 @@ module StandardHost extends ApplicationLayerNodeBase
         @display("i=device/pc2");
         @figure[submodules];
         forwarding = default(false);  // disable routing by default
-        ipv4.arp.proxyARP = default(false); // proxy arp is disabled on hosts by default
+        ipv4.arp.proxyArpInterfaces = default(""); // proxy arp is disabled on hosts by default
         *.routingTableModule = default("^.ipv4.routingTable");
 }
 

--- a/src/inet/node/inet/StandardHost.ned
+++ b/src/inet/node/inet/StandardHost.ned
@@ -42,7 +42,7 @@ module StandardHost extends ApplicationLayerNodeBase
         @display("i=device/pc2");
         @figure[submodules];
         forwarding = default(false);  // disable routing by default
-        ipv4.proxyARP = default(false);
+        ipv4.arp.proxyARP = default(false); // proxy arp is disabled on hosts by default
         *.routingTableModule = default("^.ipv4.routingTable");
 }
 

--- a/tests/misc/dlltest/omnetpp.ini
+++ b/tests/misc/dlltest/omnetpp.ini
@@ -42,7 +42,7 @@ cmdenv-express-mode = false
 **.srv*.forwarding = false
 
 # ARP configuration
-**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyArpInterfaces = "*"  # Host's is hardwired "false"
 
 # NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers

--- a/tests/misc/dlltest/omnetpp.ini
+++ b/tests/misc/dlltest/omnetpp.ini
@@ -42,7 +42,7 @@ cmdenv-express-mode = false
 **.srv*.forwarding = false
 
 # ARP configuration
-**.ipv4.proxyARP = true  # Host's is hardwired "false"
+**.ipv4.arp.proxyARP = true  # Host's is hardwired "false"
 
 # NIC configuration
 **.ppp[*].queue.typename = "DropTailQueue" # in routers


### PR DESCRIPTION
Proxy ARP is a feature of ARP and needs to be defined in the ARP module and not IPv4. By default, proxy ARP is `true` in routers and `false` in hosts.

[commit 1498038]

In most implementations, proxy ARP can be enabled/disabled per interface. This commit adds this feature to the ARP operation.

Examples:

https://github.com/ManiAm/inet/blob/INETex3/examples_INETex/address_resolution/omnetpp.ini
