### PR TITLE
Fix packet gates and add example simulation for frame preemption based on gate events

### DIFF
--- a/examples/ethernet/gatepreemption/GatePreemptionExample.ned
+++ b/examples/ethernet/gatepreemption/GatePreemptionExample.ned
@@ -1,0 +1,111 @@
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+package inet.examples.ethernet.gatepreemption;
+
+import inet.networks.WiredNetworkBase;
+import inet.node.ethernet.Eth100M;
+import inet.node.inet.StandardHost;
+import inet.protocol.common.PreemptableStreamer;
+import inet.protocol.ethernet.EthernetMacLayer;
+import inet.protocol.fragmentation.FragmentTagBasedDefragmenter;
+import inet.queueing.contract.IPacketBuffer;
+import inet.queueing.contract.IPacketClassifier;
+import inet.queueing.contract.IPacketGate;
+import inet.queueing.contract.IPacketQueue;
+import inet.queueing.contract.IPacketScheduler;
+import inet.queueing.queue.CompoundPacketQueue;
+
+module StreamableSelectiveQueue extends CompoundPacketQueue
+{
+    parameters:
+        int numQueues;
+        @display("bgb=1014,338");
+    submodules:
+        buffer: <default("PriorityBuffer")> like IPacketBuffer if typename != "" {
+            parameters:
+                @display("p=100,225");
+        }
+        classifier: <default("PacketClassifier")> like IPacketClassifier {
+            parameters:
+                @display("p=100,100");
+                classifierClass = default("inet::queueing::PacketUserPriorityIndClassifier");
+        }
+        queue[numQueues]: <default("PacketQueue")> like IPacketQueue {
+            parameters:
+                bufferModule = default(exists(buffer) ? "^.buffer" : "");
+                @display("p=300,100,column,125");
+        }
+        streamer[numQueues]: PreemptableStreamer {
+            @display("p=500,100,column,125");
+            minPacketLength = 64B;
+        }
+        gate[numQueues]: <default("PeriodicGate")> like IPacketGate {
+            parameters:
+                @display("p=700,100,column,125");
+        }
+        scheduler: <default("PriorityScheduler")> like IPacketScheduler {
+            parameters:
+                @display("p=900,100");
+        }
+    connections:
+        in --> { @display("m=w"); } --> classifier.in;
+        for i=0..sizeof(queue)-1 {
+            classifier.out++ --> queue[i].in;
+            queue[i].out --> streamer[i].in;
+            streamer[i].out --> gate[i].in;
+            gate[i].out --> scheduler.in++;
+        }
+        scheduler.out --> { @display("m=e"); } --> out;
+}
+
+module CustomMacLayer extends EthernetMacLayer
+{
+    parameters:
+        server.typename = default("PreemptingServer");
+        streamer.typename = default("OmittedPacketFlow"); // Packet streaming begins in queue module
+        receiver.typename = default("StreamingReceiver");
+        transmitter.typename = default("StreamingTransmitter");
+        fcsInserter.typename = default("EthernetFragmentFcsInserter");
+        preambleInserter.typename = default("EthernetFragmentPreambleInserter");
+        fcsChecker.typename = default("EthernetFragmentFcsChecker");
+        preambleChecker.typename = default("EthernetFragmentPreambleChecker");
+        volatile double bitrate @unit(bps);
+        server.datarate = bitrate;
+    submodules:
+        defragmenter: FragmentTagBasedDefragmenter {
+            @display("p=500,300");
+        }
+    connections:
+        fcsChecker.out --> { @reconnect; } --> defragmenter.in;
+        defragmenter.out --> { @reconnect;@display("m=n"); } --> upperLayerOut;
+}
+
+network GatePreemptionTest extends WiredNetworkBase
+{
+    parameters:
+        string highTsOperation;
+        @display("bgb=424,405");
+    submodules:
+        host1: StandardHost {
+            @display("p=250,100");
+        }
+        host2: StandardHost {
+            @display("p=350,100");
+        }
+    connections:
+        host1.ethg++ <--> Eth100M <--> host2.ethg++;
+}
+

--- a/examples/ethernet/gatepreemption/omnetpp.ini
+++ b/examples/ethernet/gatepreemption/omnetpp.ini
@@ -1,0 +1,46 @@
+[General]
+network = GatePreemptionTest
+sim-time-limit = 1ms
+measurement-label = ${highTsOperation}
+*.highTsOperation = ${highTsOperation = "correct", "faulty"}
+
+record-eventlog = true
+
+**.crcMode = "computed"
+**.fcsMode = "computed"
+
+**.recordPcap = true
+**.dumpProtocols = "ethernetphy"
+
+# host1
+*.host1.numApps = 1
+*.host1.app[*].typename = "UdpApp"
+*.host1.app[*].outbound.typename = "PacketTagger"
+*.host1.app[0].source.packetNameFormat = "background-%c"
+*.host1.app[0].outbound.userPriority = 0
+*.host1.app[0].outbound.vlanId = 1
+*.host1.app[0].io.destAddress = "host2"
+*.host1.app[0].io.destPort = 1000
+*.host1.app[0].source.packetLength = 1kB
+*.host1.app[0].source.productionInterval = 80us # 100Mpbs
+
+# host2
+*.host2.numApps = 1
+*.host2.app[*].typename = "UdpSink"
+*.host2.app[0].localPort = 1000
+
+# Ethernet interface and queuing
+*.host*.eth[0].typename = "LayeredEthernetInterface"
+*.host*.eth[0].clock.typename = "IdealClock"
+*.host*.eth[0].bitrate = 100Mbps
+#*.host*.eth[0].macLayer.server.datarate = 100Mbps
+*.host*.eth[0].macLayer.typename = "CustomMacLayer"
+*.host*.eth[0].macLayer.stagInserter.typename = "Ieee8021qInserter"
+*.host*.eth[0].macLayer.stagChecker.typename = "Ieee8021qChecker"
+*.host*.eth[0].macLayer.queue.typename = "StreamableSelectiveQueue"
+*.host*.eth[0].macLayer.queue.buffer.typename = ""
+*.host*.eth[0].macLayer.queue.numQueues = 1
+*.host*.eth[0].macLayer.queue.queue[*].typename = "DropTailQueue"
+*.host*.eth[0].macLayer.queue.gate[*].initiallyOpen = true
+*.host*.eth[0].macLayer.queue.gate[*].durations = "10us 10us" # Let a max stream of 125B pass through the gate(s)
+*.host*.eth[0].phyLayer.typename = "EthernetPreemptingPhyLayer"

--- a/examples/ethernet/gatepreemption/omnetpp.ini
+++ b/examples/ethernet/gatepreemption/omnetpp.ini
@@ -33,7 +33,6 @@ record-eventlog = true
 *.host*.eth[0].typename = "LayeredEthernetInterface"
 *.host*.eth[0].clock.typename = "IdealClock"
 *.host*.eth[0].bitrate = 100Mbps
-#*.host*.eth[0].macLayer.server.datarate = 100Mbps
 *.host*.eth[0].macLayer.typename = "CustomMacLayer"
 *.host*.eth[0].macLayer.stagInserter.typename = "Ieee8021qInserter"
 *.host*.eth[0].macLayer.stagChecker.typename = "Ieee8021qChecker"

--- a/src/inet/protocol/server/PreemptingServer.ned
+++ b/src/inet/protocol/server/PreemptingServer.ned
@@ -16,8 +16,10 @@
 package inet.protocol.server;
 
 import inet.queueing.base.PacketServerBase;
+import inet.queueing.contract.IPacketServer;
 
-simple PreemptingServer extends PacketServerBase
+
+simple PreemptingServer extends PacketServerBase like IPacketServer
 {
     parameters:
         double datarate @unit(bps);

--- a/src/inet/queueing/base/PacketGateBase.cc
+++ b/src/inet/queueing/base/PacketGateBase.cc
@@ -48,6 +48,9 @@ void PacketGateBase::close()
     ASSERT(isOpen_);
     EV_DEBUG << "Closing gate.\n";
     isOpen_ = false;
+    if (isStreamingPacket() && collector != nullptr) {
+        collector->handleCanPullPacket(outputGate->getPathEndGate());
+    }
     emit(gateStateChangedSignal, isOpen_);
 }
 

--- a/src/inet/queueing/base/PacketGateBase.ned
+++ b/src/inet/queueing/base/PacketGateBase.ned
@@ -29,6 +29,7 @@ simple PacketGateBase extends PacketProcessorBase
         @class(PacketGateBase);
         @display("i=block/cogwheel");
         @signal[gateStateChanged](type=bool);
+        @signal[packetPulled](type=inet::Packet);
         @statistic[gateStateChanged](title="gate states"; record=vector; interpolationmode=sample-hold);
     gates:
         input in;


### PR DESCRIPTION
Fixes packets streams not getting interrupted when packet gates close. Also adds an example simulation for frame preemption in combination with packet gates.