### PR TITLE
Handle Ethernet frames in QoS classifiers

### DIFF
--- a/src/inet/linklayer/common/ExampleQosClassifier.cc
+++ b/src/inet/linklayer/common/ExampleQosClassifier.cc
@@ -23,6 +23,9 @@
 #include "inet/linklayer/common/UserPriorityTag_m.h"
 #include "inet/networklayer/common/IpProtocolId_m.h"
 
+#ifdef WITH_ETHERNET
+#  include "inet/linklayer/ethernet/EtherFrame_m.h"
+#endif
 #ifdef WITH_IPv4
 #  include "inet/networklayer/ipv4/Ipv4Header_m.h"
 #  include "inet/networklayer/ipv4/IcmpHeader_m.h"
@@ -58,14 +61,24 @@ int ExampleQosClassifier::getUserPriority(cMessage *msg)
 {
     int ipProtocol = -1;
 
-#if defined(WITH_IPv4) || defined(WITH_IPv6) || defined(WITH_UDP) || defined(WITH_TCP_COMMON)
+#if defined(WITH_ETHERNET) || defined(WITH_IPv4) || defined(WITH_IPv6) || defined(WITH_UDP) || defined(WITH_TCP_COMMON)
     auto packet = check_and_cast<Packet *>(msg);
+    int ethernetMacProtocol = -1;
+    b ethernetMacHeaderLength = b(0);
     b ipHeaderLength = b(-1);
 #endif
 
+#if defined(WITH_ETHERNET)
+    if (packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ethernetMac) {
+        const auto& ethernetMacHeader = packet->peekAtFront<EthernetMacHeader>();
+        ethernetMacProtocol = ethernetMacHeader->getTypeOrLength();
+        ethernetMacHeaderLength = ethernetMacHeader->getChunkLength();
+    }
+#endif
+
 #ifdef WITH_IPv4
-    if (packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv4) {
-        const auto& ipv4Header = packet->peekAtFront<Ipv4Header>();
+    if (ethernetMacProtocol == ETHERTYPE_IPv4 || packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv4) {
+        const auto& ipv4Header = packet->peekDataAt<Ipv4Header>(ethernetMacHeaderLength);
         if (ipv4Header->getProtocolId() == IP_PROT_ICMP)
             return UP_BE; // ICMP class
         ipProtocol = ipv4Header->getProtocolId();
@@ -74,8 +87,8 @@ int ExampleQosClassifier::getUserPriority(cMessage *msg)
 #endif
 
 #ifdef WITH_IPv6
-    if (packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv6) {
-        const auto& ipv6Header = packet->peekAtFront<Ipv6Header>();
+    if (ethernetMacProtocol == ETHERTYPE_IPv6 || packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv6) {
+        const auto& ipv6Header = packet->peekDataAt<Ipv6Header>(ethernetMacHeaderLength);
         if (ipv6Header->getProtocolId() == IP_PROT_IPv6_ICMP)
             return UP_BE; // ICMPv6 class
         ipProtocol = ipv6Header->getProtocolId();
@@ -88,7 +101,7 @@ int ExampleQosClassifier::getUserPriority(cMessage *msg)
 
 #ifdef WITH_UDP
     if (ipProtocol == IP_PROT_UDP) {
-        const auto& udpHeader = packet->peekDataAt<UdpHeader>(ipHeaderLength);
+        const auto& udpHeader = packet->peekDataAt<UdpHeader>(ethernetMacHeaderLength + ipHeaderLength);
         unsigned int srcPort = udpHeader->getSourcePort();
         unsigned int destPort = udpHeader->getDestinationPort();
         if (destPort == 21 || srcPort == 21)
@@ -106,7 +119,7 @@ int ExampleQosClassifier::getUserPriority(cMessage *msg)
 
 #ifdef WITH_TCP_COMMON
     if (ipProtocol == IP_PROT_TCP) {
-        const auto& tcpHeader = packet->peekDataAt<tcp::TcpHeader>(ipHeaderLength);
+        const auto& tcpHeader = packet->peekDataAt<tcp::TcpHeader>(ethernetMacHeaderLength + ipHeaderLength);
         unsigned int srcPort = tcpHeader->getSourcePort();
         unsigned int destPort = tcpHeader->getDestinationPort();
         if (destPort == 21 || srcPort == 21)

--- a/src/inet/linklayer/common/QosClassifier.cc
+++ b/src/inet/linklayer/common/QosClassifier.cc
@@ -20,6 +20,9 @@
 #include "inet/linklayer/common/UserPriorityTag_m.h"
 #include "inet/networklayer/common/IpProtocolId_m.h"
 
+#ifdef WITH_ETHERNET
+#  include "inet/linklayer/ethernet/EtherFrame_m.h"
+#endif
 #ifdef WITH_IPv4
 #  include "inet/networklayer/ipv4/IcmpHeader_m.h"
 #  include "inet/networklayer/ipv4/Ipv4Header_m.h"
@@ -96,22 +99,32 @@ int QosClassifier::getUserPriority(cMessage *msg)
 {
     int ipProtocol = -1;
 
-#if defined(WITH_IPv4) || defined(WITH_IPv6) || defined(WITH_UDP) || defined(WITH_TCP_COMMON)
+#if defined(WITH_ETHERNET) || defined(WITH_IPv4) || defined(WITH_IPv6) || defined(WITH_UDP) || defined(WITH_TCP_COMMON)
     auto packet = check_and_cast<Packet *>(msg);
+    int ethernetMacProtocol = -1;
+    b ethernetMacHeaderLength = b(0);
     b ipHeaderLength = b(-1);
 #endif
 
+#if defined(WITH_ETHERNET)
+    if (packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ethernetMac) {
+        const auto& ethernetMacHeader = packet->peekAtFront<EthernetMacHeader>();
+        ethernetMacProtocol = ethernetMacHeader->getTypeOrLength();
+        ethernetMacHeaderLength = ethernetMacHeader->getChunkLength();
+    }
+#endif
+
 #ifdef WITH_IPv4
-    if (packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv4) {
-        const auto& ipv4Header = packet->peekAtFront<Ipv4Header>();
+    if (ethernetMacProtocol == ETHERTYPE_IPv4 || packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv4) {
+        const auto& ipv4Header = packet->peekDataAt<Ipv4Header>(ethernetMacHeaderLength);
         ipProtocol = ipv4Header->getProtocolId();
         ipHeaderLength = ipv4Header->getChunkLength();
     }
 #endif
 
 #ifdef WITH_IPv6
-    if (packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv6) {
-        const auto& ipv6Header = packet->peekAtFront<Ipv6Header>();
+    if (ethernetMacProtocol == ETHERTYPE_IPv6 || packet->getTag<PacketProtocolTag>()->getProtocol() == &Protocol::ipv6) {
+        const auto& ipv6Header = packet->peekDataAt<Ipv6Header>(ethernetMacHeaderLength);
         ipProtocol = ipv6Header->getProtocolId();
         ipHeaderLength = ipv6Header->getChunkLength();
     }
@@ -125,7 +138,7 @@ int QosClassifier::getUserPriority(cMessage *msg)
 
 #ifdef WITH_UDP
     if (ipProtocol == IP_PROT_UDP) {
-        const auto& udpHeader = packet->peekDataAt<UdpHeader>(ipHeaderLength);
+        const auto& udpHeader = packet->peekDataAt<UdpHeader>(ethernetMacHeaderLength + ipHeaderLength);
         unsigned int srcPort = udpHeader->getSourcePort();
         unsigned int destPort = udpHeader->getDestinationPort();
         auto it = udpPortUpMap.find(destPort);
@@ -139,7 +152,7 @@ int QosClassifier::getUserPriority(cMessage *msg)
 
 #ifdef WITH_TCP_COMMON
     if (ipProtocol == IP_PROT_TCP) {
-        const auto& tcpHeader = packet->peekDataAt<tcp::TcpHeader>(ipHeaderLength);
+        const auto& tcpHeader = packet->peekDataAt<tcp::TcpHeader>(ethernetMacHeaderLength + ipHeaderLength);
         unsigned int srcPort = tcpHeader->getSourcePort();
         unsigned int destPort = tcpHeader->getDestinationPort();
         auto it = tcpPortUpMap.find(destPort);


### PR DESCRIPTION
Hi,
I modified the QosClassifier and the ExampleQosClassifier so that they can also handle Ethernet frames. This fixes #548.

Best regards,
dstolpmann