### PR TITLE
use deleteModule() to delete cSimpleModule

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/channelaccess/Edca.cc
+++ b/src/inet/linklayer/ieee80211/mac/channelaccess/Edca.cc
@@ -79,8 +79,6 @@ void Edca::releaseChannelAccess(AccessCategory ac, IChannelAccess::ICallback* ca
 
 Edca::~Edca()
 {
-    for (int i = 0; i < numEdcafs; i++)
-        delete edcafs[i];
     delete[] edcafs;
 }
 


### PR DESCRIPTION
Pull request for v3.6.7-bis.

This seems to be necessary at least since OMNeT++ 5.6 to keep deleteModule() of a parent module from failing.