### PR TITLE
INET4.2.x Add ModuleIdAddress and ModulePathAddress to get L3AddressResolver::findHostWithAddress

### DIFF
--- a/src/inet/networklayer/common/L3AddressResolver.cc
+++ b/src/inet/networklayer/common/L3AddressResolver.cc
@@ -535,27 +535,27 @@ cModule *L3AddressResolver::findHostWithAddress(const L3Address& add)
                 InterfaceEntry *entry = itable->getInterface(i);
                 switch (add.getType()) {
 #ifdef WITH_IPv6
-                    case L3Address::IPv6: {
-                        auto protocolData = entry->findProtocolData<Ipv6InterfaceData>();
-                        if (protocolData != nullptr && protocolData->hasAddress(add.toIpv6()))
-                            return mod;
-                        break;
-                    }
-
+                    case L3Address::IPv6:
 #endif // ifdef WITH_IPv6
 #ifdef WITH_IPv4
-                    case L3Address::IPv4: {
-                        auto protocolData = entry->findProtocolData<Ipv4InterfaceData>();
-                        if (protocolData != nullptr && protocolData->getIPAddress() == add.toIpv4())
-                            return mod;
-                        break;
-                    }
-
+                    case L3Address::IPv4:
 #endif // ifdef WITH_IPv4
                     case L3Address::MAC:
-                        if (entry->getMacAddress() == add.toMac())
+                        if (entry->hasNetworkAddress(add))
                             return mod;
                         break;
+                    case L3Address::MODULEPATH: {
+                        if(entry->getModulePathAddress() == add.toModulePath()){
+                            return mod;
+                        }
+                        break;
+                    }
+                    case L3Address::MODULEID: {
+                        if(entry->getModuleIdAddress() == add.toModuleId()){
+                            return mod;
+                        }
+                        break;
+                    }
                     default:
                         (void)entry;    // eliminate warning: unused variable 'entry'
                         throw cRuntimeError("findHostWithAddress() doesn't accept AddressType '%s', yet", L3Address::getTypeName(add.getType()));

--- a/src/inet/networklayer/common/L3AddressResolver.cc
+++ b/src/inet/networklayer/common/L3AddressResolver.cc
@@ -534,12 +534,8 @@ cModule *L3AddressResolver::findHostWithAddress(const L3Address& add)
             for (int i = 0; i < itable->getNumInterfaces(); i++) {
                 InterfaceEntry *entry = itable->getInterface(i);
                 switch (add.getType()) {
-#ifdef WITH_IPv6
                     case L3Address::IPv6:
-#endif // ifdef WITH_IPv6
-#ifdef WITH_IPv4
                     case L3Address::IPv4:
-#endif // ifdef WITH_IPv4
                     case L3Address::MAC:
                         if (entry->hasNetworkAddress(add))
                             return mod;


### PR DESCRIPTION
Same as #682 but for Inet 4.2.x