### PR TITLE
Dymo lifecycle compatibility

### DIFF
--- a/src/inet/routing/dymo/Dymo.cc
+++ b/src/inet/routing/dymo/Dymo.cc
@@ -1405,8 +1405,11 @@ void Dymo::handleStartOperation(LifecycleOperation *operation)
 void Dymo::handleStopOperation(LifecycleOperation *operation)
 {
     // TODO: send a RERR to notify peers about broken routes
-    for (auto & elem : targetAddressToRREQTimer)
+    for (auto & elem : targetAddressToRREQTimer){
         cancelRouteDiscovery(elem.first);
+        cancelRreqTimer(target);
+        eraseRreqTimer(target);
+    }
 }
 
 void Dymo::handleCrashOperation(LifecycleOperation *operation)

--- a/src/inet/routing/dymo/Dymo.cc
+++ b/src/inet/routing/dymo/Dymo.cc
@@ -1440,8 +1440,8 @@ void Dymo::handleStopOperation(LifecycleOperation *operation)
     // TODO: send a RERR to notify peers about broken routes
     for (auto & elem : targetAddressToRREQTimer){
         cancelRouteDiscovery(elem.first);
-        cancelRreqTimer(target);
-        eraseRreqTimer(target);
+        cancelRreqTimer(elem.first);
+        eraseRreqTimer(elem.first);
     }
     for (auto & pkt_timer : jitterTimerPacketMap){
         cancelJitterTimerPacket(pkt_timer.first);

--- a/src/inet/routing/dymo/Dymo.cc
+++ b/src/inet/routing/dymo/Dymo.cc
@@ -74,6 +74,9 @@ Dymo::~Dymo()
 {
     for (auto & elem : targetAddressToRREQTimer)
         cancelAndDelete(elem.second);
+    for (auto & pkt_timer : jitterTimerPacketMap){
+        cancelJitterTimerPacket(pkt_timer.first);
+    }
     cancelAndDelete(expungeTimer);
 }
 
@@ -164,6 +167,8 @@ void Dymo::processSelfMessage(cMessage *message)
         processRreqBackoffTimer(backoffTimer);
     else if (auto holddownTimer = dynamic_cast<RreqHolddownTimer *>(message))
         processRreqHolddownTimer(holddownTimer);
+    else if (auto jitterTimer = dynamic_cast<PacketJitterTimer *>(message))
+        processJitterTimerPacket(jitterTimer);
     else
         throw cRuntimeError("Unknown self message");
 }
@@ -381,12 +386,40 @@ void Dymo::processRreqHolddownTimer(RreqHolddownTimer *message)
 // handling Udp packets
 //
 
-void Dymo::sendUdpPacket(cPacket *packet, double delay)
+void Dymo::sendUdpPacket(cPacket *packet)
 {
+    send(packet, "ipOut");
+}
+
+void Dymo::scheduleJitterTimerPacket(cPacket *packet, double delay)
+{
+
     if (delay == 0)
-        send(packet, "ipOut");
-    else
-        sendDelayed(packet, delay, "ipOut");
+        sendUdpPacket(packet);
+    else{
+        PacketJitterTimer* message = new PacketJitterTimer("PacketJitterTimer");
+        jitterTimerPacketMap[message] = packet;
+        scheduleAt(simTime() + delay, message);
+    }
+}
+
+void Dymo::processJitterTimerPacket(PacketJitterTimer *msg)
+{
+    sendUdpPacket(jitterTimerPacketMap[msg]);
+    eraseJitterTimerPacket(msg);
+    delete msg;
+}
+
+void Dymo::cancelJitterTimerPacket(PacketJitterTimer *msg){
+    auto tt = jitterTimerPacketMap.find(msg);
+    delete tt->second;
+    cancelAndDelete(msg);
+    eraseJitterTimerPacket(msg);
+}
+
+void Dymo::eraseJitterTimerPacket(PacketJitterTimer *msg){
+    auto tt = jitterTimerPacketMap.find(msg);
+    jitterTimerPacketMap.erase(tt);
 }
 
 void Dymo::processUdpPacket(Packet *packet)
@@ -422,7 +455,7 @@ void Dymo::sendDymoPacket(const Ptr<DymoPacket>& packet, const InterfaceEntry *i
     udpPacket->addTag<HopLimitReq>()->setHopLimit(255);
     udpPacket->insertAtFront(udpHeader);
     udpPacket->insertAtBack(packet);
-    sendUdpPacket(udpPacket, delay);
+    scheduleJitterTimerPacket(udpPacket, delay);
 }
 
 void Dymo::processDymoPacket(Packet *packet, const Ptr<const DymoPacket>& dymoPacket)
@@ -1410,6 +1443,9 @@ void Dymo::handleStopOperation(LifecycleOperation *operation)
         cancelRreqTimer(target);
         eraseRreqTimer(target);
     }
+    for (auto & pkt_timer : jitterTimerPacketMap){
+        cancelJitterTimerPacket(pkt_timer.first);
+    }
 }
 
 void Dymo::handleCrashOperation(LifecycleOperation *operation)
@@ -1417,6 +1453,7 @@ void Dymo::handleCrashOperation(LifecycleOperation *operation)
     targetAddressToSequenceNumber.clear();
     targetAddressToRREQTimer.clear();
     targetAddressToDelayedPackets.clear();
+    jitterTimerPacketMap.clear();
 }
 
 //

--- a/src/inet/routing/dymo/Dymo.h
+++ b/src/inet/routing/dymo/Dymo.h
@@ -89,6 +89,7 @@ class INET_API Dymo : public RoutingProtocolBase, public cListener, public Netfi
     std::map<L3Address, DymoSequenceNumber> targetAddressToSequenceNumber;
     std::map<L3Address, RreqTimer *> targetAddressToRREQTimer;
     std::multimap<L3Address, Packet *> targetAddressToDelayedPackets;
+    std::map<PacketJitterTimer *, cPacket *> jitterTimerPacketMap;
     std::vector<std::pair<L3Address, int> > clientAddressAndPrefixLengthPairs;    // 5.3.  Router Clients and Client Networks
 
   public:
@@ -142,7 +143,11 @@ class INET_API Dymo : public RoutingProtocolBase, public cListener, public Netfi
     void processRreqHolddownTimer(RreqHolddownTimer *message);
 
     // handling Udp packets
-    void sendUdpPacket(cPacket *packet, double delay);
+    void sendUdpPacket(cPacket *packet);
+    void cancelJitterTimerPacket(PacketJitterTimer *msg);
+    void eraseJitterTimerPacket(PacketJitterTimer *msg);
+    void scheduleJitterTimerPacket(cPacket *packet, double delay);
+    void processJitterTimerPacket(PacketJitterTimer *msg);
     void processUdpPacket(Packet *packet);
 
     // handling Dymo packets

--- a/src/inet/routing/dymo/Dymo.msg
+++ b/src/inet/routing/dymo/Dymo.msg
@@ -79,6 +79,9 @@ message RreqBackoffTimer extends RreqTimer {
 message RreqHolddownTimer extends RreqTimer {
 }
 
+message PacketJitterTimer{
+}
+
 //
 // Dymo packets
 //

--- a/src/inet/routing/dymo/Dymo.ned
+++ b/src/inet/routing/dymo/Dymo.ned
@@ -68,7 +68,7 @@ simple Dymo like IManetRouting
         // double CONTROL_TRAFFIC_LIMIT
 
         // Dymo extension parameters
-        double maxJitter @unit(s) = default(10ms);
+        double maxJitter @unit(s) = default(10ms); // see IETF RFC5148 (Jitter Considerations in MANET)
         bool sendIntermediateRREP = default(true);
         int minHopLimit = default(5);
         int maxHopLimit = default(10);


### PR DESCRIPTION
Two changes to add Dymo Compatibility with lifecycleOperation

First, to cancel the ongoing timers for RReq when waiting reply.

Secondly, to counter the edge case described in https://github.com/inet-framework/inet/issues/527#issuecomment-635201245 Where the node shutsdown after sendDelayed to Ipv4 but before delivery of Udp control message. This requires a custom queue, implemented with a map of `<SelfMessage, UdpPacket>` where, on node shutdown, entries are deleted before being delivered.