### PR TITLE
Fix hard limit check on queue length on RED dropper

### DIFF
--- a/src/inet/common/queue/RedDropper.cc
+++ b/src/inet/common/queue/RedDropper.cc
@@ -98,6 +98,12 @@ bool RedDropper::shouldDrop(cPacket *packet)
         avg = pow(1 - wq, m) * avg;
     }
 
+    if (queueLength >= maxth) {    // maxth is also the "hard" limit
+        EV << "Queue len " << queueLength << " >= maxth, dropping packet.\n";
+        count[i] = 0;
+        return true;
+    }
+    
     if (minth <= avg && avg < maxth)
     {
         count[i]++;
@@ -112,11 +118,6 @@ bool RedDropper::shouldDrop(cPacket *packet)
     }
     else if (avg >= maxth) {
         EV << "Avg queue len " << avg << " >= maxth, dropping packet.\n";
-        count[i] = 0;
-        return true;
-    }
-    else if (queueLength >= maxth) {    // maxth is also the "hard" limit
-        EV << "Queue len " << queueLength << " >= maxth, dropping packet.\n";
         count[i] = 0;
         return true;
     }


### PR DESCRIPTION
Corrected bug in original code. The hard limit on the instantaneous queue length (queueLength) has to be checked independently of the conditions on the average queue length (avg). Otherwise, the hard limit is not respected when minth < avg < maxth and queueLength > maxth.