### PR TITLE
Pull ospfv2 nexthop

### DIFF
--- a/src/inet/routing/ospfv2/router/Ospfv2RoutingTableEntry.cc
+++ b/src/inet/routing/ospfv2/router/Ospfv2RoutingTableEntry.cc
@@ -45,8 +45,8 @@ Ospfv2RoutingTableEntry::Ospfv2RoutingTableEntry(const Ospfv2RoutingTableEntry& 
 {
     setDestination(entry.getDestination());
     setNetmask(entry.getNetmask());
-    setGateway(entry.getGateway());
     setInterface(entry.getInterface());
+    setGateway(entry.getGateway());
     setSourceType(entry.getSourceType());
     setMetric(entry.getMetric());
     setAdminDist(entry.getAdminDist());

--- a/src/inet/routing/ospfv2/router/Ospfv2RoutingTableEntry.cc
+++ b/src/inet/routing/ospfv2/router/Ospfv2RoutingTableEntry.cc
@@ -61,6 +61,12 @@ void Ospfv2RoutingTableEntry::addNextHop(NextHop hop)
         // TODO: this used to be commented out, but it seems we need it
         // otherwise gateways will never be filled in and gateway is needed for broadcast networks
         setGateway(hop.hopAddress);
+    }else{
+      for(int i= 0; i < nextHops.size(); i++){
+        if(hop.ifIndex == nextHops.at(i).ifIndex && hop.hopAddress == nextHops.at(i).hopAddress){
+          return;
+        }
+      }
     }
     nextHops.push_back(hop);
 }


### PR DESCRIPTION
The next-hop being added has to have different Address (hopAddress)
or it has to be connected through different interface (ifIndex).
It allows to have two entries for the same next-hop if the next-hop(IP Address)
is reachable through multiple interfaces (further connected through
hubs/switches ...).