### PR TITLE
802.15.4: Set analog model of Ieee802154NarrowbandDimensionalRadioMedium to DimensionalAnalogModel

### DIFF
--- a/src/inet/physicallayer/ieee802154/packetlevel/Ieee802154NarrowbandDimensionalRadioMedium.ned
+++ b/src/inet/physicallayer/ieee802154/packetlevel/Ieee802154NarrowbandDimensionalRadioMedium.ned
@@ -23,6 +23,7 @@ import inet.physicallayer.common.packetlevel.RadioMedium;
 module Ieee802154NarrowbandDimensionalRadioMedium extends RadioMedium
 {
     parameters:
+        analogModel.typename = default("DimensionalAnalogModel");
         backgroundNoise.typename = default("IsotropicDimensionalBackgroundNoise");
 
         mediumLimitCache.carrierFrequency = 2450 MHz;


### PR DESCRIPTION
The analog model of the Ieee802154NarrowbandDimensionalRadioMedium was not set, thus it inherited the default from RadioMedium, which is a scalar model.