### PR TITLE
Improve ScalarNoise max and min computation

### DIFF
--- a/src/inet/physicallayer/wireless/common/analogmodel/packetlevel/ScalarNoise.cc
+++ b/src/inet/physicallayer/wireless/common/analogmodel/packetlevel/ScalarNoise.cc
@@ -40,8 +40,15 @@ W ScalarNoise::computeMinPower(simtime_t startTime, simtime_t endTime) const
     W noisePower = W(0);
     W minNoisePower = W(NaN);
     for (const auto& elem : *powerChanges) {
+        if(endTime <= elem.first){
+            // Power change after or at end time
+            if (std::isnan(minNoisePower.get()) || noisePower < minNoisePower)
+                // Previous power change was before start time, set to current power if not first change
+                minNoisePower = noisePower;
+            break;
+        }
         noisePower += elem.second;
-        if ((std::isnan(minNoisePower.get()) || noisePower < minNoisePower) && startTime <= elem.first && elem.first < endTime)
+        if ((std::isnan(minNoisePower.get()) || noisePower < minNoisePower) && startTime <= elem.first)
             minNoisePower = noisePower;
     }
     return minNoisePower;
@@ -52,8 +59,16 @@ W ScalarNoise::computeMaxPower(simtime_t startTime, simtime_t endTime) const
     W noisePower = W(0);
     W maxNoisePower = W(0);
     for (const auto& elem : *powerChanges) {
+        if(endTime <= elem.first){
+            // Power change after or at end time
+            if (std::isnan(maxNoisePower.get()) || noisePower > maxNoisePower)
+                // Previous power change was before start time, set to current power if not first change
+                maxNoisePower = noisePower;
+            break;
+        }
+
         noisePower += elem.second;
-        if ((std::isnan(maxNoisePower.get()) || noisePower > maxNoisePower) && startTime <= elem.first && elem.first < endTime)
+        if ((std::isnan(maxNoisePower.get()) || noisePower > maxNoisePower) && startTime <= elem.first)
             maxNoisePower = noisePower;
     }
     return maxNoisePower;

--- a/tests/unit/ScalarNoiseMaxMin_1.test
+++ b/tests/unit/ScalarNoiseMaxMin_1.test
@@ -58,9 +58,7 @@ printBoundedMinMaxPower(powerChangesBase, t4+deltaT, t4+2*deltaT); // max: 0, mi
 
 %contains: stdout
 simtime (ms)  0.0- 4.9: max:0 W
-simtime (ms)  0.0- 4.9: min:nan W
-simtime (ms)  4.9- 5.0: max:0 W
-simtime (ms)  4.9- 5.0: min:nan W
+simtime (ms)  0.0- 4.9: min:0 W
 simtime (ms)  4.9- 5.0: max:0 W
 simtime (ms)  4.9- 5.0: min:0 W
 simtime (ms)  4.9- 5.1: max:5 W
@@ -68,7 +66,7 @@ simtime (ms)  4.9- 5.1: min:5 W
 simtime (ms)  5.0- 7.9: max:5 W
 simtime (ms)  5.0- 7.9: min:5 W
 simtime (ms)  5.0- 8.1: max:8 W
-simtime (ms)  5.0- 8.1: min:8 W
+simtime (ms)  5.0- 8.1: min:5 W
 simtime (ms) 10.0-11.0: max:8 W
 simtime (ms) 10.0-11.0: min:8 W
 simtime (ms)  5.0-18.0: max:8 W
@@ -76,7 +74,7 @@ simtime (ms)  5.0-18.0: min:5 W
 simtime (ms)  7.9-20.0: max:8 W
 simtime (ms)  7.9-20.0: min:3 W
 simtime (ms) 18.0-20.1: max:3 W
-simtime (ms) 18.0-20.1: min:3 W
+simtime (ms) 18.0-20.1: min:0 W
 simtime (ms) 20.0-20.1: max:0 W
 simtime (ms) 20.0-20.1: min:0 W
 simtime (ms) 20.1-20.2: max:0 W

--- a/tests/unit/ScalarNoiseMaxMin_1.test
+++ b/tests/unit/ScalarNoiseMaxMin_1.test
@@ -1,0 +1,83 @@
+%description:
+Tests ScalarNoise max and min functions
+ - Get max and min value for a power change array, including boundary conditions
+ - Get max and min value for an empty array
+
+% includes:
+#include <stdio.h>
+#include "inet/physicallayer/analogmodel/packetlevel/ScalarNoise.h"
+
+%global:
+
+using namespace omnetpp;
+using namespace inet;
+using namespace ::inet::physicallayer;
+using inet::units::values::W;
+using inet::units::values::Hz;
+using inet::units::values::MHz;
+using inet::units::values::kHz;
+
+void printBoundedMinMaxPower(const std::map<simtime_t, W>& powerChangesBase,
+        const omnetpp::SimTime& startTime, const omnetpp::SimTime& endTime)
+{
+    Hz centerFrequency = MHz(1000);
+    Hz bandwidth = kHz(1);
+    auto testPowerChanges = new std::map<simtime_t, W>(powerChangesBase);
+    ScalarNoise test_unit(startTime, endTime, centerFrequency, bandwidth,
+            testPowerChanges);
+    char time_bounds[30];
+    sprintf(time_bounds, "simtime (ms) %4.1f-%4.1f: ", startTime.dbl()*1000.0, endTime.dbl()*1000.0);
+    EV << time_bounds << "max:" << test_unit.computeMaxPower(startTime, endTime) << endl;
+    EV << time_bounds << "min:" << test_unit.computeMinPower(startTime, endTime) << endl;
+}
+%activity:
+auto t1 = SimTime(5, SimTimeUnit::SIMTIME_MS);
+auto t2 = SimTime(8, SimTimeUnit::SIMTIME_MS);
+auto t3 = SimTime(18, SimTimeUnit::SIMTIME_MS);
+auto t4 = SimTime(20, SimTimeUnit::SIMTIME_MS);
+auto deltaT = SimTime(100, SimTimeUnit::SIMTIME_US);
+std::map<simtime_t, W> powerChangesBase;
+powerChangesBase.insert(std::pair<simtime_t, W>( t1, inet::W(5) ));
+powerChangesBase.insert(std::pair<simtime_t, W>( t2, inet::W(3) ));
+powerChangesBase.insert(std::pair<simtime_t, W>( t3, inet::W(-5) ));
+powerChangesBase.insert(std::pair<simtime_t, W>( t4, inet::W(-3) ));
+
+printBoundedMinMaxPower(powerChangesBase, 0, t1-deltaT); //max: 0, min: NaN
+printBoundedMinMaxPower(powerChangesBase, t1-deltaT, t1); //max: 0, min: NaN
+printBoundedMinMaxPower(powerChangesBase, t1-deltaT, t1+deltaT); //max: 5, min: 5
+printBoundedMinMaxPower(powerChangesBase, t1, t2-deltaT); //max: 5. min: 5
+printBoundedMinMaxPower(powerChangesBase, t1, t2+deltaT); //max: 8, min: 5
+auto startTime = SimTime(10, SimTimeUnit::SIMTIME_MS);
+auto endTime = SimTime(11, SimTimeUnit::SIMTIME_MS);
+printBoundedMinMaxPower(powerChangesBase, startTime, endTime); // max:8, min: 8
+printBoundedMinMaxPower(powerChangesBase, t1, t3); // max: 8, min: 5
+printBoundedMinMaxPower(powerChangesBase, t2-deltaT, t4); // max: 8, min: 3
+printBoundedMinMaxPower(powerChangesBase, t3, t4+deltaT); // max: 3, min: 0
+printBoundedMinMaxPower(powerChangesBase, t4, t4+deltaT); // max: 0, min: 0
+printBoundedMinMaxPower(powerChangesBase, t4+deltaT, t4+2*deltaT); // max: 0, min: NaN
+
+%contains: stdout
+simtime (ms)  0.0- 4.9: max:0 W
+simtime (ms)  0.0- 4.9: min:nan W
+simtime (ms)  4.9- 5.0: max:0 W
+simtime (ms)  4.9- 5.0: min:nan W
+simtime (ms)  4.9- 5.0: max:0 W
+simtime (ms)  4.9- 5.0: min:0 W
+simtime (ms)  4.9- 5.1: max:5 W
+simtime (ms)  4.9- 5.1: min:5 W
+simtime (ms)  5.0- 7.9: max:5 W
+simtime (ms)  5.0- 7.9: min:5 W
+simtime (ms)  5.0- 8.1: max:8 W
+simtime (ms)  5.0- 8.1: min:8 W
+simtime (ms) 10.0-11.0: max:8 W
+simtime (ms) 10.0-11.0: min:8 W
+simtime (ms)  5.0-18.0: max:8 W
+simtime (ms)  5.0-18.0: min:5 W
+simtime (ms)  7.9-20.0: max:8 W
+simtime (ms)  7.9-20.0: min:3 W
+simtime (ms) 18.0-20.1: max:3 W
+simtime (ms) 18.0-20.1: min:3 W
+simtime (ms) 20.0-20.1: max:0 W
+simtime (ms) 20.0-20.1: min:0 W
+simtime (ms) 20.1-20.2: max:0 W
+simtime (ms) 20.1-20.2: min:nan W


### PR DESCRIPTION
Fixes the behaviour for the computeMaxPower function in #700 

### Changes to out of range behaviour for `computeMinPower`
Previously a startTime and endTime out side of the range of power changes would return NaN. 

Now it returns 0 if out of range before and NaN if *both* are out of range after the power changes range

It is debatable what "correct" behaviour should be, this shouldn't ever actually be a problem though, looking at where the function is used. Since either 0 and NaN have the same effect to the subsequent computation *and/or* the powerChanges are exactly aligned with startTime or endTime