### PR TITLE
Ieee802154 lifecycle compatability

### DIFF
--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
@@ -449,7 +449,7 @@ void Ieee802154Mac::updateStatusCCA(t_mac_event event, cMessage *msg)
 
 void Ieee802154Mac::updateStatusTransmitFrame(t_mac_event event, cMessage *msg)
 {
-    if (event == EV_FRAME_TRANSMITTED) {
+    if (event == EV_FRAME_TRANSMITTED && currentTxFrame != nullptr) {
         //    delete msg;
         Packet *packet = currentTxFrame;
         const auto& csmaHeader = packet->peekAtFront<Ieee802154MacHeader>();

--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.cc
@@ -909,5 +909,30 @@ void Ieee802154Mac::decapsulate(Packet *packet)
     packet->addTagIfAbsent<PacketProtocolTag>()->setProtocol(payloadProtocol);
 }
 
+void Ieee802154Mac::handleStartOperation(LifecycleOperation *operation){
+    updateMacState(IDLE_1);
+    //manageQueue() to see waiting packets or set to idle if none
+    MacProtocolBase::handleStartOperation(operation);
+}
+
+void Ieee802154Mac::handleStopOperation(LifecycleOperation *operation) {
+    //TODO: More gracefully allow current Tx to end (delay operation)
+    //Cancel all self message timers
+    cancelEvent(backoffTimer);
+    cancelEvent(ccaTimer);
+    cancelEvent(sifsTimer);
+    cancelEvent(rxAckTimer);
+    MacProtocolBase::handleStopOperation(operation);
+}
+
+void Ieee802154Mac::handleCrashOperation(LifecycleOperation *operation) {
+    cancelEvent(backoffTimer);
+    cancelEvent(ccaTimer);
+    cancelEvent(sifsTimer);
+    cancelEvent(rxAckTimer);
+    MacProtocolBase::handleCrashOperation(operation);
+
+}
+
 } // namespace inet
 

--- a/src/inet/linklayer/ieee802154/Ieee802154Mac.h
+++ b/src/inet/linklayer/ieee802154/Ieee802154Mac.h
@@ -301,6 +301,11 @@ class INET_API Ieee802154Mac : public MacProtocolBase, public IMacProtocol
 
     virtual void decapsulate(Packet *packet);
 
+    // OperationalBase:
+    virtual void handleStartOperation(LifecycleOperation *operation) override;
+    virtual void handleStopOperation(LifecycleOperation *operation) override;
+    virtual void handleCrashOperation(LifecycleOperation *operation) override;
+
     Packet *ackMessage;
 
     //sequence number for sending, map for the general case with more senders


### PR DESCRIPTION
Two changes, the first to patch a null pointer access exception when currentTxFrame is accessed when deleted.

The second to implement the lifecycle operations.
On start, set to idle.
On stop delete all the timers