### PR TITLE
fix: Prevent acos in antenna classes getting nan

### DIFF
--- a/src/inet/physicallayer/antenna/CosineAntenna.cc
+++ b/src/inet/physicallayer/antenna/CosineAntenna.cc
@@ -55,7 +55,8 @@ CosineAntenna::AntennaGain::AntennaGain(double maxGain, deg beamWidth) :
 double CosineAntenna::AntennaGain::computeGain(const Quaternion& direction) const
 {
     double exponent = -3.0 / (20 * std::log10(std::cos(math::deg2rad(beamWidth.get()) / 4.0)));
-    double angle = std::acos(direction.rotate(Coord::X_AXIS) * Coord::X_AXIS);
+    double product = math::minnan(1.0, math::maxnan(-1.0, direction.rotate(Coord::X_AXIS) * Coord::X_AXIS));
+    double angle = std::acos(product);
     return maxGain * std::pow(std::abs(std::cos(angle / 2.0)), exponent);
 }
 

--- a/src/inet/physicallayer/antenna/DipoleAntenna.cc
+++ b/src/inet/physicallayer/antenna/DipoleAntenna.cc
@@ -51,7 +51,8 @@ DipoleAntenna::AntennaGain::AntennaGain(const char *wireAxis, m length) :
 
 double DipoleAntenna::AntennaGain::computeGain(const Quaternion& direction) const
 {
-    double angle = std::acos(direction.rotate(Coord::X_AXIS) * wireAxisDirection);
+    double product = math::minnan(1.0, math::maxnan(-1.0, direction.rotate(Coord::X_AXIS) * wireAxisDirection));
+    double angle = std::acos(product);
     double q = sin(angle);
     return 1.5 * q * q;
 }

--- a/src/inet/physicallayer/antenna/ParabolicAntenna.cc
+++ b/src/inet/physicallayer/antenna/ParabolicAntenna.cc
@@ -56,7 +56,9 @@ ParabolicAntenna::AntennaGain::AntennaGain(double maxGain, double minGain, deg b
 
 double ParabolicAntenna::AntennaGain::computeGain(const Quaternion& direction) const
 {
-    deg alpha = rad(std::acos(direction.rotate(Coord::X_AXIS) * Coord::X_AXIS));
+    double product = math::minnan(1.0, math::maxnan(-1.0, direction.rotate(Coord::X_AXIS) * Coord::X_AXIS));
+
+    deg alpha = rad(std::acos(product));
     ASSERT(deg(0) <= alpha && alpha <= deg(360));
     if (alpha > deg(180))
         alpha = deg(360) - alpha;


### PR DESCRIPTION
When simulating satellite networks, we observed the problem that the antenna gain is falling to 0 randomly due to small calculation errors in the dot product because of the large values in the position vectors. (getting absolute values slightly larger than 1)
This was only prevented in the AxiallySymmetricAntenna, thus for this pull request the implementation from the AxiallySymmetricAntenna is just copied to the other antenna classes where a acos is used.