### PR TITLE
Topic/redmarker final

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -56,7 +56,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="inet/applications/voipstream|inet/linklayer/ext|inet/transportlayer/tcp_nsc|inet/transportlayer/tcp_lwip|inet/routing/extras|transport/tcp_nsc|transport/tcp_lwip" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
+						<entry excluding="inet/applications/voipstream|inet/transportlayer/tcp_nsc|inet/transportlayer/tcp_lwip|inet/routing/extras|transport/tcp_nsc|transport/tcp_lwip" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -113,7 +113,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="inet/applications/voipstream|inet/linklayer/ext|inet/transportlayer/tcp_nsc|inet/transportlayer/tcp_lwip|inet/routing/extras|transport/tcp_nsc|transport/tcp_lwip" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
+						<entry excluding="inet/applications/voipstream|inet/transportlayer/tcp_nsc|inet/transportlayer/tcp_lwip|inet/routing/extras|transport/tcp_nsc|transport/tcp_lwip" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/examples/inet/redmarker/network.ned
+++ b/examples/inet/redmarker/network.ned
@@ -1,0 +1,137 @@
+//
+// author: Marcel Marek
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+package inet.examples.inet.redmarker;
+
+
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+//import inet.node.ethernet.EtherSwitch;
+import inet.node.inet.Router;
+//import inet.node.dmpr.DmprRouter;
+//import inet.nodes.inet.Router;
+//import inet.node.ospfv2.OspfRouter;
+import inet.node.inet.StandardHost;
+//import inet.nodes.inet.StandardHost;
+import ned.DatarateChannel;
+
+//import inet.linklayer.queue.REDDropper;
+
+//import inet.common.queue.IOutputQueue;
+//import inet.linklayer.queue.DropTailQueue;
+//import inet.common.queue.FifoQueue;
+//import inet.common.queue.RedDropper;
+//import inet.common.queue.RedMarkerQueue;
+
+
+
+//import inet.visualizer.integrated.IntegratedCanvasVisualizer;
+
+
+channel NormalP extends DatarateChannel
+{
+    parameters:
+        datarate = default(10Mbps);
+        delay = default(1ms);
+        per = 0;
+        ber = 0;
+}
+
+channel FastP extends DatarateChannel
+{
+    parameters:
+        datarate = 100Mbps;
+        delay = 1ms;
+        per = 0;
+        ber = 0;
+}
+
+
+
+
+network RedMarkerNetwork
+{
+    parameters:
+        @display("bgb=4166.738,3051.564,white;bgl=8");
+
+    submodules:
+
+
+        routerCore1: Router {
+            parameters:
+                @display("p=1026.4801,995.93005;i=abstract/router");
+
+        }
+        routerCore2: Router {
+            parameters:
+                @display("p=2945.02,995.93005;i=abstract/router");
+        }
+        
+        configurator: Ipv4NetworkConfigurator {
+//            parameters:
+//                @display("p=150,115;is=m");
+//                addStaticRoutes = false;
+//                config = default(xml("<config>"
+//                        + "<interface among='routerCore1 routerCore2' address='10.1.2.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore1 routerCore5' address='10.1.5.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore3 routerCore4' address='10.3.4.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore3 routerCore5' address='10.3.5.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore5 routerCore6' address='10.5.6.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore2 routerCore6' address='10.2.6.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore4 routerCore6' address='10.4.6.x' netmask='255.255.255.x' />"
+//                        
+//                        + "<interface among='routerCore1 sender1*' address='192.168.1.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore2 receiver1*' address='192.168.2.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore3 sender2*' address='192.168.3.x' netmask='255.255.255.x' />"
+//                        + "<interface among='routerCore4 receiver2*' address='192.168.4.x' netmask='255.255.255.x' />"
+//                        
+//                        + "<interface host='sender1*' address='192.168.1.x' netmask='255.255.255.x' />"
+//                        + "<interface host='receiver1*' address='192.168.2.x' netmask='255.255.255.x' />"
+//                        + "<interface host='sender2*' address='192.168.3.x' netmask='255.255.255.x' />"
+//                        + "<interface host='receiver2*' address='192.168.4.x' netmask='255.255.255.x' />"
+//                        
+//                        + "<multicast-group hosts='r*' address='224.0.0.5 224.0.0.6' />"
+//                        + "<route hosts='sender1*' destination='*' gateway='routerCore1'/>"
+//                        + "<route hosts='receiver1*' destination='*' gateway='routerCore2'/>"
+//                        + "<route hosts='sender2*' destination='*' gateway='routerCore3'/>"
+//                        + "<route hosts='receiver2*' destination='*' gateway='routerCore4'/>"
+//                        + "</config>"));
+//
+        }
+
+
+        sender1: StandardHost {
+            parameters:
+                @display("p=342.16,995.93005");
+        }
+
+        receiver1: StandardHost {
+            parameters:
+                @display("p=3708.7703,995.93005");
+        }
+
+    connections:
+
+        sender1.ethg++ <--> FastP <--> routerCore1.ethg++;
+        receiver1.ethg++ <--> FastP <--> routerCore2.ethg++;
+        routerCore1.ethg++ <--> NormalP <--> routerCore2.ethg++;
+
+
+}
+
+
+
+

--- a/examples/inet/redmarker/omnetpp.ini
+++ b/examples/inet/redmarker/omnetpp.ini
@@ -1,0 +1,56 @@
+[General]
+network = inet.examples.inet.redmarker.RedMarkerNetwork
+
+
+# Queue setting
+**.routerCore*.eth[*].queue.typename       = "RedMarkerQueue"
+**.routerCore*.eth[*].queue.red.wq         = 1 #0.002 #0.8
+**.routerCore*.eth[*].queue.red.minths     = "3" #"5"
+**.routerCore*.eth[*].queue.red.maxths     = "4"  
+**.routerCore*.eth[*].queue.red.maxps      = "1"
+**.routerCore*.eth[0].queue.red.pkrates    = "8333.3333"
+**.routerCore*.eth[1].queue.red.pkrates    = "833.3333"
+**.routerCore*.eth[*].queue.red.marks 	   = "1"
+**.routerCore*.eth[*].queue.red.recStart   = 0
+**.routerCore*.eth[*].queue.red.frameQueueCapacity = 24 # 
+
+
+[Config TcpSender1]
+
+**.arp.typename = "GlobalArp"
+
+**.tcp.delayedAcksEnabled = false                    # delayed ACK algorithm (RFC 1122) enabled/disabled
+**.tcp.nagleEnabled = false                           # Nagle's algorithm (RFC 896) enabled/disabled
+**.tcp.limitedTransmitEnabled = false                # Limited Transmit algorithm (RFC 3042) enabled/disabled (can be used for TCPReno/TCPTahoe/TCPNewReno/TCPNoCongestionControl)
+**.tcp.increasedIWEnabled = false                    # Increased Initial Window (RFC 3390) enabled/disabled
+**.tcp.sackSupport = false                            # Selective Acknowledgment (RFC 2018, 2883, 3517) support (header option) (SACK will be enabled for a connection if both endpoints support it)
+**.tcp.windowScalingSupport = true                  # Window Scale (RFC 1323) support (header option) (WS will be enabled for a connection if both endpoints support it)
+**.tcp.timestampSupport = false                      # Timestamps (RFC 1323) support (header option) (TS will be enabled for a connection if both endpoints support it)
+**.tcp.tcpAlgorithmClass = "TcpReno"                 # TCPReno/TCPTahoe/TCPNewReno/TCPNoCongestionControl/DumbTCP
+**.tcp.advertisedWindow = 5000000
+**.tcp.recordStats = true
+**.tcp.mss = 1460
+
+**.tcp.ecnEnabled = true   # This activates ECN (ECT - ECN Capable Transport) 
+
+**.sender1.numApps = 1
+**.receiver1.numApps = 1
+
+**.sender1.app[0].typename = "TcpSessionApp"
+**.sender1.app[0].active = true
+**.sender1.app[0].localPort = -1
+**.sender1.app[0].sendBytes = 5MiB
+**.sender1.app[0].sendScript = ""
+**.sender1.app[0].tClose = -1s
+**.sender1.app[0].connectPort = 1000
+**.sender1.app[0].connectAddress = "receiver1"
+
+**.sender1.app[0].tOpen = 10s
+
+**.receiver1.app[0].typename = "TcpSinkApp"
+**.receiver1.app[0].localPort = 1000
+
+
+
+
+

--- a/src/inet/common/queue/RedDropper.cc
+++ b/src/inet/common/queue/RedDropper.cc
@@ -38,7 +38,7 @@ void RedDropper::initialize()
 {
     AlgorithmicDropperBase::initialize();
 
-    wq = par("wq");
+    wq = par("wq").doubleValue();
     if (wq < 0.0 || wq > 1.0)
         throw cRuntimeError("Invalid value for wq parameter: %g", wq);
 

--- a/src/inet/common/queue/RedDropper.cc
+++ b/src/inet/common/queue/RedDropper.cc
@@ -38,7 +38,7 @@ void RedDropper::initialize()
 {
     AlgorithmicDropperBase::initialize();
 
-    wq = par("wq").doubleValue();
+    wq = par("wq");
     if (wq < 0.0 || wq > 1.0)
         throw cRuntimeError("Invalid value for wq parameter: %g", wq);
 

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -120,7 +120,14 @@ void RedMarker::handleMessage(cMessage *msg)
         }
         else
         {
-          shouldMark(packet);
+          if(shouldMark(packet))
+          {
+            if(packetDropped)
+            {
+              packetDropped = false;
+              return;
+            }
+          }
 
         }
         packet->setFrontOffset(headerOffset);
@@ -134,7 +141,7 @@ void RedMarker::handleMessage(cMessage *msg)
 
 
   if (shouldDrop(packet)){
-    std::cout<< "RedMarker: Dropping packet "<< std::endl;
+    EV_DETAIL<< "RedMarker: Dropping packet\n";
     dropPacket(packet);
     return;
   }
@@ -183,8 +190,8 @@ bool RedMarker::shouldMark(Packet *packet)
             dropPacket(packet);
             packetDropped = true;
             return true;
-        } else
-    if (minth <= avg && avg < maxth)
+    }
+    else if (minth <= avg && avg < maxth)
     {
         count[i]++;
         const double pb = maxp * (avg - minth) / (maxth - minth);

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -1,0 +1,233 @@
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+#include "inet/common/queue/RedMarker.h"
+#include "inet/common/INETUtils.h"
+
+//#include "inet/networklayer/diffserv/DscpMarker.h"
+
+#include "inet/common/ProtocolTag_m.h"
+
+
+#include "inet/networklayer/ipv4/Ipv4Header_m.h"
+
+
+//#ifdef WITH_IPv6
+//#include "inet/networklayer/ipv6/Ipv6Header.h"
+//#endif // ifdef WITH_IPv6
+
+//#include "inet/networklayer/diffserv/Dscp_m.h"
+//
+//#include "inet/networklayer/diffserv/DiffservUtil.h"
+
+namespace inet {
+
+Define_Module(RedMarker);
+
+
+RedMarker::RedMarker()
+{
+
+
+}
+
+RedMarker::~RedMarker()
+{
+  delete[] marks;
+
+}
+
+void RedMarker::initialize()
+{
+  RedDropper::initialize();
+
+
+  marks = new double[numGates];
+
+  cStringTokenizer marksTokens(par("marks"));
+  for (int i = 0; i < numGates; ++i) {
+      marks[i] = marksTokens.hasMoreTokens() ? utils::atod(marksTokens.nextToken()) :
+          (i > 0 ? marks[i - 1] : 0);
+
+
+      if (marks[i] < 0.0)
+          throw cRuntimeError("marks parameter must not be negative");
+
+  }
+}
+
+void RedMarker::handleMessage(cMessage *msg)
+{
+  cPacket *packet = check_and_cast<cPacket *>(msg);
+
+  if (shouldDrop(packet)){
+    dropPacket(packet);
+    return;
+  }
+//  else if (shouldMark(packet))
+//  {
+//    markPacket(check_and_cast<Packet *>(packet));
+//  }
+
+   sendOut(packet);
+}
+
+bool RedMarker::shouldDrop(cPacket *packet)
+{
+    const int i = packet->getArrivalGate()->getIndex();
+    ASSERT(i >= 0 && i < numGates);
+    const double minth = minths[i];
+    const double maxth = maxths[i];
+    const double maxp = maxps[i];
+    const double pkrate = pkrates[i];
+    const int queueLength = getLength();
+
+    if (queueLength > 0)
+    {
+        // TD: This following calculation is only useful when the queue is not empty!
+        avg = (1 - wq) * avg + wq * queueLength;
+    }
+    else
+    {
+        // TD: Added behaviour for empty queue.
+        const double m = SIMTIME_DBL(simTime() - q_time) * pkrate;
+        avg = pow(1 - wq, m) * avg;
+    }
+
+//    Random dropping is disabled; returns true only for hard limit
+
+    if (minth <= avg && avg < maxth)
+    {
+        count[i]++;
+        const double pb = maxp * (avg - minth) / (maxth - minth);
+        const double pa = pb / (1 - count[i] * pb); // TD: Adapted to work as in [Floyd93].
+        if (dblrand() < pa)
+        {
+            EV << "Random early packet drop (avg queue len=" << avg << ", pa=" << pb << ")\n";
+            count[i] = 0;
+            markPacket(check_and_cast<Packet *>(packet));
+            return false;
+        }
+    }
+    else if (avg >= maxth) {
+        EV << "Avg queue len " << avg << " >= maxth, dropping packet.\n";
+        count[i] = 0;
+        markPacket(check_and_cast<Packet *>(packet));
+        return false;
+    }
+    else if (queueLength >= maxth) {    // maxth is also the "hard" limit
+        EV << "Queue len " << queueLength << " >= maxth, dropping packet.\n";
+        count[i] = 0;
+        return true;
+    }
+    else
+    {
+        count[i] = -1;
+    }
+
+    return false;
+}
+
+bool RedMarker::shouldMark(cPacket *packet)
+{
+  const int i = packet->getArrivalGate()->getIndex();
+   ASSERT(i >= 0 && i < numGates);
+   const double minth = minths[i];
+   const double maxth = maxths[i];
+   const double maxp = maxps[i];
+   const double pkrate = pkrates[i];
+   const int queueLength = getLength();
+
+   if (queueLength > 0)
+   {
+       // TD: This following calculation is only useful when the queue is not empty!
+       avg = (1 - wq) * avg + wq * queueLength;
+   }
+   else
+   {
+       // TD: Added behaviour for empty queue.
+       const double m = SIMTIME_DBL(simTime() - q_time) * pkrate;
+       avg = pow(1 - wq, m) * avg;
+   }
+
+   if (minth <= avg && avg < maxth)
+   {
+       count[i]++;
+       const double pb = maxp * (avg - minth) / (maxth - minth);
+       const double pa = pb / (1 - count[i] * pb); // TD: Adapted to work as in [Floyd93].
+       if (dblrand() < pa)
+       {
+           EV << "Random early packet drop (avg queue len=" << avg << ", pa=" << pb << ")\n";
+           count[i] = 0;
+           return true;
+       }
+   }
+   else if (avg >= maxth) {
+       EV << "Avg queue len " << avg << " >= maxth, dropping packet.\n";
+       count[i] = 0;
+       return true;
+   }
+   else if (queueLength >= maxth) {    // maxth is also the "hard" limit
+       EV << "Queue len " << queueLength << " >= maxth, dropping packet.\n";
+       count[i] = 0;
+       return true;
+   }
+   else
+   {
+       count[i] = -1;
+   }
+
+   return false;
+}
+
+
+bool RedMarker::markPacket(Packet *packet)
+{
+  EV_DETAIL << "Marking packet with ECN \n";
+
+  auto protocol = packet->getTag<PacketProtocolTag>()->getProtocol();
+
+  //TODO processing link-layer headers when exists
+
+
+  if (protocol == &Protocol::ipv4) {
+      packet->trimFront();
+      const auto& ipv4Header = packet->removeAtFront<Ipv4Header>();
+
+      ipv4Header->setExplicitCongestionNotification(1);
+      packet->insertAtFront(ipv4Header);
+      return true;
+  }
+
+//#ifdef WITH_IPv6
+//  if (protocol == &Protocol::ipv6) {
+//      packet->trimFront();
+//      const auto& ipv6Header = packet->removeAtFront<Ipv6Header>();
+//      ipv6Header->setDiffServCodePoint(dscp);
+//      packet->insertAtFront(ipv6Header);
+//      return true;
+//  }
+//#endif // ifdef WITH_IPv6
+
+  return false;
+
+
+}
+
+
+
+
+
+} //namespace

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -1,4 +1,6 @@
 //
+// Copyright (C) 2019 Marcel Marek
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -139,7 +141,7 @@ void RedMarker::handleMessage(cMessage *msg)
     }
   }
 
-
+  // For packets that does not support marking - shouldDrop is called instead
   if (shouldDrop(packet)){
     EV_DETAIL<< "RedMarker: Dropping packet\n";
     dropPacket(packet);

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -97,7 +97,7 @@ void RedMarker::handleMessage(cMessage *msg)
   //      packet->insertAtFront(ipv4Header);
 
   // if packet supports marking (ECT(1) or ECT(0))
-      if ((ect == IP_ECN_ECT_0) || (ect == IP_ECN_ECT_1))
+      if (((ect & IP_ECN_ECT_0) == IP_ECN_ECT_0) || ((ect & IP_ECN_ECT_1) == IP_ECN_ECT_1))
       {
 
         // if next packet should be marked and it is not

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -27,6 +27,7 @@
 #include "inet/linklayer/ethernet/EtherEncap.h"
 
 #include "inet/networklayer/common/L3Tools.h"
+#include "inet/networklayer/common/EcnTag_m.h"
 
 
 //#ifdef WITH_IPv6
@@ -96,16 +97,16 @@ void RedMarker::handleMessage(cMessage *msg)
   //      packet->insertAtFront(ipv4Header);
 
   // if packet supports marking (ECT(1) or ECT(0))
-      if ((ect & 0x01) || (ect & 0x02))
+      if ((ect == IP_ECN_ECT_0) || (ect == IP_ECN_ECT_1))
       {
 
         // if next packet should be marked and it is not
-        if (markNext && !(ect & 0x03))
+        if (markNext && !(ect == IP_ECN_CE))
         {
           markPacket(packet);
           markNext = false;
         }
-        else if (ect & 0x03)
+        else if (ect == IP_ECN_CE)
         {
           if (shouldMark(packet))
           {

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -128,6 +128,7 @@ void RedMarker::handleMessage(cMessage *msg)
 
 
   if (shouldDrop(packet)){
+    std::cout<< "RedMarker: Dropping packet "<< std::endl;
     dropPacket(packet);
     return;
   }
@@ -253,7 +254,7 @@ bool RedMarker::shouldDrop(cPacket *packet)
 bool RedMarker::markPacket(Packet *packet)
 {
   EV_DETAIL << "Marking packet with ECN \n";
-  std::cout << "Marking packet with ECN \n";
+//  std::cout << "Marking packet with ECN \n";
 
   packet->setFrontOffset(b(0));
   auto macHeader = packet->popAtFront<EthernetMacHeader>();

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -110,6 +110,11 @@ void RedMarker::handleMessage(cMessage *msg)
           if (shouldMark(packet))
           {
             markNext = true;
+            if(packetDropped)
+            {
+              packetDropped = false;
+              return;
+            }
           }
         }
         else
@@ -141,7 +146,7 @@ void RedMarker::handleMessage(cMessage *msg)
  *  Drops when size is bigger then max allowed size.
  *  Returns true when drop or mark occurs, false otherwise.
  * **/
-bool RedMarker::shouldMark(cPacket *packet)
+bool RedMarker::shouldMark(Packet *packet)
 {
     const int i = packet->getArrivalGate()->getIndex();
     ASSERT(i >= 0 && i < numGates);
@@ -188,6 +193,7 @@ bool RedMarker::shouldMark(cPacket *packet)
         EV << "Queue len " << queueLength << " >= maxth, dropping packet.\n";
         count[i] = 0;
         dropPacket(packet);
+        packetDropped = true;
         return true;
     }
     else

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -280,15 +280,15 @@ bool RedMarker::markPacket(Packet *packet)
 
   packet->setFrontOffset(b(0));
   auto macHeader = packet->popAtFront<EthernetMacHeader>();
-  packet->popAtBack<EthernetFcs>(ETHER_FCS_BYTES);
+  auto ethFcs = packet->popAtBack<EthernetFcs>(ETHER_FCS_BYTES);
 
   const auto& ipv4Header = removeNetworkProtocolHeader<Ipv4Header>(packet);
-  ipv4Header->setExplicitCongestionNotification(3);
+  ipv4Header->setExplicitCongestionNotification(IP_ECN_CE);
   insertNetworkProtocolHeader(packet, Protocol::ipv4, ipv4Header);
 
   packet->insertAtFront(macHeader);
 
-  EtherEncap::addPaddingAndFcs(packet, FCS_DECLARED_CORRECT);
+  EtherEncap::addPaddingAndFcs(packet, ethFcs->getFcsMode());
 
   return true;
 

--- a/src/inet/common/queue/RedMarker.cc
+++ b/src/inet/common/queue/RedMarker.cc
@@ -290,34 +290,7 @@ bool RedMarker::markPacket(Packet *packet)
 
   EtherEncap::addPaddingAndFcs(packet, FCS_DECLARED_CORRECT);
 
-
-//
-//  auto networkHeader = getNetworkProtocolHeader(packet);
-//
-//  Ipv4Header* ipv4Header = static_cast<Ipv4Header*>(networkHeader);
-//
-//  //  auto ipv4Header = packet->peekAtFront<Ipv4Header>();
-////  auto ipv4Header = removeNetworkProtocolHeader<Ipv4Header>(packet);
-//
-//  //congestion experiencd CE
-//  ipv4Header->setExplicitCongestionNotification(3);
-//  insertNetworkProtocolHeader(packet, Protocol::ipv4, ipv4Header);
-
   return true;
-
-
-//#ifdef WITH_IPv6
-//  if (protocol == &Protocol::ipv6) {
-//      packet->trimFront();
-//      const auto& ipv6Header = packet->removeAtFront<Ipv6Header>();
-//      ipv6Header->setDiffServCodePoint(dscp);
-//      packet->insertAtFront(ipv6Header);
-//      return true;
-//  }
-//#endif // ifdef WITH_IPv6
-
-  return false;
-
 
 }
 

--- a/src/inet/common/queue/RedMarker.h
+++ b/src/inet/common/queue/RedMarker.h
@@ -36,12 +36,15 @@ class INET_API RedMarker : public RedDropper
     double *marks;
     bool markNext;
 
+  private:
+    bool packetDropped = false;
+
   protected:
 
     virtual ~RedMarker();
     virtual void initialize() override;
     virtual void handleMessage(cMessage *msg) override;
-    bool shouldMark(cPacket *packet);
+    bool shouldMark(Packet *packet);
     virtual bool shouldDrop(cPacket *packet) override;
     bool markPacket(Packet *packet);
 };

--- a/src/inet/common/queue/RedMarker.h
+++ b/src/inet/common/queue/RedMarker.h
@@ -34,6 +34,7 @@ class INET_API RedMarker : public RedDropper
 
   protected:
     double *marks;
+    bool markNext;
 
   protected:
 

--- a/src/inet/common/queue/RedMarker.h
+++ b/src/inet/common/queue/RedMarker.h
@@ -38,6 +38,7 @@ class INET_API RedMarker : public RedDropper
 
   private:
     bool packetDropped = false;
+    int frameQueueCapacity;
 
   protected:
 

--- a/src/inet/common/queue/RedMarker.h
+++ b/src/inet/common/queue/RedMarker.h
@@ -1,0 +1,50 @@
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+#ifndef __INET_REDMARKER_H_
+#define __INET_REDMARKER_H_
+
+
+
+#include "inet/common/INETDefs.h"
+#include "inet/common/queue/RedDropper.h"
+#include "inet/common/packet/Packet.h"
+
+
+
+namespace inet {
+
+
+class INET_API RedMarker : public RedDropper
+{
+  public:
+    RedMarker();
+
+  protected:
+    double *marks;
+
+  protected:
+
+    virtual ~RedMarker();
+    virtual void initialize() override;
+    virtual void handleMessage(cMessage *msg) override;
+    bool shouldMark(cPacket *packet);
+    virtual bool shouldDrop(cPacket *packet) override;
+    bool markPacket(Packet *packet);
+};
+
+} //namespace
+
+#endif

--- a/src/inet/common/queue/RedMarker.h
+++ b/src/inet/common/queue/RedMarker.h
@@ -1,4 +1,6 @@
 //
+// Copyright (C) 2019 Marcel Marek
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/inet/common/queue/RedMarker.ned
+++ b/src/inet/common/queue/RedMarker.ned
@@ -24,8 +24,8 @@ simple RedMarker extends RedDropper
 {
     parameters:
         @class(RedMarker);
-
-        string marks = default("0");  // average packet rate for calculations when queue is empty
+		int frameQueueCapacity = default(120);
+        string marks = default("0");  
         @signal[markingProb](type=double);
         @statistic[marked](title="marking Prob"; source="markingProb"; record=mean,vector(count); interpolationmode=none);
 }

--- a/src/inet/common/queue/RedMarker.ned
+++ b/src/inet/common/queue/RedMarker.ned
@@ -27,5 +27,5 @@ simple RedMarker extends RedDropper
 
         string marks = default("0");  // average packet rate for calculations when queue is empty
         @signal[markingProb](type=double);
-        @statistic[marked](title="marking Prob"; source="markingProb"; record=mean; interpolationmode=none);
+        @statistic[marked](title="marking Prob"; source="markingProb"; record=mean,vector(count); interpolationmode=none);
 }

--- a/src/inet/common/queue/RedMarker.ned
+++ b/src/inet/common/queue/RedMarker.ned
@@ -1,0 +1,31 @@
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+package inet.common.queue;
+
+
+import inet.common.queue.RedDropper;
+//
+// TODO auto-generated module
+//
+simple RedMarker extends RedDropper
+{
+    parameters:
+        @class(RedMarker);
+
+        string marks = default("0");  // average packet rate for calculations when queue is empty
+        @signal[markingProb](type=double);
+        @statistic[marked](title="marking Prob"; source="markingProb"; record=mean; interpolationmode=none);
+}

--- a/src/inet/common/queue/RedMarker.ned
+++ b/src/inet/common/queue/RedMarker.ned
@@ -1,4 +1,6 @@
 //
+// Copyright (C) 2019 Marcel Marek
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/src/inet/common/queue/RedMarkerQueue.ned
+++ b/src/inet/common/queue/RedMarkerQueue.ned
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2019 Marcel Marek
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+// Author
+
+package inet.common.queue;
+
+import inet.common.queue.RedMarker;
+import inet.common.queue.FifoQueue;
+import inet.common.queue.IOutputQueue;
+
+
+module RedMarkerQueue like IOutputQueue
+{
+    gates:
+        input in;
+        output out;
+
+    submodules:
+        red: RedMarker;
+        fifo: FifoQueue;
+    connections:
+        in --> red.in[0];
+        red.out[0] --> fifo.in++;
+        fifo.out --> out;
+}

--- a/src/inet/networklayer/common/EcnTag.msg
+++ b/src/inet/networklayer/common/EcnTag.msg
@@ -7,6 +7,12 @@ import inet.common.TagBase;
 
 namespace inet;
 
+enum IpEcnCode {
+  IP_ECN_NOT_ECT = 0;
+  IP_ECN_ECT_1 = 1;
+  IP_ECN_ECT_0 = 2;
+  IP_ECN_CE = 3;
+}
 //
 // This is an abstract base class that should not be directly added as a tag.
 //

--- a/src/inet/transportlayer/tcp/Tcp.ned
+++ b/src/inet/transportlayer/tcp/Tcp.ned
@@ -209,6 +209,7 @@ simple Tcp like ITcp
         string tcpAlgorithmClass @enum("TcpVegas", "TcpWestwood", "TcpNewReno", "TcpReno", "TcpTahoe", "TcpNoCongestionControl") = default("TcpReno");
         bool recordStats = default(true); // recording of seqNum etc. into output vectors enabled/disabled
         bool useDataNotification = default(false); // turn the notifications for arrived data on or off
+        bool ecnEnabled = default(false);
         @display("i=block/wheelbarrow");
         @signal[tcpConnectionAdded];
         @signal[tcpConnectionRemoved];

--- a/src/inet/transportlayer/tcp/TcpConnection.h
+++ b/src/inet/transportlayer/tcp/TcpConnection.h
@@ -113,6 +113,13 @@ enum TcpEventCode {
     // are handled in TcpAlgorithm.
 };
 
+enum IpEcnCode {
+  IP_ECN_NOT_ECT,
+  IP_ECN_ECT_1,
+  IP_ECN_ECT_0,
+  IP_ECN_CE,
+};
+
 /** @name Timeout values */
 //@{
 #define TCP_TIMEOUT_CONN_ESTAB        75  // 75 seconds
@@ -261,6 +268,12 @@ class INET_API TcpStateVariables : public cObject
     uint32 usedRcvBuffer;    // current amount of used bytes in tcp receive queue
     uint32 freeRcvBuffer;    // current amount of free bytes in tcp receive queue
     uint32 tcpRcvQueueDrops;    // number of drops in tcp receive queue
+
+    bool ecnEnabled; // the user requests it
+    bool ecnSetupSynReceived; // indicates the next ACK-SYN should have ECN-setup (ECE = 1; CRW = 0) set
+    bool ecnActive; // ecn echoing is used on this connection (assumes ecnEnabled=true and successful handshake)
+
+    bool ecnCe;
 };
 
 /**

--- a/src/inet/transportlayer/tcp/TcpConnectionBase.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionBase.cc
@@ -117,6 +117,12 @@ TcpStateVariables::TcpStateVariables()
     tcpRcvQueueDrops = 0;
     sendQueueLimit = 0;
     queueUpdate = true;
+
+    ecnEnabled = false; // RFC 3168
+    ecnSetupSynReceived = false;
+    ecnActive = false;
+
+    ecnCe = false;
 }
 
 std::string TcpStateVariables::str() const

--- a/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
@@ -25,6 +25,7 @@
 #include "inet/transportlayer/tcp/TcpSackRexmitQueue.h"
 #include "inet/transportlayer/tcp/TcpReceiveQueue.h"
 #include "inet/transportlayer/tcp/TcpAlgorithm.h"
+#include "inet/networklayer/common/EcnTag_m.h"
 
 namespace inet {
 
@@ -480,6 +481,11 @@ TcpEventCode TcpConnection::processSegment1stThru8th(Packet *packet, const Ptr<c
         //"
 
         if (payloadLength > 0) {
+          auto ecnTag = packet->findTag<EcnInd>();
+
+          if (ecnTag->getExplicitCongestionNotification() == IP_ECN_CE){
+             state->ecnCe = true;
+          }
             // check for full sized segment
             if ((uint32_t)payloadLength == state->snd_mss || (uint32_t)payloadLength + B(tcpseg->getHeaderLength() - TCP_MIN_HEADER_LENGTH).get() == state->snd_mss)
                 state->full_sized_segment_counter++;
@@ -817,6 +823,12 @@ TcpEventCode TcpConnection::processSegmentInListen(Packet *packet, const Ptr<con
         if (tcpseg->getHeaderLength() > TCP_MIN_HEADER_LENGTH) // Header options present?
             readHeaderOptions(tcpseg);
 
+        if (state->ecnEnabled && (tcpseg->getEceBit() && tcpseg->getCwrBit()))
+        {
+          state->ecnSetupSynReceived = true;
+          state->ecnActive = true;
+        }
+
         state->ack_now = true;
         sendSynAck();
         startSynRexmitTimer();
@@ -1008,6 +1020,13 @@ TcpEventCode TcpConnection::processSegmentInSynSent(Packet *packet, const Ptr<co
 
             if (tcpseg->getHeaderLength() > TCP_MIN_HEADER_LENGTH) // Header options present?
                 readHeaderOptions(tcpseg);
+
+            //RFC 3168 - ECN enabled and received ECN-setup SYN-ACK packet
+            //ECN setup -> ECE = 1; CRW = 0
+            if (state->ecnEnabled && (tcpseg->getEceBit() && !tcpseg->getCwrBit()))
+            {
+              state->ecnActive = true;
+            }
 
             // notify tcpAlgorithm (it has to send ACK of SYN) and app layer
             state->ack_now = true;

--- a/src/inet/transportlayer/tcp_common/TcpHeader.cc
+++ b/src/inet/transportlayer/tcp_common/TcpHeader.cc
@@ -78,6 +78,14 @@ std::string TcpHeader::str() const
     static const char *flagEnd = "]";
     stream << getSrcPort() << "->" << getDestPort();
     const char *separ = flagStart;
+    if (getCwrBit()) {
+        stream << separ << "Cwr";
+        separ = flagSepar;
+    }
+    if (getEceBit()) {
+        stream << separ << "Ece";
+        separ = flagSepar;
+    }
     if (getUrgBit()) {
         stream << separ << "Urg=" << getUrgentPointer();
         separ = flagSepar;

--- a/src/inet/transportlayer/tcp_common/TcpHeader.msg
+++ b/src/inet/transportlayer/tcp_common/TcpHeader.msg
@@ -207,6 +207,8 @@ class TcpHeader extends TransportHeaderBase
     // if header options are used the headerLength is greater than 20 bytes (default)
     B headerLength = TCP_MIN_HEADER_LENGTH; // TCP_MIN_HEADER_LENGTH = 20 bytes
 
+	bool cwrBit; // CWR: congestion window reduced (RFC 3168)
+	bool eceBit; // ECE: ECN-echo (RFC 3168)
     bool urgBit; // URG: urgent pointer field significant if set
     bool ackBit; // ACK: ackNo significant if set
     bool pshBit; // PSH: push function

--- a/src/inet/transportlayer/tcp_common/TcpHeaderSerializer.cc
+++ b/src/inet/transportlayer/tcp_common/TcpHeaderSerializer.cc
@@ -56,7 +56,12 @@ void TcpHeaderSerializer::serialize(MemoryOutputStream& stream, const Ptr<const 
     if (tcpHeader->getAckBit())
         flags |= TH_ACK;
     if (tcpHeader->getUrgBit())
-        flags |= TH_URG;
+            flags |= TH_URG;
+    if (tcpHeader->getEceBit())
+            flags |= TH_ECE;
+    if (tcpHeader->getCwrBit())
+            flags |= TH_CWR;
+
     tcp.th_flags = (TH_FLAGS & flags);
     tcp.th_win = htons(tcpHeader->getWindow());
     tcp.th_urp = htons(tcpHeader->getUrgentPointer());
@@ -179,6 +184,8 @@ const Ptr<Chunk> TcpHeaderSerializer::deserialize(MemoryInputStream& stream) con
     tcpHeader->setPshBit((flags & TH_PUSH) == TH_PUSH);
     tcpHeader->setAckBit((flags & TH_ACK) == TH_ACK);
     tcpHeader->setUrgBit((flags & TH_URG) == TH_URG);
+    tcpHeader->setEceBit((flags & TH_ECE) == TH_ECE);
+    tcpHeader->setCwrBit((flags & TH_CWR) == TH_CWR);
 
     tcpHeader->setWindow(ntohs(tcp.th_win));
 

--- a/src/inet/transportlayer/tcp_common/headers/tcphdr.h
+++ b/src/inet/transportlayer/tcp_common/headers/tcphdr.h
@@ -29,6 +29,8 @@ namespace tcp {
 #  define TH_PUSH    0x08
 #  define TH_ACK     0x10
 #  define TH_URG     0x20
+#  define TH_ECE     0x40
+#  define TH_CWR     0x80
 #define TH_FLAGS     0x3F
 
 struct tcphdr


### PR DESCRIPTION
Submitting RedMarker - module based on RedDropper (RED-Random Early Detection).



It supports only Eth2 -> Ipv4 encapsulation.
Marks only IPv4 packets with DiffServ two least significant bits - ECN bits - (Explicit Congestion Notification) - capability (IP_ECN_ECT_0 or IP_ECN_ECT_1;   ECT-> ECN Capable Transport).

It marks packet if avg queue lenght > maxth or random  when  minth < avg < maxth.
It drops packet when the current queue legth is bigger than max allowed size.

Traffic that is not supported (non-Eth2, Ipv6, Ipv4 without ECT) is handled by RedDropper - but packets are dropped only when exceeding max size.

1. I want to push it to INET upstream in case somebody else finds it useful.
2. It is the first step for integrating DataCenter TCP which uses ECN marks.
3. I want to get feedback on how to update packet mid-way (in-network) and correctly handle front and back offset with the (still new for me) INETv4 packet representation.

The resulting compound module RedMarkerQueue is used as follows:

**.router.eth[*].queue.typename       = "RedMarkerQueue"
**.router.eth[*].queue.red.wq         = 1 
**.router.eth[*].queue.red.minths     = "3" #"5"
**.router.eth[*].queue.red.maxths     = "4"  
**.router.eth[*].queue.red.maxps      = "1"
**.router.eth[*].queue.red.pkrates    = "833.3333"
**.router.eth[*].queue.red.frameQueueCapacity = 24 
