### PR TITLE
Tcp: Removed TODO; Updated comment

### DIFF
--- a/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
@@ -780,9 +780,7 @@ TcpEventCode TcpConnection::processSegmentInListen(Packet *packet, const Ptr<con
         // LISTENing on the port. Note: forking will change our socketId.
         //
         if (state->fork) {
-            // TODO maybe change the code: current connection stay listening and created connection will be used for communication???
-
-            TcpConnection *conn = cloneListeningConnection();    // "conn" is the clone which will stay LISTENing, while "this" gets updated with the remote address
+            TcpConnection *conn = cloneListeningConnection();    // "conn" is the clone which will handle the new connection, while "this" stay LISTENing
             tcpMain->addForkedConnection(this, conn, destAddr, srcAddr, tcpseg->getDestPort(), tcpseg->getSrcPort());
             EV_DETAIL << "Connection forked: new connection got new socketId=" << conn->socketId << ", "
                                                                                            "old connection keeps LISTENing with socketId=" << socketId << "\n";


### PR DESCRIPTION
The TODO is already DONE;
Updated the comment to reflect that.
The clone handles the new connection and the (old) listening connection stays LISTENing.
#497 