### PR TITLE
Refactor duplicate find(Interface/Node)ByAddress in routing table and visualizer

### DIFF
--- a/src/inet/networklayer/ipv4/Ipv4RoutingTable.cc
+++ b/src/inet/networklayer/ipv4/Ipv4RoutingTable.cc
@@ -306,15 +306,7 @@ std::vector<Ipv4Address> Ipv4RoutingTable::gatherAddresses() const
 NetworkInterface *Ipv4RoutingTable::getInterfaceByAddress(const Ipv4Address& addr) const
 {
     Enter_Method("getInterfaceByAddress(%u.%u.%u.%u)", addr.getDByte(0), addr.getDByte(1), addr.getDByte(2), addr.getDByte(3)); // note: str().c_str() too slow here
-
-    if (addr.isUnspecified())
-        return nullptr;
-    for (int i = 0; i < ift->getNumInterfaces(); ++i) {
-        NetworkInterface *ie = ift->getInterface(i);
-        if (ie->hasNetworkAddress(addr))
-            return ie;
-    }
-    return nullptr;
+    return ift->findInterfaceByAddress(addr);
 }
 
 // ---
@@ -322,12 +314,7 @@ NetworkInterface *Ipv4RoutingTable::getInterfaceByAddress(const Ipv4Address& add
 bool Ipv4RoutingTable::isLocalAddress(const Ipv4Address& dest) const
 {
     Enter_Method("isLocalAddress(%u.%u.%u.%u)", dest.getDByte(0), dest.getDByte(1), dest.getDByte(2), dest.getDByte(3)); // note: str().c_str() too slow here
-
-    for (int i = 0; i < ift->getNumInterfaces(); i++) {
-        if (ift->getInterface(i)->hasNetworkAddress(dest))
-            return true;
-    }
-    return false;
+    return ift->isLocalAddress(dest);
 }
 
 // JcM add: check if the dest addr is local network broadcast

--- a/src/inet/networklayer/ipv6/Ipv6RoutingTable.cc
+++ b/src/inet/networklayer/ipv6/Ipv6RoutingTable.cc
@@ -407,15 +407,7 @@ NetworkInterface *Ipv6RoutingTable::getInterfaceByAddress(const Ipv6Address& add
 {
     Enter_Method("getInterfaceByAddress(%s)=?", addr.str().c_str());
 
-    if (addr.isUnspecified())
-        return nullptr;
-
-    for (int i = 0; i < ift->getNumInterfaces(); ++i) {
-        NetworkInterface *ie = ift->getInterface(i);
-        if (ie->getProtocolData<Ipv6InterfaceData>()->hasAddress(addr))
-            return ie;
-    }
-    return nullptr;
+    return ift->findInterfaceByAddress(addr);
 }
 
 NetworkInterface *Ipv6RoutingTable::getInterfaceByAddress(const L3Address& address) const
@@ -428,11 +420,8 @@ bool Ipv6RoutingTable::isLocalAddress(const Ipv6Address& dest) const
     Enter_Method("isLocalAddress(%s) y/n", dest.str().c_str());
 
     // first, check if we have an interface with this address
-    for (int i = 0; i < ift->getNumInterfaces(); i++) {
-        NetworkInterface *ie = ift->getInterface(i);
-        if (ie->getProtocolData<Ipv6InterfaceData>()->hasAddress(dest))
-            return true;
-    }
+    if (ift->isLocalAddress(dest))
+        return true;
 
     // then check for special, preassigned multicast addresses
     // (these addresses occur more rarely than specific interface addresses,

--- a/src/inet/networklayer/nexthop/NextHopRoutingTable.cc
+++ b/src/inet/networklayer/nexthop/NextHopRoutingTable.cc
@@ -239,27 +239,12 @@ L3Address NextHopRoutingTable::getRouterIdAsGeneric() const
 
 bool NextHopRoutingTable::isLocalAddress(const L3Address& dest) const
 {
-    // TODO Enter_Method("isLocalAddress(%s)", dest.str().c_str());
-
-    // collect interface addresses if not yet done
-    for (int i = 0; i < ift->getNumInterfaces(); i++) {
-        L3Address interfaceAddr = ift->getInterface(i)->getProtocolData<NextHopInterfaceData>()->getAddress();
-        if (interfaceAddr == dest)
-            return true;
-    }
-    return false;
+    return ift->isLocalAddress(dest);
 }
 
 NetworkInterface *NextHopRoutingTable::getInterfaceByAddress(const L3Address& address) const
 {
-    // collect interface addresses if not yet done
-    for (int i = 0; i < ift->getNumInterfaces(); i++) {
-        NetworkInterface *ie = ift->getInterface(i);
-        L3Address interfaceAddr = ie->getProtocolData<NextHopInterfaceData>()->getAddress();
-        if (interfaceAddr == address)
-            return ie;
-    }
-    return nullptr;
+    return ift->findInterfaceByAddress(address);
 }
 
 NextHopRoute *NextHopRoutingTable::findBestMatchingRoute(const L3Address& dest) const

--- a/src/inet/visualizer/base/LinkBreakVisualizerBase.cc
+++ b/src/inet/visualizer/base/LinkBreakVisualizerBase.cc
@@ -174,8 +174,8 @@ cModule *LinkBreakVisualizerBase::findNode(MacAddress address)
         auto networkNode = *it;
         if (isNetworkNode(networkNode)) {
             auto interfaceTable = addressResolver.findInterfaceTableOf(networkNode);
-            for (int i = 0; i < interfaceTable->getNumInterfaces(); i++)
-                if (interfaceTable->getInterface(i)->getMacAddress() == address)
+            if (interfaceTable != nullptr)
+                if(interfaceTable->isLocalAddress(L3Address(address)))
                     return networkNode;
         }
     }

--- a/src/inet/visualizer/base/RoutingTableVisualizerBase.cc
+++ b/src/inet/visualizer/base/RoutingTableVisualizerBase.cc
@@ -176,13 +176,9 @@ std::vector<Ipv4Address> RoutingTableVisualizerBase::getDestinations()
             auto interfaceTable = addressResolver.findInterfaceTableOf(networkNode);
             for (int i = 0; i < interfaceTable->getNumInterfaces(); i++) {
                 auto interface = interfaceTable->getInterface(i);
-#ifdef INET_WITH_IPv4
-                if (auto ipv4Data = interface->findProtocolData<Ipv4InterfaceData>()) {
-                    auto address = ipv4Data->getIPAddress();
-                    if (!address.isUnspecified())
-                        destinations.push_back(address);
-                }
-#endif // INET_WITH_IPv4
+                auto address = interface->getIpv4Address();
+                if (!address.isUnspecified())
+                    destinations.push_back(address);
             }
         }
     }


### PR DESCRIPTION
Use the provided abstract interfaces of InterfaceTable and NetworkInterface