### PR TITLE
Ieee802154Mac: statistic recording of the number of failed transmission attempts

### DIFF
--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
@@ -345,13 +345,16 @@ void Ieee802154Mac::updateStatusCCA(t_mac_event event, cMessage *msg)
     switch (event) {
         case EV_TIMER_CCA: {
             EV_DETAIL << "(25) FSM State CCA_3, EV_TIMER_CCA" << endl;
+
+            if (currentTxFrame == nullptr)
+		popTxQueue();
+
             bool isIdle = radio->getReceptionState() == IRadio::RECEPTION_STATE_IDLE;
             if (isIdle) {
                 EV_DETAIL << "(3) FSM State CCA_3, EV_TIMER_CCA, [Channel Idle]: -> TRANSMITFRAME_4." << endl;
                 updateMacState(TRANSMITFRAME_4);
                 radio->setRadioMode(IRadio::RADIO_MODE_TRANSMITTER);
-                if (currentTxFrame == nullptr)
-                    popTxQueue();
+
                 Packet *mac = currentTxFrame->dup();
                 attachSignal(mac, simTime() + aTurnaroundTime);
                 //sendDown(msg);


### PR DESCRIPTION
Frames are taken from the queue only if CCA successes, that is why the `currentTxFrame` has `nullptr` alway before the condition `if(currentTxFrame)` is verified for incrementing `nbDroppedFrame`. I think this is clearly an issue. 

Furthermore,  taking frames from the queue if and only if CCA successes imply never drop a frame in the head of the line of the queue until get transmitted, this simulates a queue of "infinite" length. I do not know if this was intended in the model, but I remarked that this affects positively packet loss rates on the link compared to this new approach (carried by this pull request) consisting of popping frames from the queue regardless if CCA will success or fail.