### PR TITLE
Topic/pull dctcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ backups
 *~
 xxx
 /tmp/
+/.computed/
+*.DS_Store

--- a/examples/inet/dctcp/DcTcpIncast.ned
+++ b/examples/inet/dctcp/DcTcpIncast.ned
@@ -1,0 +1,122 @@
+//
+// author: Marcel Marek
+//
+
+package inet.examples.inet.dctcp;
+
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.Router;
+import inet.node.inet.StandardHost;
+import ned.DatarateChannel;
+
+
+network DcTcpIncast
+{
+    parameters:
+        @display("bgb=740,580");
+
+    types:
+        channel NormalP extends DatarateChannel
+        {
+            parameters:
+
+                per = 0;
+                ber = 0;
+        }
+
+
+    submodules:
+        routerCore: Router {
+            parameters:
+                @display("p=315,141;i=abstract/router");
+        }
+        client11: StandardHost {
+            @display("p=50,100");
+        }
+        client12: StandardHost {
+            @display("p=50,176");
+        }
+        client13: StandardHost {
+            @display("p=32,239");
+        }
+        client14: StandardHost {
+            @display("p=38,307");
+        }
+        client15: StandardHost {
+            @display("p=60.000004,359.23077");
+        }
+        client16: StandardHost {
+            @display("p=110.00001,404.6154");
+        }
+        client17: StandardHost {
+            @display("p=160.76924,430.00003");
+        }
+        client18: StandardHost {
+            @display("p=215.38463,455.38464");
+        }
+        client19: StandardHost {
+            @display("p=263.84616,463.07693");
+        }
+        client110: StandardHost {
+            @display("p=313.84616,468.46155");
+        }
+        client111: StandardHost {
+            @display("p=375.38464,469.23077");
+        }
+        client112: StandardHost {
+            @display("p=424.6154,470.00003");
+        }
+        client113: StandardHost {
+            @display("p=461.53848,457.69232");
+        }
+        client114: StandardHost {
+            @display("p=516.9231,429.23077");
+        }
+        client115: StandardHost {
+            @display("p=557.6923,406.15387");
+        }
+        client116: StandardHost {
+            @display("p=598,377");
+        }
+        client117: StandardHost {
+            @display("p=591,307");
+        }
+        client118: StandardHost {
+            @display("p=591,245");
+        }
+        client119: StandardHost {
+            @display("p=591,176");
+        }
+        client120: StandardHost {
+            @display("p=580,119");
+        }
+        configurator: Ipv4NetworkConfigurator {
+            @display("p=523.8462,35.384617");
+        }
+        client21: StandardHost {
+            @display("p=311.53848,27.692308");
+        }
+    connections:
+        routerCore.ethg++ <--> e1: NormalP <--> client11.ethg++;
+        routerCore.ethg++ <--> e2: NormalP <--> client12.ethg++;
+        routerCore.ethg++ <--> e3: NormalP <--> client13.ethg++;
+        routerCore.ethg++ <--> e4: NormalP <--> client14.ethg++;
+        routerCore.ethg++ <--> e5: NormalP <--> client15.ethg++;
+        routerCore.ethg++ <--> e6: NormalP <--> client16.ethg++;
+        routerCore.ethg++ <--> e7: NormalP <--> client17.ethg++;
+        routerCore.ethg++ <--> e8: NormalP <--> client18.ethg++;
+        routerCore.ethg++ <--> e9: NormalP <--> client19.ethg++;
+        routerCore.ethg++ <--> e10: NormalP <--> client110.ethg++;
+        routerCore.ethg++ <--> e11: NormalP <--> client111.ethg++;
+        routerCore.ethg++ <--> e12: NormalP <--> client112.ethg++;
+        routerCore.ethg++ <--> e13: NormalP <--> client113.ethg++;
+        routerCore.ethg++ <--> e14: NormalP <--> client114.ethg++;
+        routerCore.ethg++ <--> e15: NormalP <--> client115.ethg++;
+        routerCore.ethg++ <--> e16: NormalP <--> client116.ethg++;
+        routerCore.ethg++ <--> e17: NormalP <--> client117.ethg++;
+        routerCore.ethg++ <--> e18: NormalP <--> client118.ethg++;
+        routerCore.ethg++ <--> e19: NormalP <--> client119.ethg++;
+        routerCore.ethg++ <--> e20: NormalP <--> client120.ethg++;
+        routerCore.ethg++ <--> e21: NormalP <--> client21.ethg++;
+}
+

--- a/examples/inet/dctcp/omnetpp.ini
+++ b/examples/inet/dctcp/omnetpp.ini
@@ -1,0 +1,124 @@
+[General]
+
+network = DcTcpIncast
+
+parallel-simulation = false
+warnings = true
+#sim-time-limit = 3.3s
+
+#cmdenv-module-messages = true # for normal (non-express) mode only
+cmdenv-event-banners = true   # for normal (non-express) mode only
+
+tkenv-plugin-path = ../../../etc/plugins
+
+**.e*.datarate = 10Mbps
+**.e*.delay = 12ms
+
+#
+# Network specific settings
+#
+
+
+# ARP settings
+**.arp.typename = "GlobalArp"
+**.arp.retryTimeout = 1s
+**.arp.retryCount = 3
+**.arp.cacheTimeout = 100s
+
+
+**.tcp.delayedAcksEnabled = false                    # delayed ACK algorithm (RFC 1122) enabled/disabled
+**.tcp.nagleEnabled = false                           # Nagle's algorithm (RFC 896) enabled/disabled
+**.tcp.limitedTransmitEnabled = false                # Limited Transmit algorithm (RFC 3042) enabled/disabled (can be used for TCPReno/TCPTahoe/TCPNewReno/TCPNoCongestionControl)
+**.tcp.increasedIWEnabled = false                    # Increased Initial Window (RFC 3390) enabled/disabled
+**.tcp.sackSupport = false                            # Selective Acknowledgment (RFC 2018, 2883, 3517) support (header option) (SACK will be enabled for a connection if both endpoints support it)
+**.tcp.windowScalingSupport = true                  # Window Scale (RFC 1323) support (header option) (WS will be enabled for a connection if both endpoints support it)
+**.tcp.timestampSupport = false                      # Timestamps (RFC 1323) support (header option) (TS will be enabled for a connection if both endpoints support it)
+**.tcp.tcpAlgorithmClass = "DcTcp"                 # TCPReno/TCPTahoe/TCPNewReno/TCPNoCongestionControl/DumbTCP
+**.tcp.advertisedWindow = 350000
+**.tcp.recordStats = true
+**.tcp.mss = 1460
+**.tcp.ecnWillingness = true
+
+
+## tcp apps
+**.client21.numApps = 20
+**.client21.app[*].typename = "TcpSinkApp"
+**.client21.app[0].localPort = 1000
+**.client21.app[1].localPort = 1001
+**.client21.app[2].localPort = 1002
+**.client21.app[3].localPort = 1003
+**.client21.app[4].localPort = 1004
+**.client21.app[5].localPort = 1005
+**.client21.app[6].localPort = 1006
+**.client21.app[7].localPort = 1007
+**.client21.app[8].localPort = 1008
+**.client21.app[9].localPort = 1009
+**.client21.app[10].localPort = 10010
+**.client21.app[11].localPort = 10011
+**.client21.app[12].localPort = 10012
+**.client21.app[13].localPort = 10013
+**.client21.app[14].localPort = 10014
+**.client21.app[15].localPort = 10015
+**.client21.app[16].localPort = 10016
+**.client21.app[17].localPort = 10017
+**.client21.app[18].localPort = 10018
+**.client21.app[19].localPort = 10019
+#**.tcp.windowScalingSupport = true
+#**.tcp.advertisedWindow = 350000
+**.client1*.numApps = 1
+**.client1*.app[*].typename = "TcpSessionApp"
+**.client1*.app[0].active = true
+**.client1*.app[0].localPort = -1
+**.client1*.app[0].connectAddress = "client21"
+**.client1*.app[0].tOpen = 1s
+**.client1*.app[0].sendBytes = 10MiB
+**.client1*.app[0].sendScript = ""
+**.client1*.app[0].tClose = 0s
+
+
+**.client11.app[0].connectPort = 1000
+**.client12.app[0].connectPort = 1001
+**.client13.app[0].connectPort = 1002
+**.client14.app[0].connectPort = 1003
+**.client15.app[0].connectPort = 1004
+**.client16.app[0].connectPort = 1005
+**.client17.app[0].connectPort = 1006
+**.client18.app[0].connectPort = 1007
+**.client19.app[0].connectPort = 1008
+**.client110.app[0].connectPort = 1009
+**.client111.app[0].connectPort = 10010
+**.client112.app[0].connectPort = 10011
+**.client113.app[0].connectPort = 10012
+**.client114.app[0].connectPort = 10013
+**.client115.app[0].connectPort = 10014
+**.client116.app[0].connectPort = 10015
+**.client117.app[0].connectPort = 10016
+**.client118.app[0].connectPort = 10017
+**.client119.app[0].connectPort = 10018
+**.client120.app[0].connectPort = 10019
+
+
+
+#**.eth[*].queueType = "REDDropper"
+**.routerCore.eth[*].mac.queue.typename			= "RedDropperQueue"
+**.routerCore.eth[*].mac.queue.red.useEcn		= true
+**.routerCore.eth[*].mac.queue.red.wq			= 1.0
+**.routerCore.eth[*].mac.queue.red.minth		= 0
+**.routerCore.eth[*].mac.queue.red.maxth		= 6
+**.routerCore.eth[*].mac.queue.red.maxp			= 1.0
+**.routerCore.eth[*].mac.queue.red.pkrate		= 833.3333
+**.routerCore.eth[*].mac.queue.red.mark			= 1
+**.routerCore.eth[*].mac.queue.red.packetCapacity = 500
+
+
+
+
+############################################################## DCTCP-Incast
+[Config DcTcpIncast]
+**.client*.app[0].tSend = 62s
+
+
+[Config TcpRenoIncast]
+extends  = DcTcpIncast
+
+**.tcp.tcpAlgorithmClass = "TcpReno" 

--- a/examples/inet/redmarker/omnetpp.ini
+++ b/examples/inet/redmarker/omnetpp.ini
@@ -33,7 +33,7 @@ network = inet.examples.inet.redmarker.RedMarkerNetwork
 **.tcp.recordStats = true
 **.tcp.mss = 1460
 
-**.tcp.ecnEnabled = true   # This activates ECN (ECT - ECN Capable Transport) 
+**.tcp.ecnWillingness = true   # This activates ECN (ECT - ECN Capable Transport) 
 
 **.sender1.numApps = 1
 **.receiver1.numApps = 1

--- a/src/inet/transportlayer/tcp/Tcp.cc
+++ b/src/inet/transportlayer/tcp/Tcp.cc
@@ -171,8 +171,12 @@ void Tcp::handleLowerPacket(Packet *packet)
                 // This may be true only in receiver side. According to RFC 3168, page 20:
                 // pure acknowledgement packets (e.g., packets that do not contain
                 // any accompanying data) MUST be sent with the not-ECT codepoint.
-                if (ecn == 3)
+                if (ecn == 3){
                     state->gotCeIndication = true;
+                }
+                else {
+                    state->gotCeIndication = false;
+                }
             }
 
             bool ret = conn->processTCPSegment(packet, tcpHeader, srcAddr, destAddr);

--- a/src/inet/transportlayer/tcp/Tcp.ned
+++ b/src/inet/transportlayer/tcp/Tcp.ned
@@ -213,6 +213,7 @@ simple Tcp like ITcp
         double stopOperationExtraTime @unit(s) = default(0s);    // extra time after lifecycle stop operation finished
         double stopOperationTimeout @unit(s) = default(2s);    // timeout value for lifecycle stop operation
         bool ecnWillingness = default(false);	// true if willing to use ECN
+        double dctcpGamma = default(0.0625); // A fixed estimation gain for calculating dctcp_alpha (RFC 8257 4.2) 
         @display("i=block/wheelbarrow");
         @signal[tcpConnectionAdded];
         @signal[tcpConnectionRemoved];

--- a/src/inet/transportlayer/tcp/Tcp.ned
+++ b/src/inet/transportlayer/tcp/Tcp.ned
@@ -208,6 +208,7 @@ simple Tcp like ITcp
         int msl @unit(s) = default(120s);   // Maximum Segment Lifetime
         string tcpAlgorithmClass @enum("TcpVegas", "TcpWestwood", "TcpNewReno", "TcpReno", "TcpTahoe", "TcpNoCongestionControl") = default("TcpReno");
         bool useDataNotification = default(false); // turn the notifications for arrived data on or off
+        int dupthresh = default(3); // used for TcpTahoe, TcpReno and SACK (RFC 3517) DO NOT change unless you really know what you are doing
         double stopOperationExtraTime @unit(s) = default(0s);    // extra time after lifecycle stop operation finished
         double stopOperationTimeout @unit(s) = default(2s);    // timeout value for lifecycle stop operation
         bool ecnWillingness = default(false);	// true if willing to use ECN

--- a/src/inet/transportlayer/tcp/Tcp.ned
+++ b/src/inet/transportlayer/tcp/Tcp.ned
@@ -209,6 +209,7 @@ simple Tcp like ITcp
         string tcpAlgorithmClass @enum("TcpVegas", "TcpWestwood", "TcpNewReno", "TcpReno", "TcpTahoe", "TcpNoCongestionControl") = default("TcpReno");
         bool useDataNotification = default(false); // turn the notifications for arrived data on or off
         int dupthresh = default(3); // used for TcpTahoe, TcpReno and SACK (RFC 3517) DO NOT change unless you really know what you are doing
+        int initialSsthresh = default(0xFFFFFFFF); // initial value for Slow Start threshold used in TahoeRenoFamily. The initial value of ssthresh SHOULD be set arbitrarily high (e.g.,to the size of the largest possible advertised window) Without user interaction there is no limit...
         double stopOperationExtraTime @unit(s) = default(0s);    // extra time after lifecycle stop operation finished
         double stopOperationTimeout @unit(s) = default(2s);    // timeout value for lifecycle stop operation
         bool ecnWillingness = default(false);	// true if willing to use ECN

--- a/src/inet/transportlayer/tcp/TcpAlgorithm.h
+++ b/src/inet/transportlayer/tcp/TcpAlgorithm.h
@@ -182,6 +182,17 @@ class INET_API TcpAlgorithm : public cObject
      * to update state vars with new measured RTT value.
      */
     virtual void rttMeasurementCompleteUsingTS(uint32 echoedTS) = 0;
+
+    /**
+     * Called before sending ACK. Determines whether to set ECE bit.
+     */
+    virtual bool shouldMarkAck() = 0;
+
+    /**
+     * Called before processing segment in established state.
+     * This function process ECN marks.
+     */
+    virtual void processEcnInEstablished() = 0;
 };
 
 } // namespace tcp

--- a/src/inet/transportlayer/tcp/TcpConnection.h
+++ b/src/inet/transportlayer/tcp/TcpConnection.h
@@ -347,6 +347,7 @@ class INET_API TcpConnection : public cSimpleModule
     static simsignal_t sackedBytesSignal;    // current number of received sacked bytes
     static simsignal_t tcpRcvQueueBytesSignal;    // current amount of used bytes in tcp receive queue
     static simsignal_t tcpRcvQueueDropsSignal;    // number of drops in tcp receive queue
+    static simsignal_t tcpRcvPayloadBytesSignal;  // amount of payload bytes received (including duplicates, out of order etc) for TCP throughput
 
     // connection identification by apps: socketId
     int socketId = -1;    // identifies connection within the app

--- a/src/inet/transportlayer/tcp/TcpConnection.h
+++ b/src/inet/transportlayer/tcp/TcpConnection.h
@@ -124,7 +124,6 @@ enum TcpEventCode {
 
 #define MAX_SYN_REXMIT_COUNT          12  // will only be used with SYN+ACK: with SYN CONN_ESTAB occurs sooner
 #define TCP_MAX_WIN                   65535  // 65535 bytes, largest value (16 bit) for (unscaled) window size
-#define DUPTHRESH                     3  // used for TcpTahoe, TcpReno and SACK (RFC 3517)
 #define MAX_SACK_BLOCKS               60  // will only be used with SACK
 #define PAWS_IDLE_TIME_THRESH         (24 * 24 * 3600)  // 24 days in seconds (RFC 1323)
 
@@ -274,6 +273,8 @@ class INET_API TcpStateVariables : public cObject
     bool sndAck;               // set if sending Ack packet, used to set relevant info in controlInfo.
     bool rexmit;               // set if retransmitting data, used to send not-ECT codepoint (rfc3168, p. 20)
     simtime_t eceReactionTime; // records the time of the last ECE reaction
+
+    uint32 dupthresh; // used for TcpTahoe, TcpReno and SACK (RFC 3517)
 };
 
 /**

--- a/src/inet/transportlayer/tcp/TcpConnection.ned
+++ b/src/inet/transportlayer/tcp/TcpConnection.ned
@@ -49,6 +49,10 @@ simple TcpConnection {
         @signal[rttvar];    // will record RTT variance (rttvar)
         @signal[rto];    // will record retransmission timeout
         @signal[numRtos];    // will record total number of RTOs
+        
+        @signal[load];   // will record load (currently only with DcTcp)
+        @signal[calcLoad];    // will record calcLoad (currently only with DcTcp)
+        @signal[markingProb];   // will record marking probability (currently only with DcTcp)
 
         @statistic[state](record=vector; interpolationmode=sample-hold);
         @statistic[sndWnd](record=vector; interpolationmode=sample-hold);    // snd_wnd
@@ -76,5 +80,9 @@ simple TcpConnection {
         @statistic[rttvar](record=vector; interpolationmode=sample-hold);    // will record RTT variance (rttvar)
         @statistic[rto](record=vector; interpolationmode=sample-hold);    // will record retransmission timeout
         @statistic[numRtos](record=vector; interpolationmode=sample-hold);    // will record total number of RTOs
+        
+        @statistic[load](record=vector; interpolationmode=sample-hold);    // will record load (currently only with DcTcp)
+        @statistic[calcLoad](record=vector; interpolationmode=sample-hold);    // will record calcLoad (currently only with DcTcp)
+        @statistic[markingProb](record=vector; interpolationmode=sample-hold);    // will record marking probability (currently only with DcTcp)
 }
 

--- a/src/inet/transportlayer/tcp/TcpConnection.ned
+++ b/src/inet/transportlayer/tcp/TcpConnection.ned
@@ -39,6 +39,7 @@ simple TcpConnection {
         @signal[sackedBytes];    // current number of received sacked bytes
         @signal[tcpRcvQueueBytes];    // current amount of used bytes in tcp receive queue
         @signal[tcpRcvQueueDrops];    // number of drops in tcp receive queue
+        @signal[tcpRcvPayloadBytes];   // amount of payload bytes received (including duplicates, out of order etc) for TCP throughput
 
         //TcpAlgorithm signals:
         @signal[cwnd];    // will record changes to snd_cwnd

--- a/src/inet/transportlayer/tcp/TcpConnectionBase.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionBase.cc
@@ -51,7 +51,7 @@ simsignal_t TcpConnection::rcvNASegSignal = registerSignal("rcvNASeg");    // nu
 simsignal_t TcpConnection::sackedBytesSignal = registerSignal("sackedBytes");    // current number of received sacked bytes
 simsignal_t TcpConnection::tcpRcvQueueBytesSignal = registerSignal("tcpRcvQueueBytes");    // current amount of used bytes in tcp receive queue
 simsignal_t TcpConnection::tcpRcvQueueDropsSignal = registerSignal("tcpRcvQueueDrops");    // number of drops in tcp receive queue
-
+simsignal_t TcpConnection::tcpRcvPayloadBytesSignal = registerSignal("tcpRcvPayloadBytes");  // amount of payload bytes received (including duplicates, out of order etc) for TCP throughput
 
 TcpStateVariables::TcpStateVariables()
 {

--- a/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
@@ -135,6 +135,10 @@ bool TcpConnection::hasEnoughSpaceForSegmentInReceiveQueue(Packet *packet, const
 
 TcpEventCode TcpConnection::processSegment1stThru8th(Packet *packet, const Ptr<const TcpHeader>& tcpseg)
 {
+
+    // Delegates additional processing of ECN to the algorithm
+    tcpAlgorithm->processEcnInEstablished();
+
     //
     // RFC 793: first check sequence number
     //
@@ -1142,6 +1146,8 @@ bool TcpConnection::processAckInEstabEtc(Packet *packet, const Ptr<const TcpHead
         if (tcpseg->getEceBit() == true) {
             EV_INFO << "Received packet with ECE\n";
             state->gotEce = true;
+        }else{
+            state->gotEce = false;
         }
     }
 

--- a/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionRcvSegment.cc
@@ -95,6 +95,7 @@ TcpEventCode TcpConnection::process_RCV_SEGMENT(Packet *packet, const Ptr<const 
     emit(rcvSeqSignal, tcpseg->getSequenceNo());
     emit(rcvAckSignal, tcpseg->getAckNo());
 
+    emit(tcpRcvPayloadBytesSignal, int(packet->getByteLength() - B(tcpseg->getHeaderLength()).get()));
     //
     // Note: this code is organized exactly as RFC 793, section "3.9 Event
     // Processing", subsection "SEGMENT ARRIVES".

--- a/src/inet/transportlayer/tcp/TcpConnectionSackUtil.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionSackUtil.cc
@@ -142,8 +142,8 @@ bool TcpConnection::isLost(uint32 seqNum)
     // false."
     ASSERT(seqGE(seqNum, state->snd_una));    // HighAck = snd_una
 
-    bool isLost = (rexmitQueue->getNumOfDiscontiguousSacks(seqNum) >= DUPTHRESH    // DUPTHRESH = 3
-                   || rexmitQueue->getAmountOfSackedBytes(seqNum) >= (DUPTHRESH * state->snd_mss));
+    bool isLost = (rexmitQueue->getNumOfDiscontiguousSacks(seqNum) >= state->dupthresh    // DUPTHRESH = 3
+                   || rexmitQueue->getAmountOfSackedBytes(seqNum) >= (state->dupthresh * state->snd_mss));
 
     return isLost;
 }

--- a/src/inet/transportlayer/tcp/TcpConnectionUtil.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionUtil.cc
@@ -708,19 +708,10 @@ void TcpConnection::sendAck()
     // data packets) until it receives a CWR packet (a packet with the CWR
     // flag set).  After the receipt of the CWR packet, acknowledgments for
     // subsequent non-CE data packets do not have the ECN-Echo flag set.
+
     TcpStateVariables* state = getState();
     if (state && state->ect) {
-        if (state->gotCeIndication) {
-            EV_INFO << "Received CE... ";
-            if (state->ecnEchoState)
-                EV_INFO << "Already in ecnEcho state\n";
-            else {
-                state->ecnEchoState = true;
-                EV << "Entering ecnEcho state\n";
-            }
-            state->gotCeIndication = false;
-        }
-        if (state->ecnEchoState == true) {
+        if (tcpAlgorithm->shouldMarkAck()) {
             tcpseg->setEceBit(true);
             EV_INFO << "In ecnEcho state... send ACK with ECE bit set\n";
         }

--- a/src/inet/transportlayer/tcp/TcpConnectionUtil.cc
+++ b/src/inet/transportlayer/tcp/TcpConnectionUtil.cc
@@ -450,6 +450,7 @@ void TcpConnection::initConnection(TcpOpenCommand *openCmd)
 
 void TcpConnection::configureStateVariables()
 {
+    state->dupthresh = tcpMain->par("dupthresh");
     long advertisedWindowPar = tcpMain->par("advertisedWindow");
     state->ws_support = tcpMain->par("windowScalingSupport");    // if set, this means that current host supports WS (RFC 1323)
     state->ws_manual_scale = tcpMain->par("windowScalingFactor"); // scaling factor (set manually) to help for Tcp validation

--- a/src/inet/transportlayer/tcp/flavours/DcTcp.cc
+++ b/src/inet/transportlayer/tcp/flavours/DcTcp.cc
@@ -1,0 +1,241 @@
+//
+// Copyright (C) 2004-2005 Andras Varga
+// Copyright (C) 2009 Thomas Reschka
+// Copyright (C) 2019-2020 Marcel Marek
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <algorithm>    // min,max
+#include "inet/transportlayer/tcp/flavours/DcTcp.h"
+#include "inet/transportlayer/tcp/Tcp.h"
+
+namespace inet {
+
+namespace tcp {
+
+Register_Class(DcTcp);
+
+simsignal_t DcTcp::loadSignal = cComponent::registerSignal("load"); // will record load
+simsignal_t DcTcp::calcLoadSignal = cComponent::registerSignal("calcLoad"); // will record total number of RTOs
+simsignal_t DcTcp::markingProbSignal = cComponent::registerSignal("markingProb"); // will record marking probability
+
+DcTcp::DcTcp() : TcpReno(),
+        state((DcTcpStateVariables *&)TcpAlgorithm::state)
+{
+}
+
+void DcTcp::initialize()
+{
+    TcpReno::initialize();
+    state->dctcp_gamma = conn->getTcpMain()->par("dctcpGamma");
+
+}
+
+void DcTcp::receivedDataAck(uint32 firstSeqAcked)
+{
+    TcpTahoeRenoFamily::receivedDataAck(firstSeqAcked);
+
+    if (state->dupacks >= state->dupthresh) {    // DUPTHRESH = 3
+        //
+        // Perform Fast Recovery: set cwnd to ssthresh (deflating the window).
+        //
+        EV_INFO << "Fast Recovery: setting cwnd to ssthresh=" << state->ssthresh << "\n";
+        state->snd_cwnd = state->ssthresh;
+
+        conn->emit(cwndSignal, state->snd_cwnd);
+    }
+    else {
+        bool performSsCa = true; //Stands for: "perform slow start and congestion avoidance"
+        if (state && state->ect){
+            // RFC 8257 3.3.1
+            uint32 bytes_acked = state->snd_una - firstSeqAcked;
+
+            bool cut = false;
+
+            // RFC 8257 3.3.2
+            state->dctcp_bytesAcked += bytes_acked;
+
+            // RFC 8257 3.3.3
+            if (state->gotEce) {
+                state->dctcp_bytesMarked += bytes_acked;
+                conn->emit(markingProbSignal, 1);
+            }
+            else{
+                conn->emit(markingProbSignal, 0);
+            }
+
+
+            // RFC 8257 3.3.4
+            if(state->snd_una > state->dctcp_windEnd){
+
+                if (state->dctcp_bytesMarked){
+                    cut = true;
+                }
+
+                // RFC 8257 3.3.5
+                double ratio;
+
+                ratio = ((double)state->dctcp_bytesMarked / state->dctcp_bytesAcked);
+                conn->emit(loadSignal, ratio);
+
+                // RFC 8257 3.3.6
+                // DCTCP.Alpha = DCTCP.Alpha * (1 - g) + g * M
+                state->dctcp_alpha = state->dctcp_alpha * (1 - state->dctcp_gamma) + state->dctcp_gamma * ratio;
+                conn->emit(calcLoadSignal, state->dctcp_alpha);
+
+                // RFC 8257 3.3.7
+                state->dctcp_windEnd = state->snd_nxt;
+
+                // RFC 8257 3.3.8
+                state->dctcp_bytesAcked = state->dctcp_bytesMarked = 0;
+                state->sndCwr = false;
+
+            }
+
+            // Applying DcTcp style cwnd update only if there was congestion and the window has not yet been reduced during current interval
+            if ((state->dctcp_bytesMarked && !state->sndCwr)) {
+
+                performSsCa = false;
+                state->sndCwr = true;
+
+                //RFC 8257 3.3.9
+                state->snd_cwnd = state->snd_cwnd * (1 - state->dctcp_alpha / 2);
+
+                conn->emit(cwndSignal, state->snd_cwnd);
+
+                uint32 flight_size = std::min(state->snd_cwnd, state->snd_wnd); // FIXME TODO - Does this formula computes the amount of outstanding data?
+                state->ssthresh = std::max(3 * flight_size / 4, 2 * state->snd_mss);
+
+                conn->emit(ssthreshSignal, state->ssthresh);
+
+            }
+        }
+
+        if (performSsCa) {
+            // If ECN is not enabled or if ECN is enabled and received multiple ECE-Acks in
+            // less than RTT, then perform slow start and congestion avoidance.
+
+            if (state->snd_cwnd < state->ssthresh) {
+                EV_INFO << "cwnd <= ssthresh: Slow Start: increasing cwnd by one SMSS bytes to ";
+
+                // perform Slow Start. RFC 2581: "During slow start, a TCP increments cwnd
+                // by at most SMSS bytes for each ACK received that acknowledges new data."
+                state->snd_cwnd += state->snd_mss;
+
+                conn->emit(cwndSignal, state->snd_cwnd);
+                conn->emit(ssthreshSignal, state->ssthresh);
+
+                EV_INFO << "cwnd=" << state->snd_cwnd << "\n";
+            }
+            else {
+                // perform Congestion Avoidance (RFC 2581)
+                uint32 incr = state->snd_mss * state->snd_mss / state->snd_cwnd;
+
+                if (incr == 0)
+                    incr = 1;
+
+                state->snd_cwnd += incr;
+
+                conn->emit(cwndSignal, state->snd_cwnd);
+                conn->emit(ssthreshSignal, state->ssthresh);
+
+                //
+                // Note: some implementations use extra additive constant mss / 8 here
+                // which is known to be incorrect (RFC 2581 p5)
+                //
+                // Note 2: RFC 3465 (experimental) "Appropriate Byte Counting" (ABC)
+                // would require maintaining a bytes_acked variable here which we don't do
+                //
+
+                EV_INFO << "cwnd > ssthresh: Congestion Avoidance: increasing cwnd linearly, to " << state->snd_cwnd << "\n";
+            }
+        }
+    }
+
+    if (state->sack_enabled && state->lossRecovery) {
+        // RFC 3517, page 7: "Once a TCP is in the loss recovery phase the following procedure MUST
+        // be used for each arriving ACK:
+        //
+        // (A) An incoming cumulative ACK for a sequence number greater than
+        // RecoveryPoint signals the end of loss recovery and the loss
+        // recovery phase MUST be terminated.  Any information contained in
+        // the scoreboard for sequence numbers greater than the new value of
+        // HighACK SHOULD NOT be cleared when leaving the loss recovery
+        // phase."
+        if (seqGE(state->snd_una, state->recoveryPoint)) {
+            EV_INFO << "Loss Recovery terminated.\n";
+            state->lossRecovery = false;
+        }
+        // RFC 3517, page 7: "(B) Upon receipt of an ACK that does not cover RecoveryPoint the
+        //following actions MUST be taken:
+        //
+        // (B.1) Use Update () to record the new SACK information conveyed
+        // by the incoming ACK.
+        //
+        // (B.2) Use SetPipe () to re-calculate the number of octets still
+        // in the network."
+        else {
+            // update of scoreboard (B.1) has already be done in readHeaderOptions()
+            conn->setPipe();
+
+            // RFC 3517, page 7: "(C) If cwnd - pipe >= 1 SMSS the sender SHOULD transmit one or more
+            // segments as follows:"
+            if (((int)state->snd_cwnd - (int)state->pipe) >= (int)state->snd_mss) // Note: Typecast needed to avoid prohibited transmissions
+                conn->sendDataDuringLossRecoveryPhase(state->snd_cwnd);
+        }
+    }
+
+    // RFC 3517, pages 7 and 8: "5.1 Retransmission Timeouts
+    // (...)
+    // If there are segments missing from the receiver's buffer following
+    // processing of the retransmitted segment, the corresponding ACK will
+    // contain SACK information.  In this case, a TCP sender SHOULD use this
+    // SACK information when determining what data should be sent in each
+    // segment of the slow start.  The exact algorithm for this selection is
+    // not specified in this document (specifically NextSeg () is
+    // inappropriate during slow start after an RTO).  A relatively
+    // straightforward approach to "filling in" the sequence space reported
+    // as missing should be a reasonable approach."
+    sendData(false);
+}
+
+bool DcTcp::shouldMarkAck()
+{
+    // RFC 8257 3.2 page 6
+    // When sending an ACK, the ECE flag MUST be set if and only if DCTCP.CE is true.
+    return state->dctcp_ce;
+}
+
+void DcTcp::processEcnInEstablished()
+{
+    if(state && state->ect){
+    // RFC 8257 3.2.1
+        if(state->gotCeIndication && !state->dctcp_ce){
+            state->dctcp_ce = true;
+            state->ack_now = true;
+        }
+
+        // RFC 8257 3.2.2
+        if(!state->gotCeIndication && state->dctcp_ce){
+            state->dctcp_ce = false;
+            state->ack_now = true;
+        }
+    }
+}
+
+} // namespace tcp
+
+} // namespace inet
+

--- a/src/inet/transportlayer/tcp/flavours/DcTcp.h
+++ b/src/inet/transportlayer/tcp/flavours/DcTcp.h
@@ -1,0 +1,73 @@
+//
+// Copyright (C) 2004 Andras Varga
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_DCTCP_H
+#define __INET_DCTCP_H
+
+#include "inet/common/INETDefs.h"
+
+#include "inet/transportlayer/tcp/flavours/TcpReno.h"
+#include "inet/transportlayer/tcp/flavours/DcTcpFamily.h"
+
+namespace inet {
+
+namespace tcp {
+/**
+ * State variables for DcTcp.
+ */
+typedef DcTcpFamilyStateVariables DcTcpStateVariables;
+
+/**
+ * Implements DCTCP.
+ */
+class INET_API DcTcp : public TcpReno
+{
+protected:
+    DcTcpStateVariables *& state;
+
+    static simsignal_t loadSignal; // will record load
+    static simsignal_t calcLoadSignal; // will record total number of RTOs
+    static simsignal_t markingProbSignal; // will record marking probability
+
+    /** Create and return a DcTcpStateVariables object. */
+    virtual TcpStateVariables *createStateVariables() override
+    {
+        return new DcTcpStateVariables();
+    }
+
+    virtual void initialize() override;
+
+  public:
+    /** Constructor */
+    DcTcp();
+
+    /** Redefine what should happen when data got acked, to add congestion window management */
+    virtual void receivedDataAck(uint32 firstSeqAcked) override;
+
+    virtual bool shouldMarkAck() override;
+
+    virtual void processEcnInEstablished() override;
+
+
+};
+
+} // namespace tcp
+
+} // namespace inet
+
+#endif // ifndef __INET_DCTCP_H
+

--- a/src/inet/transportlayer/tcp/flavours/DcTcpFamily.cc
+++ b/src/inet/transportlayer/tcp/flavours/DcTcpFamily.cc
@@ -1,0 +1,68 @@
+//
+// Copyright (C) 2020 Marcel Marek
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "inet/transportlayer/tcp/Tcp.h"
+#include "inet/transportlayer/tcp/flavours/DcTcpFamily.h"
+
+namespace inet {
+namespace tcp {
+
+DcTcpFamilyStateVariables::DcTcpFamilyStateVariables()
+{
+    dctcp_ce = false;
+    dctcp_alpha = 0;
+    dctcp_windEnd = snd_una;
+    dctcp_bytesAcked = 0;
+    dctcp_bytesMarked = 0;
+    dctcp_gamma = 0.0625;   // 1/16 (backup 0.16) TODO make it NED parameter;
+}
+
+std::string DcTcpFamilyStateVariables::str() const
+{
+    std::stringstream out;
+    out << TcpTahoeRenoFamilyStateVariables::str();
+    out << " dctcp_alpha=" << dctcp_alpha;
+    out << " dctcp_windEnd=" << dctcp_windEnd;
+    out << " dctcp_bytesAcked=" << dctcp_bytesAcked;
+    out << " dctcp_bytesMarked=" << dctcp_bytesMarked;
+    out << " dctcp_gamma=" << dctcp_gamma;
+
+    return out.str();
+}
+
+std::string DcTcpFamilyStateVariables::detailedInfo() const
+{
+    std::stringstream out;
+    out << TcpTahoeRenoFamilyStateVariables::detailedInfo();
+    out << " dctcp_alpha=" << dctcp_alpha;
+    out << " dctcp_windEnd=" << dctcp_windEnd;
+    out << " dctcp_bytesAcked=" << dctcp_bytesAcked;
+    out << " dctcp_bytesMarked=" << dctcp_bytesMarked;
+    out << " dctcp_gamma=" << dctcp_gamma;
+    return out.str();
+}
+
+//---
+
+DcTcpFamily::DcTcpFamily() : TcpTahoeRenoFamily(),
+    state((DcTcpFamilyStateVariables *&)TcpTahoeRenoFamily::state)
+{
+}
+
+} // namespace tcp
+} // namespace inet
+

--- a/src/inet/transportlayer/tcp/flavours/DcTcpFamily.h
+++ b/src/inet/transportlayer/tcp/flavours/DcTcpFamily.h
@@ -1,0 +1,65 @@
+//
+// Copyright (C) 2020 Marcel Marek
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef __INET_DCTCPFAMILY_H
+#define __INET_DCTCPFAMILY_H
+
+#include "inet/common/INETDefs.h"
+#include "inet/transportlayer/tcp/flavours/TcpTahoeRenoFamily.h"
+
+namespace inet {
+namespace tcp {
+
+/**
+ * State variables for DcTcp.
+ */
+class INET_API DcTcpFamilyStateVariables : public TcpTahoeRenoFamilyStateVariables
+{
+  public:
+    DcTcpFamilyStateVariables();
+    virtual std::string str() const override;
+    virtual std::string detailedInfo() const override;
+
+    //DCTCP
+    bool dctcp_ce;
+    uint32 dctcp_windEnd;
+    uint32 dctcp_bytesAcked;
+    uint32 dctcp_bytesMarked; //amount of bytes marked
+    double dctcp_alpha;
+    double dctcp_gamma;
+
+
+};
+
+/**
+ * Provides utility functions to implement DcTcp.
+ */
+class INET_API DcTcpFamily : public TcpTahoeRenoFamily
+{
+  protected:
+    DcTcpFamilyStateVariables *& state;    // alias to TcpAlgorithm's 'state'
+
+  public:
+    /** Ctor */
+    DcTcpFamily();
+};
+
+} // namespace tcp
+} // namespace inet
+
+#endif // ifndef __INET_DCTCPFAMILY_H
+

--- a/src/inet/transportlayer/tcp/flavours/DumbTcp.cc
+++ b/src/inet/transportlayer/tcp/flavours/DumbTcp.cc
@@ -134,6 +134,15 @@ void DumbTcp::rttMeasurementCompleteUsingTS(uint32 echoedTS)
 {
 }
 
+bool DumbTcp::shouldMarkAck()
+{
+    return false;
+}
+
+void DumbTcp::processEcnInEstablished()
+{
+
+}
 } // namespace tcp
 
 } // namespace inet

--- a/src/inet/transportlayer/tcp/flavours/DumbTcp.h
+++ b/src/inet/transportlayer/tcp/flavours/DumbTcp.h
@@ -89,6 +89,10 @@ class INET_API DumbTcp : public TcpAlgorithm
     virtual void restartRexmitTimer() override;
 
     virtual void rttMeasurementCompleteUsingTS(uint32 echoedTS) override;
+
+    virtual bool shouldMarkAck() override;
+
+    virtual void processEcnInEstablished() override;
 };
 
 } // namespace tcp

--- a/src/inet/transportlayer/tcp/flavours/TcpBaseAlg.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpBaseAlg.cc
@@ -593,7 +593,7 @@ void TcpBaseAlg::receivedDuplicateAck()
     EV_INFO << "Duplicate ACK #" << state->dupacks << "\n";
 
     bool fullSegmentsOnly = state->nagle_enabled && state->snd_una != state->snd_max;
-    if (state->dupacks < DUPTHRESH && state->limited_transmit_enabled) // DUPTRESH = 3
+    if (state->dupacks < state->dupthresh && state->limited_transmit_enabled) // DUPTRESH = 3
         conn->sendOneNewSegment(fullSegmentsOnly, state->snd_cwnd); // RFC 3042
 
     //

--- a/src/inet/transportlayer/tcp/flavours/TcpBaseAlg.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpBaseAlg.cc
@@ -659,6 +659,43 @@ void TcpBaseAlg::restartRexmitTimer()
     startRexmitTimer();
 }
 
+bool TcpBaseAlg::shouldMarkAck()
+{
+
+    // rfc-3168, pages 19-20:
+    // When TCP receives a CE data packet at the destination end-system, the
+    // TCP data receiver sets the ECN-Echo flag in the TCP header of the
+    // subsequent ACK packet.
+    // ...
+    // After a TCP receiver sends an ACK packet with the ECN-Echo bit set,
+    // that TCP receiver continues to set the ECN-Echo flag in all the ACK
+    // packets it sends (whether they acknowledge CE data packets or non-CE
+    // data packets) until it receives a CWR packet (a packet with the CWR
+    // flag set).  After the receipt of the CWR packet, acknowledgments for
+    // subsequent non-CE data packets do not have the ECN-Echo flag set.
+
+    if (state && state->ect) {
+        if (state->gotCeIndication) {
+            EV_INFO << "Received CE... ";
+            if (state->ecnEchoState)
+                EV_INFO << "Already in ecnEcho state\n";
+            else {
+                state->ecnEchoState = true;
+                EV << "Entering ecnEcho state\n";
+            }
+            state->gotCeIndication = false;
+        }
+        return  state->ecnEchoState;
+    }
+}
+
+
+void TcpBaseAlg::processEcnInEstablished()
+{
+
+
+}
+
 } // namespace tcp
 } // namespace inet
 

--- a/src/inet/transportlayer/tcp/flavours/TcpBaseAlg.h
+++ b/src/inet/transportlayer/tcp/flavours/TcpBaseAlg.h
@@ -197,6 +197,10 @@ class INET_API TcpBaseAlg : public TcpAlgorithm
     virtual void segmentRetransmitted(uint32 fromseq, uint32 toseq) override;
 
     virtual void restartRexmitTimer() override;
+
+    virtual bool shouldMarkAck() override;
+
+    virtual void processEcnInEstablished() override;
 };
 
 } // namespace tcp

--- a/src/inet/transportlayer/tcp/flavours/TcpNewReno.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpNewReno.cc
@@ -260,7 +260,7 @@ void TcpNewReno::receivedDuplicateAck()
 {
     TcpTahoeRenoFamily::receivedDuplicateAck();
 
-    if (state->dupacks == DUPTHRESH) {    // DUPTHRESH = 3
+    if (state->dupacks == state->dupthresh) {    // DUPTHRESH = 3
         if (!state->lossRecovery) {
             // RFC 3782, page 4:
             // "1) Three duplicate ACKs:
@@ -323,7 +323,7 @@ void TcpNewReno::receivedDuplicateAck()
         }
         EV_INFO << "NewReno on dupAcks == DUPTHRESH(=3): TCP is already in Fast Recovery procedure\n";
     }
-    else if (state->dupacks > DUPTHRESH) {    // DUPTHRESH = 3
+    else if (state->dupacks > state->dupthresh) {    // DUPTHRESH = 3
         if (state->lossRecovery) {
             // RFC 3782, page 4:
             // "3) Fast Recovery:

--- a/src/inet/transportlayer/tcp/flavours/TcpReno.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpReno.cc
@@ -90,7 +90,7 @@ void TcpReno::receivedDataAck(uint32 firstSeqAcked)
 {
     TcpTahoeRenoFamily::receivedDataAck(firstSeqAcked);
 
-    if (state->dupacks >= DUPTHRESH) {    // DUPTHRESH = 3
+    if (state->dupacks >= state->dupthresh) {    // DUPTHRESH = 3
         //
         // Perform Fast Recovery: set cwnd to ssthresh (deflating the window).
         //
@@ -240,7 +240,7 @@ void TcpReno::receivedDuplicateAck()
 {
     TcpTahoeRenoFamily::receivedDuplicateAck();
 
-    if (state->dupacks == DUPTHRESH) {    // DUPTHRESH = 3
+    if (state->dupacks == state->dupthresh) {    // DUPTHRESH = 3
         EV_INFO << "Reno on dupAcks == DUPTHRESH(=3): perform Fast Retransmit, and enter Fast Recovery:";
 
         if (state->sack_enabled) {
@@ -329,7 +329,7 @@ void TcpReno::receivedDuplicateAck()
         // try to transmit new segments (RFC 2581)
         sendData(false);
     }
-    else if (state->dupacks > DUPTHRESH) {    // DUPTHRESH = 3
+    else if (state->dupacks > state->dupthresh) {    // DUPTHRESH = 3
         //
         // Reno: For each additional duplicate ACK received, increment cwnd by SMSS.
         // This artificially inflates the congestion window in order to reflect the

--- a/src/inet/transportlayer/tcp/flavours/TcpTahoe.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpTahoe.cc
@@ -119,7 +119,7 @@ void TcpTahoe::receivedDuplicateAck()
 {
     TcpTahoeRenoFamily::receivedDuplicateAck();
 
-    if (state->dupacks == DUPTHRESH) {    // DUPTHRESH = 3
+    if (state->dupacks == state->dupthresh) {    // DUPTHRESH = 3
         EV_DETAIL << "Tahoe on dupAcks == DUPTHRESH(=3): perform Fast Retransmit, and enter Slow Start:\n";
 
         // enter Slow Start

--- a/src/inet/transportlayer/tcp/flavours/TcpTahoeRenoFamily.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpTahoeRenoFamily.cc
@@ -23,10 +23,7 @@ namespace tcp {
 
 TcpTahoeRenoFamilyStateVariables::TcpTahoeRenoFamilyStateVariables()
 {
-    // The initial value of ssthresh SHOULD be set arbitrarily high (e.g.,
-    // to the size of the largest possible advertised window)
-    // Without user interaction there is no limit...
-    ssthresh = 0xFFFFFFFF;
+
 }
 
 void TcpTahoeRenoFamilyStateVariables::setSendQueueLimit(uint32 newLimit){
@@ -57,6 +54,14 @@ std::string TcpTahoeRenoFamilyStateVariables::detailedInfo() const
 TcpTahoeRenoFamily::TcpTahoeRenoFamily() : TcpBaseAlg(),
     state((TcpTahoeRenoFamilyStateVariables *&)TcpAlgorithm::state)
 {
+
+}
+
+void TcpTahoeRenoFamily::initialize()
+{
+    TcpBaseAlg::initialize();
+    state->ssthresh = conn->getTcpMain()->par("initialSsthresh");
+
 }
 
 } // namespace tcp

--- a/src/inet/transportlayer/tcp/flavours/TcpTahoeRenoFamily.h
+++ b/src/inet/transportlayer/tcp/flavours/TcpTahoeRenoFamily.h
@@ -50,6 +50,8 @@ class INET_API TcpTahoeRenoFamily : public TcpBaseAlg
   public:
     /** Ctor */
     TcpTahoeRenoFamily();
+
+    void initialize() override;
 };
 
 } // namespace tcp

--- a/src/inet/transportlayer/tcp/flavours/TcpVegas.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpVegas.cc
@@ -278,7 +278,7 @@ void TcpVegas::receivedDataAck(uint32 firstSeqAcked)
             // added comprobation to check that received ACK do not acks all outstanding data. If not,
             // TcpConnection::retransmitOneSegment will fail: ASSERT(bytes!=0), line 839), because bytes = snd_max-snd_una
             if (expired && (state->snd_max - state->snd_una > 0)) {
-                state->dupacks = DUPTHRESH;
+                state->dupacks = state->dupthresh;
                 EV_DETAIL << "Vegas: retransmission (v_rtt_timeout) " << "\n";
                 conn->retransmitOneSegment(false);    //retransmit one segment from snd_una
             }
@@ -311,7 +311,7 @@ void TcpVegas::receivedDuplicateAck()
     bool expired = found && ((currentTime - tSent) >= state->v_rtt_timeout);
 
     // rtx if Vegas timeout || 3 dupacks
-    if (expired || state->dupacks == DUPTHRESH) {    //DUPTHRESH = 3
+    if (expired || state->dupacks == state->dupthresh) {    //DUPTHRESH = 3
         uint32 win = std::min(state->snd_cwnd, state->snd_wnd);
         state->v_worried = std::min((uint32)2 * state->snd_mss, state->snd_nxt - state->snd_una);
 
@@ -345,10 +345,10 @@ void TcpVegas::receivedDuplicateAck()
         conn->retransmitOneSegment(false);
 
         if (found && num_transmits == 1)
-            state->dupacks = DUPTHRESH;
+            state->dupacks = state->dupthresh;
     }
     //else if dupacks > duphtresh, cwnd+1
-    else if (state->dupacks > DUPTHRESH) {    // DUPTHRESH = 3
+    else if (state->dupacks > state->dupthresh) {    // DUPTHRESH = 3
         state->snd_cwnd += state->snd_mss;
         conn->emit(cwndSignal, state->snd_cwnd);
     }

--- a/src/inet/transportlayer/tcp/flavours/TcpWestwood.cc
+++ b/src/inet/transportlayer/tcp/flavours/TcpWestwood.cc
@@ -153,7 +153,7 @@ void TcpWestwood::receivedDataAck(uint32 firstSeqAcked)
 
     // Same behavior of Reno during fast recovery, slow start and cong. avoidance
 
-    if (state->dupacks >= DUPTHRESH) {    // DUPTHRESH = 3
+    if (state->dupacks >= state->dupthresh) {    // DUPTHRESH = 3
         //
         // Perform Fast Recovery: set cwnd to ssthresh (deflating the window).
         //
@@ -224,7 +224,7 @@ void TcpWestwood::receivedDuplicateAck()
         recalculateBWE(cumul_ack);
     }    // Closes if w_sendtime != nullptr
 
-    if (state->dupacks == DUPTHRESH) {    // DUPTHRESH = 3
+    if (state->dupacks == state->dupthresh) {    // DUPTHRESH = 3
         EV_DETAIL << "Westwood on dupAcks == DUPTHRESH(=3): Faster Retransmit \n";
 
         // TCP Westwood: congestion control with faster recovery. S. Mascolo, C. Casetti, M. Gerla, S.S. Lee, M. Sanadidi
@@ -274,7 +274,7 @@ void TcpWestwood::receivedDuplicateAck()
         sendData(false);
     }
     // Behavior like Reno:
-    else if (state->dupacks > DUPTHRESH) {    // DUPTHRESH = 3
+    else if (state->dupacks > state->dupthresh) {    // DUPTHRESH = 3
         // Westwood: like Reno
         state->snd_cwnd += state->snd_mss;
         EV_DETAIL << "Westwood on dupAcks > DUPTHRESH(=3): Fast Recovery: inflating cwnd by SMSS, new cwnd=" << state->snd_cwnd << "\n";


### PR DESCRIPTION
This is a DCTCP implementation based on RFC 8257.

It based on the TCP Reno (slow start, fast retransmit, fast recovery, congestion avoidance).
In case of ECN (Explicit Congestion Notification) the DCTCP behaves differently than typical TCP.
Each ECN marked data packet is reflected in one Ack packet (normal TCP sends ECE marked Acks until it receives CWR). 

The sender then uses two equations to reduce cwnd
1. DCTCP.Alpha = DCTCP.Alpha * (1 - g) + g * M
where g is preconfigured variable and M is the ration of bytesMarked/bytesAcked.
and
2. cwnd = cwnd * (1 - DCTCP.Alpha / 2)

Also included is one scenario (Incast) with DcTcp config and TcpReno for easy comparison.
 