### PR TITLE
TCP SACK related bug fixed [EDITED]

### DIFF
--- a/src/inet/transportlayer/tcp/TcpConnectionSackUtil.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionSackUtil.cc
@@ -387,7 +387,10 @@ void TcpConnection::sendSegmentDuringLossRecoveryPhase(uint32 seqNum)
 
     uint32 sentSeqNum = seqNum + state->sentBytes;
 
-    ASSERT(seqLE(state->snd_nxt, sentSeqNum + 1));    // +1 for FIN, if sent
+    if(state->send_fin && sentSeqNum == state->snd_fin_seq)
+        sentSeqNum = sentSeqNum + 1;
+    
+    ASSERT(seqLE(state->snd_nxt, sentSeqNum));
 
     // RFC 3517 page 8: "(C.2) If any of the data octets sent in (C.1) are below HighData,
     // HighRxt MUST be set to the highest sequence number of the

--- a/src/inet/transportlayer/tcp/TcpConnectionUtil.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionUtil.cc
@@ -618,6 +618,7 @@ void TcpConnection::sendFin()
     // send it
     sendToIP(fp, tcpseg);
 
+
     // notify
     tcpAlgorithm->ackSent();
 }
@@ -662,9 +663,11 @@ void TcpConnection::sendSegment(uint32 bytes)
     tcpseg->setSequenceNo(state->snd_nxt);
     ASSERT(tcpseg != nullptr);
 
-    // if sack_enabled copy region of tcpseg to rexmitQueue
-    if (state->sack_enabled)
-        rexmitQueue->enqueueSentData(state->snd_nxt, state->snd_nxt + bytes);
+    //Remember old_snd_next to store in SACK rexmit queue.
+    uint32 old_snd_nxt = state->snd_nxt;
+
+    //Number of bytes of data (without FIN) sent
+    uint32 bytes_sent = state->snd_nxt + bytes;
 
     tcpseg->setAckNo(state->rcv_nxt);
     tcpseg->setAckBit(true);
@@ -684,7 +687,12 @@ void TcpConnection::sendSegment(uint32 bytes)
         EV_DETAIL << "Setting FIN on segment\n";
         tcpseg->setFinBit(true);
         state->snd_nxt = state->snd_fin_seq + 1;
+        bytes_sent += 1; //Increase the number of bytes by one for FIN
     }
+
+    // if sack_enabled copy region of tcpseg to rexmitQueue
+    if (state->sack_enabled)
+        rexmitQueue->enqueueSentData(old_snd_nxt, bytes_sent);
 
     // add header options and update header length (from tcpseg_temp)
     for (uint i = 0; i < tcpseg_temp->getHeaderOptionArraySize(); i++)

--- a/tests/module/tcp_sack_7.test
+++ b/tests/module/tcp_sack_7.test
@@ -1,0 +1,99 @@
+%description:
+TCP SACK test
+ Testing correct closure of TCP connection when SACK is enabled.
+ 
+ In this example, we assume that the data receiver has first received seven segments of
+ 500 bytes each, and has sent an acknowledgement with the cumulative
+ acknowledgement field set to 3501 (assuming the first sequence number
+ is one). The congestion window size at sender's side is 8 segments (i.e. 4000B)
+ 
+        Transmitted      Received    ACK Sent
+        Segment          Segment     (Including SACK Blocks)
+
+        [3501-4001)      (data packet dropped)
+        [4001-4501)      (data packet dropped)
+        [4501-5001)      [4501-5001)   3501, SACK=4501-5001
+        [5001-5501)      [5001-5501)   3501, SACK=4501-5501
+        [5501-6001)      [5501-6001)   3501, SACK=4501-6001       
+        --- 3 Duplicate ACKs: Enter Fast Retransmit + Fast recovery---     
+        [6001-6501)      [5001-5501)   3501, SACK=4501-6501
+        [6501-7001)      [6001-6501)   3501, SACK=4501-7001                              
+ 		[7001-7501)		 [7001-7501)   3501, SACK=4501-7501
+ 		
+   Because of two consecutive lost data packets, the sender receives three duplicate acks,
+   triggering Fast Retransmirt + Fast Recovery. The congestion window is not reduced to 7 
+   segments (3500B). 
+   
+ 		(Re-)Transmitted      	Received       ACK Sent
+        Segment               	Segment        (Including SACK Blocks)
+ 		(R) [3501-4001)     	[3501-4001)   4001, SACK=3501-4001 SACK=4501-5001
+        (R) [4001-4501)  	    [4001-4501)   7501
+        [7501-8001)			  	[7501-8001)   8001
+ 		[8001-8201)+FIN		  	[8001-8202)   8202
+ 
+   In the current imoplementation, rcv_nxt on the receiver side will be updated to 8202,
+   snd_max on the sender side is set to 8201, causing an error.
+   
+   
+
+%inifile: {}.ini
+[General]
+#preload-ned-files = *.ned ../../*.ned @../../../../nedfiles.lst
+ned-path = .;../../../../src;../../lib
+
+#omnetpp 5.0 - 5.1 compatibility:
+eventlog-file = "${resultdir}/${configname}-${runnumber}.elog"
+output-scalar-file = "${resultdir}/${configname}-${runnumber}.sca"
+output-vector-file = "${resultdir}/${configname}-${runnumber}.vec"
+snapshot-file = "${resultdir}/${configname}-${runnumber}.sna"
+
+network = TcpTestNet1
+
+#[Cmdenv]
+cmdenv-event-banners=false
+cmdenv-express-mode=false
+cmdenv-log-prefix="[%c]: "
+
+#[Parameters]
+*.testing=false
+
+# for scriptabletester
+*.tcptester.script="A9 delete; A10 delete"
+
+# client test apps
+*.cli_app.active = true
+*.cli_app.localAddress="10.0.0.1"
+*.cli_app.localPort=1000
+*.cli_app.connectAddress="10.0.0.2"
+*.cli_app.connectPort=2000
+*.cli_app.active=true
+*.cli_app.tOpen=0s
+*.cli_app.tSend=0s
+*.cli_app.sendBytes = 8200B
+*.cli_app.sendScript=""
+*.cli_app.tClose=0.005s
+
+# server test apps
+*.srv_app.active=false
+*.srv_app.localAddress="10.0.0.2"
+*.srv_app.localPort=2000
+*.srv_app.connectAddress="10.0.0.1"
+*.srv_app.connectPort=1000
+*.srv_app.tOpen=0s
+*.srv_app.tSend=-1s
+*.srv_app.sendBytes=0B
+*.srv_app.sendScript=""
+*.srv_app.tClose=-1s
+
+# tcp settings
+*.*_tcp.advertisedWindow = 10000                       # in bytes, corresponds with the maximal receiver buffer capacity (Note: normally, NIC queues should be at least this size)
+*.*_tcp.delayedAcksEnabled = false                   # delayed ACK algorithm (RFC 1122) enabled/disabled
+*.*_tcp.nagleEnabled = false                          # Nagle's algorithm (RFC 896) enabled/disabled
+*.*_tcp.limitedTransmitEnabled = false                # Limited Transmit algorithm (RFC 3042) enabled/disabled (can be used for TcpReno/TcpTahoe/TcpNewReno/TcpNoCongestionControl)
+*.*_tcp.increasedIWEnabled = false                    # Increased Initial Window (RFC 3390) enabled/disabled
+*.*_tcp.sackSupport = true                            # Selective Acknowledgment (RFC 2018, 2883, 3517) support (header option) (SACK will be enabled for a connection if both endpoints support it)
+*.*_tcp.windowScalingSupport = false                  # Window Scale (RFC 1323) support (header option) (WS will be enabled for a connection if both endpoints support it)
+*.*_tcp.timestampSupport = false                     # Timestamps (RFC 1323) support (header option) (TS will be enabled for a connection if both endpoints support it)
+*.*_tcp.mss = 500                                     # Maximum Segment Size (RFC 793) (header option)
+*.*_tcp.tcpAlgorithmClass = "TcpReno"                 # TcpReno/TcpTahoe/TcpNewReno/TcpNoCongestionControl/DumbTcp
+*.*_tcp.recordStats = true                            # recording of seqNum etc. into output vectors enabled/disabled

--- a/tests/module/tcp_sack_7.test
+++ b/tests/module/tcp_sack_7.test
@@ -14,26 +14,24 @@ TCP SACK test
         [4001-4501)      (data packet dropped)
         [4501-5001)      [4501-5001)   3501, SACK=4501-5001
         [5001-5501)      [5001-5501)   3501, SACK=4501-5501
-        [5501-6001)      [5501-6001)   3501, SACK=4501-6001       
-        --- 3 Duplicate ACKs: Enter Fast Retransmit + Fast recovery---     
+        [5501-6001)      [5501-6001)   3501, SACK=4501-6001          
         [6001-6501)      [5001-5501)   3501, SACK=4501-6501
         [6501-7001)      [6001-6501)   3501, SACK=4501-7001                              
- 		[7001-7501)		 [7001-7501)   3501, SACK=4501-7501
+ 		     [7001-7501)		    [7001-7501)   3501, SACK=4501-7501
  		
    Because of two consecutive lost data packets, the sender receives three duplicate acks,
-   triggering Fast Retransmirt + Fast Recovery. The congestion window is not reduced to 7 
+   triggering Fast Retransmirt + Fast Recovery. The congestion window is now reduced to 7 
    segments (3500B). 
    
  		(Re-)Transmitted      	Received       ACK Sent
-        Segment               	Segment        (Including SACK Blocks)
+        Segment           Segment        (Including SACK Blocks)
  		(R) [3501-4001)     	[3501-4001)   4001, SACK=3501-4001 SACK=4501-5001
-        (R) [4001-4501)  	    [4001-4501)   7501
-        [7501-8001)			  	[7501-8001)   8001
- 		[8001-8201)+FIN		  	[8001-8202)   8202
+   (R) [4001-4501)  	   [4001-4501)   7501
+   [7501-8001)			  	    [7501-8001)   8001
+ 		[8001-8201)+FIN		  	 [8001-8202)   8202
  
-   In the current imoplementation, rcv_nxt on the receiver side will be updated to 8202,
-   snd_max on the sender side is set to 8201, causing an error.
-   
+ The last segment [8001-8201), which is sent for the first time during Fast Recovery, 
+ contains 200 bytes of data and 1 byte for the FIN. 
    
 
 %inifile: {}.ini


### PR DESCRIPTION
**EDIT**: during copying and pasting from a second repository to this one to perform the pull request, I accidentally removed the definition of a variable (`sentSeqNum`). I am submitting the correct pull request here.

When TCP SACK option is enabled, an assertion in TcpSackRexmitQueue.cc can fail, as already reported in #278.

I attach at the end of the pull request description the .ini and .ned files to reproduce the same error I encountered (which is in a different scenario than the one reported in #278, but which I believe to be the same). In my scenario, two nodes are sending data to the same receiver through a bottleneck and a very small buffer at the router. 

I believe the root cause problem is that during the **loss recovery** phase, if **SACK option is enabled**, `snd_max` reaches an inconsistent state since updates do not account for the possibility that the FIN might have been sent along with the last data segment for the first time. 

In the class member `TcpConnection::sendSegmentDuringLossRecoveryPhase(uint32 seqNum)` in `TcpConnectionSackUtil.cc`, which can only be invoked when SACK option is enabled, segments are sent as long as the difference between the congestion window size and the current pipe (i.e. estimated data still on flight) is greater or equal than 1 MSS. A single segment is sent by:

```
 // start sending from seqNum
    state->snd_nxt = seqNum;

    uint32 old_highRxt = rexmitQueue->getHighestRexmittedSeqNum();

    // no need to check cwnd and rwnd - has already be done before
    // no need to check nagle - sending mss bytes
    sendSegment(state->snd_mss);

```

At this point, we check the amount of bytes sent with the last segment:

```
   uint32 sentSeqNum = seqNum + state->sentBytes; 

    ASSERT(seqLE(state->snd_nxt, sentSeqNum + 1));  // +1 for FIN, if sent
```

The assertion verifies that `snd_nxt` is actually pointing to the sequence number following the last sequence number of data sent and it considers the case in which the FIN has also been sent along. 

Few lines down in the code, if the last segment carried data that hadn't been sent before, `snd_max` needs updating:

```
 // RFC 3517 page 8: "(C.3) If any of the data octets sent in (C.1) are above HighData,
    // HighData must be updated to reflect the transmission of
    // previously unsent data."
    if (seqGreater(sentSeqNum, state->snd_max)){// HighData = snd_max
        state->snd_max = sentSeqNum;
    }
```

This update, however, does not account for the case in which the FIN has been sent for the first time along with the last segment, bringing `snd_max` to an inconsistent value, since the receiver will update its `rcv_nxt` to the correct value `sentSeqNum + 1`. 

The assertion in #278 fails because:

1. The `snd_max` of the sender does not account for the sequence number of the FIN.
2. The receiver ACKs the correctly received segment with an ACK carrying ACK number equal to `sentSeqNum + 1`
3. When the sender receives the ACK packet, it compares the ACK number with its current state and finds that the ACK number is greater than `snd_max`. As a result, it assumes the receiver is acknowledging data that has not been sent yet:
     ```
        ASSERT(seqGreater(tcpseg->getAckNo(), state->snd_max));    // from if-ladder

        // send an ACK, drop the segment, and return.
        tcpAlgorithm->receivedAckForDataNotYetSent(tcpseg->getAckNo());
    ```
4. The basic behaviour in this circumstance is to send an ACK back, as implemented in `TcpBaseAlg.cc`:

```
void TcpBaseAlg::receivedAckForDataNotYetSent(uint32 seq)
{
    // Note: In this case no immediate ACK will be send because not mentioned
    // in [Stevens, W.R.: TCP/IP Illustrated, Volume 2, page 861].
    // To force immediate ACK use:
    // state->ack_now = true;
    // tcpEV << "ACK acks something not yet sent, sending immediate ACK\n";
    EV_INFO << "ACK acks something not yet sent, sending ACK\n";
    conn->sendAck();
}
```
5. At this point the receiver receives an ACK with SACK option enabled, but values carried are all initial values, cause the receiver to throw an error. 

Hence, here is the proposed solution:

```
    if(state->send_fin && sentSeqNum == state->snd_fin_seq)
        sentSeqNum = sentSeqNum + 1;

    ASSERT(seqLE(state->snd_nxt, sentSeqNum));
```

`sentSeqNum` now accounts for the possible FIN's sequence number if FIN was sent with the last data segment.

This solution seems to have fixed the issue, but if you could review the changes and confirm that everything makes sense, it would be greatly appreciated.

### NED definition

```
import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
import inet.node.inet.Router;
import inet.node.inet.StandardHost;
import inet.common.misc.ThruputMeteringChannel;
import ned.DatarateChannel;

network SACKBugNetwork
{
    parameters:
        @display("bgb=480,382");
        int numHosts;
        double bottleneck = default(10Mbps) @unit(bps);
        double neck_delay = default(1ms) @unit(s);
        

    types:
        channel slowline extends ThruputMeteringChannel
        {
            datarate = bottleneck;
            delay = neck_delay;
        }
        
        channel fastline extends DatarateChannel
        {
            datarate = 1000000Mbps;
        }

    submodules:
        client[numHosts]: StandardHost {
            @display("p=398,165");
        }
        server: StandardHost {
            @display("p=67,165");
        }
        configurator: Ipv4NetworkConfigurator {
            @display("p=372,61");
        }

        router1: Router {
            parameters:
                @display("p=293,165");
        }

        router2: Router {
            @display("p=172,165");
        }
    connections:
        for i=0..numHosts-1 {
            client[i].pppg++ <--> fastline <--> router1.pppg++;
        }
        server.pppg++ <--> fastline <--> router2.pppg++;

        router1.pppg++ <--> slowline <--> router2.pppg++;
}
```

### INI configuration

```
[General]
network = SACKBugNetwork

**.tcpType = "TCP"
**.tcp.mss=1460
**.hasTcp = true
**.tcp.nagleEnabled = false

**.tcp.tcpAlgorithmClass = "TcpReno"
**.tcp.tcpAlgorithmClass = "TcpReno"
**.sackSupport = true
**.tcp.timestampSupport = true

# tcp apps
**.client[*].numApps = 1
**.client[*].app[*].typename = "TcpSessionApp"
**.server.numApps = 1
**.server.app[*].typename = "TcpSinkApp"
**.server.app[*].serverThreadModuleType = "inet.applications.tcpapp.TcpSinkAppThread"


**.numHosts = 2
**.client[0].app[*].connectAddress = "server>router2"
**.client[0].app[*].tOpen = 0s
**.client[0].app[*].tClose = -1s
**.client[0].app[*].sendBytes = 10MiB

**.client[1].app[*].connectAddress = "server>router2"
**.client[1].app[*].tOpen = 3s
**.client[1].app[*].tClose = -1s
**.client[1].app[*].sendBytes = 5MiB

**.ppp.mtu = 1500B
**router*.ppp[*].queue.frameCapacity = 1

**.channel.throughput.result-recording-modes=all

seed-set = 10
```
