### PR TITLE
Clock: Add methods for rescheduling events

### DIFF
--- a/src/inet/common/clock/ClockUserModuleMixin.h
+++ b/src/inet/common/clock/ClockUserModuleMixin.h
@@ -48,6 +48,8 @@ class INET_API ClockUserModuleMixin : public T, public cListener
     virtual void scheduleClockEventAfter(clocktime_t delay, ClockEvent *msg);
     virtual cMessage *cancelClockEvent(ClockEvent *msg);
     virtual void cancelAndDeleteClockEvent(ClockEvent *msg);
+    virtual void rescheduleClockEventAt(clocktime_t time, ClockEvent* msg);
+    virtual void rescheduleClockEventAfter(clocktime_t time, ClockEvent* msg);
 
     virtual clocktime_t getClockTime() const;
     virtual clocktime_t getArrivalClockTime(ClockEvent *msg) const;
@@ -68,6 +70,8 @@ class INET_API ClockUserModuleMixin : public T, public cListener
     virtual void scheduleClockEventAfter(clocktime_t delay, ClockEvent *msg) { T::scheduleAfter(delay, msg); }
     virtual cMessage *cancelClockEvent(ClockEvent *msg) { return T::cancelEvent(msg); }
     virtual void cancelAndDeleteClockEvent(ClockEvent *msg) { T::cancelAndDelete(msg); }
+    virtual void rescheduleClockEventAt(clocktime_t time, ClockEvent* msg) { T::rescheduleAt(time, cancelEvent(msg)); }
+    virtual void rescheduleClockEventAfter(clocktime_t time, ClockEvent* msg) { T::rescheduleAfter(time, cancelEvent(msg)); }
     virtual clocktime_t getClockTime() const { return simTime(); }
     virtual clocktime_t getArrivalClockTime(ClockEvent *msg) const { return msg->getArrivalTime(); }
 #endif // #ifdef INET_WITH_CLOCK

--- a/src/inet/common/clock/ClockUserModuleMixinImpl.h
+++ b/src/inet/common/clock/ClockUserModuleMixinImpl.h
@@ -111,6 +111,30 @@ void ClockUserModuleMixin<T>::cancelAndDeleteClockEvent(ClockEvent *msg) {
 }
 
 template<typename T>
+void ClockUserModuleMixin<T>::rescheduleClockEventAt(clocktime_t t, ClockEvent* msg)
+{
+#ifndef NDEBUG
+    usedClockApi = true;
+#endif
+    if (clock != nullptr)
+        clock->scheduleClockEventAt(t, clock->cancelClockEvent(msg));
+    else
+        T::rescheduleAt(t.asSimTime(), msg);
+}
+
+template<typename T>
+void ClockUserModuleMixin<T>::rescheduleClockEventAfter(clocktime_t t, ClockEvent* msg)
+{
+#ifndef NDEBUG
+    usedClockApi = true;
+#endif
+    if (clock != nullptr)
+        clock->scheduleClockEventAfter(t, clock->cancelClockEvent(msg));
+    else
+        T::rescheduleAfter(t.asSimTime(), msg);
+}
+
+template<typename T>
 clocktime_t ClockUserModuleMixin<T>::getClockTime() const {
 #ifndef NDEBUG
     usedClockApi = true;


### PR DESCRIPTION
In OMNeT++ 6.0 preview 9 the rescheduleAt and rescheduleAfter methods have been added to cSimpleModule. It might be a good idea to also add these methods to the ClockModuleMixin for a more consistent API.