### PR TITLE
RelayUnit: Consider user priority

### DIFF
--- a/src/inet/linklayer/ethernet/common/MacRelayUnit.cc
+++ b/src/inet/linklayer/ethernet/common/MacRelayUnit.cc
@@ -22,6 +22,7 @@
 #include "inet/linklayer/common/InterfaceTag_m.h"
 #include "inet/linklayer/common/MacAddressTag_m.h"
 #include "inet/linklayer/common/VlanTag_m.h"
+#include "inet/linklayer/common/UserPriorityTag_m.h"
 
 namespace inet {
 
@@ -45,6 +46,8 @@ void MacRelayUnit::handleLowerPacket(Packet *incomingPacket)
     outgoingPacket->addTag<PacketProtocolTag>()->setProtocol(protocol);
     if (auto vlanInd = incomingPacket->findTag<VlanInd>())
         outgoingPacket->addTag<VlanReq>()->setVlanId(vlanInd->getVlanId());
+    if (auto userPriorityInd = incomingPacket->findTag<UserPriorityInd>())
+        outgoingPacket->addTag<UserPriorityReq>()->setUserPriority(userPriorityInd->getUserPriority());
     auto& macAddressReq = outgoingPacket->addTag<MacAddressReq>();
     macAddressReq->setSrcAddress(sourceAddress);
     macAddressReq->setDestAddress(destinationAddress);

--- a/src/inet/linklayer/ieee8021d/relay/Ieee8021dRelay.cc
+++ b/src/inet/linklayer/ieee8021d/relay/Ieee8021dRelay.cc
@@ -24,6 +24,7 @@
 #include "inet/linklayer/common/InterfaceTag_m.h"
 #include "inet/linklayer/common/MacAddressTag_m.h"
 #include "inet/linklayer/common/VlanTag_m.h"
+#include "inet/linklayer/common/UserPriorityTag_m.h"
 #include "inet/linklayer/configurator/Ieee8021dInterfaceData.h"
 #include "inet/linklayer/ethernet/common/EthernetMacHeader_m.h"
 #include "inet/linklayer/ieee8022/Ieee8022LlcHeader_m.h"
@@ -124,6 +125,8 @@ void Ieee8021dRelay::handleLowerPacket(Packet *incomingPacket)
         outgoingPacket->addTag<PacketProtocolTag>()->setProtocol(protocol);
         if (auto vlanInd = incomingPacket->findTag<VlanInd>())
             outgoingPacket->addTag<VlanReq>()->setVlanId(vlanInd->getVlanId());
+        if (auto userPriorityInd = incomingPacket->findTag<UserPriorityInd>())
+            outgoingPacket->addTag<UserPriorityReq>()->setUserPriority(userPriorityInd->getUserPriority());
         auto& macAddressReq = outgoingPacket->addTag<MacAddressReq>();
         macAddressReq->setSrcAddress(sourceAddress);
         macAddressReq->setDestAddress(destinationAddress);


### PR DESCRIPTION
If we don't carry over user priorities (from IEEE802.1Q tag) in the relay unit, they'll get lost.