### PR TITLE
double-delete when both NetworkNodeOsgVisualizer and NetworkNodeCanvasVisualizer delete osg node?

### DIFF
--- a/src/inet/visualizer/base/NetworkNodeVisualizerBase.cc
+++ b/src/inet/visualizer/base/NetworkNodeVisualizerBase.cc
@@ -63,7 +63,6 @@ void NetworkNodeVisualizerBase::receiveSignal(cComponent *source, simsignal_t si
             if (isNetworkNode(module) && nodeFilter.matches(module)) {
                 auto visualization = getNetworkNodeVisualization(module);
                 removeNetworkNodeVisualization(visualization);
-                delete visualization;
             }
         }
     }

--- a/src/inet/visualizer/scene/NetworkNodeCanvasVisualizer.cc
+++ b/src/inet/visualizer/scene/NetworkNodeCanvasVisualizer.cc
@@ -78,6 +78,7 @@ void NetworkNodeCanvasVisualizer::removeNetworkNodeVisualization(NetworkNodeVisu
     auto networkNodeCanvasVisualization = check_and_cast<NetworkNodeCanvasVisualization *>(networkNodeVisualization);
     networkNodeVisualizations.erase(networkNodeVisualizations.find(networkNodeCanvasVisualization->networkNode));
     visualizationTargetModule->getCanvas()->removeFigure(networkNodeCanvasVisualization);
+    delete networkNodeVisualization;
 }
 
 } // namespace visualizer


### PR DESCRIPTION
In INET 4.2.0, when deleting a module with a NetworkNodeOsgVisualizer at runtime, I am running into a double-delete that I don't quite understand - potentially because the `scene->removeChild` of https://github.com/inet-framework/inet/blob/v4.2.0/src/inet/visualizer/scene/NetworkNodeOsgVisualizer.cc#L85 also calls `delete`. Moving the `delete` from the base class to only the canvas visualizer works around this, but I'd love to get a second opinion on whether this is a bug to begin with.