### PR TITLE
Explicitly inline some get module functions to prevent error when linking against INET api

### DIFF
--- a/src/inet/common/ModuleAccess.h
+++ b/src/inet/common/ModuleAccess.h
@@ -128,7 +128,7 @@ INET_API InterfaceEntry *getContainingNicModule(const cModule *from);
  * Returns nullptr if no such module is found along the path.
  */
 template<typename T>
-INET_API cGate *findConnectedGate(cGate *gate, int direction = 0)
+INET_API inline cGate *findConnectedGate(cGate *gate, int direction = 0)
 {
     if (!gate->isConnectedOutside())
         return nullptr;
@@ -155,7 +155,7 @@ INET_API cGate *findConnectedGate(cGate *gate, int direction = 0)
  * Throws an error if no such module is found along the path.
  */
 template<typename T>
-INET_API cGate *getConnectedGate(cGate *gate, int direction = 0)
+INET_API inline cGate *getConnectedGate(cGate *gate, int direction = 0)
 {
     auto connectedGate = findConnectedGate<T>(gate, direction);
     if (connectedGate == nullptr)
@@ -168,7 +168,7 @@ INET_API cGate *getConnectedGate(cGate *gate, int direction = 0)
  * Returns nullptr if no such module is found along the path.
  */
 template<typename T>
-INET_API T *findConnectedModule(cGate *gate, int direction = 0)
+INET_API T inline *findConnectedModule(cGate *gate, int direction = 0)
 {
     auto connectedGate = findConnectedGate<T>(gate, direction);
     return connectedGate != nullptr ? check_and_cast<T *>(connectedGate->getOwnerModule()) : nullptr;
@@ -179,7 +179,7 @@ INET_API T *findConnectedModule(cGate *gate, int direction = 0)
  * Throws an error if no such module is found along the path.
  */
 template<typename T>
-INET_API T *getConnectedModule(cGate *gate, int direction = 0)
+INET_API T inline *getConnectedModule(cGate *gate, int direction = 0)
 {
     auto module = findConnectedModule<T>(gate, direction);
     if (module == nullptr)


### PR DESCRIPTION
Not sure exactly why this was a problem, and I think it is only a problem on Windows.

Caused by builiding another project that relies on INET and imports the dll. It will not link giving the following error: 
``` 
...
INET_API cGate *findConnectedGate(cGate *gate, int direction = 0)
                 ^~~~~~~~~~~~~~~~~
../../inet/src/inet/common/ModuleAccess.h:158:17: error: function 'omnetpp::cGate* inet::getConnectedGate(omnetpp::cGate*, int)' definition is marked dllimport
 INET_API cGate *getConnectedGate(cGate *gate, int direction = 0)
                 ^~~~~~~~~~~~~~~~
../../inet/src/inet/common/ModuleAccess.h:171:13: error: function 'T* inet::findConnectedModule(omnetpp::cGate*, int)' definition is marked dllimport
 INET_API T *findConnectedModule(cGate *gate, int direction = 0)
             ^~~~~~~~~~~~~~~~~~~
../../inet/src/inet/common/ModuleAccess.h:182:13: error: function 'T* inet::getConnectedModule(omnetpp::cGate*, int)' definition is marked dllimport
 INET_API T *getConnectedModule(cGate *gate, int direction = 0)```

Explicitly inlining these functions works though.