### PR TITLE
Bugfix: Segfault when accessing receptionTimer after endReception

### DIFF
--- a/src/inet/physicallayer/wireless/common/radio/packetlevel/Radio.cc
+++ b/src/inet/physicallayer/wireless/common/radio/packetlevel/Radio.cc
@@ -481,13 +481,14 @@ void Radio::endReception(cMessage *timer)
         // TODO: FIXME: see handling packets with incorrect PHY headers in the TODO file
         decapsulate(macFrame);
         sendUp(macFrame);
-        receptionTimer = nullptr;
         emit(receptionEndedSignal, check_and_cast<const cObject *>(reception));
     }
     else
         EV_INFO << "Reception ended: \x1b[1mignoring\x1b[0m " << (IWirelessSignal *)signal << " " << IRadioSignal::getSignalPartName(part) << " as " << reception << endl;
     updateTransceiverState();
     updateTransceiverPart();
+    if(timer == receptionTimer)
+        receptionTimer = nullptr;
     delete timer;
     // TODO: move to radio medium
     check_and_cast<RadioMedium *>(medium)->emit(IRadioMedium::signalArrivalEndedSignal, check_and_cast<const cObject *>(reception));


### PR DESCRIPTION
This only occurs in very specific scenarios where:

* Reception has started
* The radio mode has begun switching, but not completed switching.
* The signal ends and `endReception` is called. But since the radio is now in the switching mode, the if statement on https://github.com/inet-framework/inet/blob/bbf2ef9cd8eb59271527cde549c5e9994f36df43/src/inet/physicallayer/wireless/common/radio/packetlevel/Radio.cc#L474 is false.
* The  timer object is deleted https://github.com/inet-framework/inet/blob/bbf2ef9cd8eb59271527cde549c5e9994f36df43/src/inet/physicallayer/wireless/common/radio/packetlevel/Radio.cc#L491 but `receptionTimer` variable still points to a deallocated section.
* The `completeRadioModeSwitch` calls `abortReception(receptionTimer)` which tries to access the deleted object.