### PR TITLE
Ieee802154Mac: remove subscription of an unused radio signal

### DIFF
--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
@@ -106,7 +106,6 @@ void Ieee802154Mac::initialize(int stage)
     }
     else if (stage == INITSTAGE_LINK_LAYER) {
         cModule *radioModule = getModuleFromPar<cModule>(par("radioModule"), this);
-        radioModule->subscribe(IRadio::radioModeChangedSignal, this);
         radioModule->subscribe(IRadio::transmissionStateChangedSignal, this);
         radio = check_and_cast<IRadio *>(radioModule);
 


### PR DESCRIPTION
The signal is not used anywhere in the hierachy of the module.