### PR TITLE
Bugfix to prevent wrong ...StateChangedSignal when Switching

### DIFF
--- a/src/inet/physicallayer/wireless/common/radio/packetlevel/Radio.cc
+++ b/src/inet/physicallayer/wireless/common/radio/packetlevel/Radio.cc
@@ -557,7 +557,7 @@ void Radio::updateTransceiverState()
 {
     // reception state
     ReceptionState newRadioReceptionState;
-    if (radioMode == RADIO_MODE_OFF || radioMode == RADIO_MODE_SLEEP || radioMode == RADIO_MODE_TRANSMITTER)
+    if (radioMode == RADIO_MODE_OFF || radioMode == RADIO_MODE_SWITCHING || radioMode == RADIO_MODE_SLEEP || radioMode == RADIO_MODE_TRANSMITTER)
         newRadioReceptionState = RECEPTION_STATE_UNDEFINED;
     else if (receptionTimer && receptionTimer->isScheduled())
         newRadioReceptionState = RECEPTION_STATE_RECEIVING;
@@ -572,7 +572,7 @@ void Radio::updateTransceiverState()
     }
     // transmission state
     TransmissionState newRadioTransmissionState;
-    if (radioMode == RADIO_MODE_OFF || radioMode == RADIO_MODE_SLEEP || radioMode == RADIO_MODE_RECEIVER)
+    if (radioMode == RADIO_MODE_OFF || radioMode == RADIO_MODE_SWITCHING || radioMode == RADIO_MODE_SLEEP || radioMode == RADIO_MODE_RECEIVER)
         newRadioTransmissionState = TRANSMISSION_STATE_UNDEFINED;
     else if (transmissionTimer->isScheduled())
         newRadioTransmissionState = TRANSMISSION_STATE_TRANSMITTING;


### PR DESCRIPTION
Example that revealed problem:

1) Radio transmission from neighbour active on medium
2) Radio is commanded (e.g. from Mac layer) to receive mode, switching begins
3) Active transmission from neighbour ends and `endReception(timer)` is called
4) `updateTransceiverState()` determines `RECEPTION_STATE_BUSY` or `RECEPTION_STATE_IDLE`
5) Emits incorrect `receptionStateChangedSignal` and `transmissionStateChangedSignal`