### PR TITLE
Report MTU when sending an ICMPv4 PTB

### DIFF
--- a/src/inet/networklayer/ipv4/Icmp.cc
+++ b/src/inet/networklayer/ipv4/Icmp.cc
@@ -160,42 +160,9 @@ void Icmp::sendErrorMessage(Packet *packet, int inputInterfaceId, IcmpType type,
 {
     Enter_Method("sendErrorMessage(datagram, type=%d, code=%d)", type, code);
 
-    const auto& ipv4Header = packet->peekAtFront<Ipv4Header>();
-    Ipv4Address origSrcAddr = ipv4Header->getSrcAddress();
-    Ipv4Address origDestAddr = ipv4Header->getDestAddress();
-
-    // don't send ICMP error messages in response to broadcast or multicast messages
-    if (origDestAddr.isMulticast() || origDestAddr.isLimitedBroadcastAddress() || possiblyLocalBroadcast(origDestAddr, inputInterfaceId)) {
-        EV_DETAIL << "won't send ICMP error messages for broadcast/multicast message " << ipv4Header << endl;
+    if (!doSendErrorMessage(packet, -1)) {
         delete packet;
         return;
-    }
-
-    // don't send ICMP error messages response to unspecified, broadcast or multicast addresses
-    if ((inputInterfaceId != -1 && origSrcAddr.isUnspecified())
-            || origSrcAddr.isMulticast()
-            || origSrcAddr.isLimitedBroadcastAddress()
-            || possiblyLocalBroadcast(origSrcAddr, inputInterfaceId)) {
-        EV_DETAIL << "won't send ICMP error messages to broadcast/multicast address, message " << ipv4Header << endl;
-        delete packet;
-        return;
-    }
-
-    // ICMP messages are only sent about errors in handling fragment zero of fragmented datagrams
-    if (ipv4Header->getFragmentOffset() != 0) {
-        EV_DETAIL << "won't send ICMP error messages about errors in non-first fragments" << endl;
-        delete packet;
-        return;
-    }
-
-    // do not reply with error message to error message
-    if (ipv4Header->getProtocolId() == IP_PROT_ICMP) {
-        const auto& recICMPMsg = packet->peekDataAt<IcmpHeader>(B(ipv4Header->getHeaderLength()));
-        if (!isIcmpInfoType(recICMPMsg->getType())) {
-            EV_DETAIL << "ICMP error received -- do not reply to it" << endl;
-            delete packet;
-            return;
-        }
     }
 
     // assemble a message name
@@ -214,24 +181,12 @@ void Icmp::sendErrorMessage(Packet *packet, int inputInterfaceId, IcmpType type,
     icmpHeader->setCode(code);
     // ICMP message length: the internet header plus the first 8 bytes of
     // the original datagram's data is returned to the sender.
+    const auto& ipv4Header = packet->peekAtFront<Ipv4Header>();
     errorPacket->insertAtBack(packet->peekDataAt(B(0), ipv4Header->getHeaderLength() + B(8)));
     insertCrc(icmpHeader, errorPacket);
     errorPacket->insertAtFront(icmpHeader);
 
-    errorPacket->addTag<PacketProtocolTag>()->setProtocol(&Protocol::icmpv4);
-
-    // if srcAddr is not filled in, we're still in the src node, so we just
-    // process the ICMP message locally, right away
-    if (origSrcAddr.isUnspecified()) {
-        // pretend it came from the Ipv4 layer
-        errorPacket->addTag<L3AddressInd>()->setDestAddress(Ipv4Address::LOOPBACK_ADDRESS);    // FIXME maybe use configured loopback address
-
-        // then process it locally
-        processICMPMessage(errorPacket);
-    }
-    else {
-        sendToIP(errorPacket, ipv4Header->getSrcAddress());
-    }
+    sendOrProcessIcmpPacket(errorPacket, ipv4Header->getSrcAddress());
     delete packet;
 }
 

--- a/src/inet/networklayer/ipv4/Icmp.cc
+++ b/src/inet/networklayer/ipv4/Icmp.cc
@@ -145,10 +145,14 @@ void Icmp::sendPtbMessage(Packet *packet, int mtu)
     Packet *errorPacket = new Packet(msgname);
     const auto& icmpPtb = makeShared<IcmpPtb>();
     icmpPtb->setMtu(mtu);
-    // ICMP message length: the internet header plus the first 8 bytes of
+    // ICMP message length: the internet header plus the first queteLength bytes of
     // the original datagram's data is returned to the sender.
     const auto& ipv4Header = packet->peekAtFront<Ipv4Header>();
-    errorPacket->insertAtBack(packet->peekDataAt(B(0), ipv4Header->getHeaderLength() + B(8)));
+    B quoteLength = ipv4Header->getHeaderLength() + B(par("quoteLength"));
+    if (quoteLength > packet->getDataLength()) {
+        quoteLength = packet->getDataLength();
+    }
+    errorPacket->insertAtBack(packet->peekDataAt(B(0), quoteLength));
     insertCrc(icmpPtb, errorPacket);
     errorPacket->insertAtFront(icmpPtb);
 
@@ -179,10 +183,14 @@ void Icmp::sendErrorMessage(Packet *packet, int inputInterfaceId, IcmpType type,
     icmpHeader->setChunkLength(B(8));      //FIXME second 4 byte in icmp header not represented yet
     icmpHeader->setType(type);
     icmpHeader->setCode(code);
-    // ICMP message length: the internet header plus the first 8 bytes of
+    // ICMP message length: the internet header plus the first queteLength bytes of
     // the original datagram's data is returned to the sender.
     const auto& ipv4Header = packet->peekAtFront<Ipv4Header>();
-    errorPacket->insertAtBack(packet->peekDataAt(B(0), ipv4Header->getHeaderLength() + B(8)));
+    B quoteLength = ipv4Header->getHeaderLength() + B(par("quoteLength"));
+    if (quoteLength > packet->getDataLength()) {
+        quoteLength = packet->getDataLength();
+    }
+    errorPacket->insertAtBack(packet->peekDataAt(B(0), quoteLength));
     insertCrc(icmpHeader, errorPacket);
     errorPacket->insertAtFront(icmpHeader);
 

--- a/src/inet/networklayer/ipv4/Icmp.h
+++ b/src/inet/networklayer/ipv4/Icmp.h
@@ -58,6 +58,7 @@ class INET_API Icmp : public cSimpleModule, public DefaultProtocolRegistrationLi
      * KLUDGE: if inputInterfaceId cannot be determined, pass in -1.
      */
     virtual void sendErrorMessage(Packet *packet, int inputInterfaceId, IcmpType type, IcmpCode code);
+    virtual void sendPtbMessage(Packet *packet, int mtu);
     static void insertCrc(CrcMode crcMode, const Ptr<IcmpHeader>& icmpHeader, Packet *payload);
     void insertCrc(const Ptr<IcmpHeader>& icmpHeader, Packet *payload) { insertCrc(crcMode, icmpHeader, payload); }
     bool verifyCrc(const Packet *packet);
@@ -66,6 +67,8 @@ class INET_API Icmp : public cSimpleModule, public DefaultProtocolRegistrationLi
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
     virtual void handleMessage(cMessage *msg) override;
+    virtual bool doSendErrorMessage(Packet *packet, int inputInterfaceId);
+    virtual void sendOrProcessIcmpPacket(Packet *packet, Ipv4Address origSrcAddr);
 };
 
 } // namespace inet

--- a/src/inet/networklayer/ipv4/Icmp.ned
+++ b/src/inet/networklayer/ipv4/Icmp.ned
@@ -29,6 +29,7 @@ simple Icmp
         string interfaceTableModule;   // The path to the InterfaceTable module
         string routingTableModule;
         string crcMode @enum("declared", "computed") = default("declared");
+        int quoteLength @unit("B") = default(8B); // Number of bytes from original packet to quote in ICMP reply
         @display("i=block/control");
     gates:
         input transportIn;

--- a/src/inet/networklayer/ipv4/IcmpHeader.msg
+++ b/src/inet/networklayer/ipv4/IcmpHeader.msg
@@ -145,3 +145,9 @@ class IcmpEchoReply extends IcmpHeader
     int seqNumber; // sequence number           // 2 bytes
 }
 
+class IcmpPtb extends IcmpHeader
+{
+    type = ICMP_DESTINATION_UNREACHABLE;
+    code = ICMP_DU_FRAGMENTATION_NEEDED;
+    int mtu = 0;   // 1 byte
+}

--- a/src/inet/networklayer/ipv4/Ipv4.cc
+++ b/src/inet/networklayer/ipv4/Ipv4.cc
@@ -907,8 +907,7 @@ void Ipv4::fragmentAndSend(Packet *packet)
         PacketDropDetails details;
         emit(packetDroppedSignal, packet, &details);
         EV_WARN << "datagram larger than MTU and don't fragment bit set, sending ICMP_DESTINATION_UNREACHABLE\n";
-        sendIcmpError(packet, -1    /*TODO*/, ICMP_DESTINATION_UNREACHABLE,
-                ICMP_DU_FRAGMENTATION_NEEDED);
+        icmp->sendPtbMessage(packet, mtu);
         numDropped++;
         return;
     }

--- a/src/inet/transportlayer/udp/Udp.cc
+++ b/src/inet/transportlayer/udp/Udp.cc
@@ -1200,7 +1200,7 @@ void Udp::processICMPv4Error(Packet *packet)
         if (sd) {
             // send UDP_I_ERROR to socket
             EV_DETAIL << "Source socket is sockId=" << sd->sockId << ", notifying.\n";
-            sendUpErrorIndication(sd, localAddr, localPort, remoteAddr, remotePort);
+            sendUpErrorIndication(sd, localAddr, localPort, remoteAddr, remotePort, packet);
         }
         else {
             EV_WARN << "No socket on that local port, ignoring ICMP error\n";
@@ -1261,7 +1261,7 @@ void Udp::processICMPv6Error(Packet *packet)
         if (sd) {
             // send UDP_I_ERROR to socket
             EV_DETAIL << "Source socket is sockId=" << sd->sockId << ", notifying.\n";
-            sendUpErrorIndication(sd, localAddr, localPort, remoteAddr, remotePort);
+            sendUpErrorIndication(sd, localAddr, localPort, remoteAddr, remotePort, packet);
         }
         else {
             EV_WARN << "No socket on that local port, ignoring ICMPv6 error\n";
@@ -1275,11 +1275,10 @@ void Udp::processICMPv6Error(Packet *packet)
     delete packet;
 }
 
-void Udp::sendUpErrorIndication(SockDesc *sd, const L3Address& localAddr, ushort localPort, const L3Address& remoteAddr, ushort remotePort)
+void Udp::sendUpErrorIndication(SockDesc *sd, const L3Address& localAddr, ushort localPort, const L3Address& remoteAddr, ushort remotePort, Packet *icmpPacket)
 {
     auto indication = new Indication("ERROR", UDP_I_ERROR);
-    UdpErrorIndication *udpCtrl = new UdpErrorIndication();
-    indication->setControlInfo(udpCtrl);
+    indication->setControlInfo(icmpPacket->dup());
     //FIXME notifyMsg->addTagIfAbsent<InterfaceInd>()->setInterfaceId(interfaceId);
     indication->addTag<SocketInd>()->setSocketId(sd->sockId);
     auto addresses = indication->addTag<L3AddressInd>();

--- a/src/inet/transportlayer/udp/Udp.h
+++ b/src/inet/transportlayer/udp/Udp.h
@@ -172,7 +172,7 @@ class INET_API Udp : public TransportProtocolBase
     virtual SockDesc *findFirstSocketByLocalAddress(const L3Address& localAddr, ushort localPort);
     virtual void sendUp(Ptr<const UdpHeader>& header, Packet *payload, SockDesc *sd, ushort srcPort, ushort destPort);
     virtual void processUndeliverablePacket(Packet *udpPacket);
-    virtual void sendUpErrorIndication(SockDesc *sd, const L3Address& localAddr, ushort localPort, const L3Address& remoteAddr, ushort remotePort);
+    virtual void sendUpErrorIndication(SockDesc *sd, const L3Address& localAddr, ushort localPort, const L3Address& remoteAddr, ushort remotePort, Packet *icmpPacket);
 
     // process an ICMP error packet
     virtual void processICMPv4Error(Packet *icmpPacket);


### PR DESCRIPTION
* The ICMPv4 Packet Too Big message (type=3, code=4) includes the MTU as defined in RFC 1191.
* The new ICMP parameter quoteLength let the user specify the number of bytes to quote from the dropped packet.
* UDP forwards the ICMP packet inside the Control Info of the Error Indication to the upper layer protocol. This gives UDP based protocols access to the information in the ICMP packet.