### PR TITLE
queuing: Allow inverse priorities for PriorityScheduler

### DIFF
--- a/src/inet/queueing/scheduler/PriorityScheduler.cc
+++ b/src/inet/queueing/scheduler/PriorityScheduler.cc
@@ -25,9 +25,11 @@ Define_Module(PriorityScheduler);
 void PriorityScheduler::initialize(int stage)
 {
     PacketSchedulerBase::initialize(stage);
-    if (stage == INITSTAGE_LOCAL)
+    if (stage == INITSTAGE_LOCAL) {
         for (auto provider : providers)
             collections.push_back(dynamic_cast<IPacketCollection *>(provider));
+        inversePriorities = par("inversePriorities");
+    }
 }
 
 int PriorityScheduler::getNumPackets() const
@@ -82,9 +84,17 @@ void PriorityScheduler::removePacket(Packet *packet)
 
 int PriorityScheduler::schedulePacket()
 {
-    for (int i = 0; i < (int)providers.size(); i++)
-        if (providers[i]->canPullSomePacket(inputGates[i]->getPathStartGate()))
-            return i;
+    if (!inversePriorities) {
+        for (int i = 0; i < (int)providers.size(); i++)
+            if (providers[i]->canPullSomePacket(inputGates[i]->getPathStartGate()))
+                return i;
+    } else {
+        for (int i = (int)providers.size() - 1; i >= 0; i--) {
+            if (providers[i]->canPullSomePacket(inputGates[i]->getPathStartGate()))
+                return i;
+        }
+    }
+
     return -1;
 }
 

--- a/src/inet/queueing/scheduler/PriorityScheduler.h
+++ b/src/inet/queueing/scheduler/PriorityScheduler.h
@@ -28,6 +28,7 @@ class INET_API PriorityScheduler : public PacketSchedulerBase, public virtual IP
 {
   protected:
     std::vector<IPacketCollection *> collections;
+    bool inversePriorities;
 
   protected:
     virtual void initialize(int stage) override;

--- a/src/inet/queueing/scheduler/PriorityScheduler.ned
+++ b/src/inet/queueing/scheduler/PriorityScheduler.ned
@@ -27,5 +27,6 @@ import inet.queueing.contract.IPacketScheduler;
 simple PriorityScheduler extends PacketSchedulerBase like IPacketScheduler
 {
     parameters:
+        bool inversePriorities = default(false);
         @class(PriorityScheduler);
 }


### PR DESCRIPTION
For example in the IEEE 802.1Q standard's multi-queues, queue priorities are in descending order. So I think it makes sense to support inverse priorities in INET's PriorityScheduler module to be able to easily recreate such queuing networks while retaining the queue indizes given in these standards.