### PR TITLE
NetworkProtocolBase : protect protocol pointer dereference.

### DIFF
--- a/src/inet/networklayer/base/NetworkProtocolBase.cc
+++ b/src/inet/networklayer/base/NetworkProtocolBase.cc
@@ -61,6 +61,8 @@ void NetworkProtocolBase::sendUp(cMessage *message)
 {
     if (Packet *packet = dynamic_cast<Packet *>(message)) {
         const Protocol *protocol = packet->getTag<PacketProtocolTag>()->getProtocol();
+        if (!protocol)
+            throw cRuntimeError("Packet does not have a protocol tag");
         const auto& addr = packet->getTag<L3AddressInd>();
         auto remoteAddress(addr->getSrcAddress());
         auto localAddress(addr->getDestAddress());


### PR DESCRIPTION
When receiving a packet from a lower layer, the object `NetworkProtocolBase` uses the `PacketProtocolTag` to determine the protocol of the upper layer, in order to decide the gate to which to send the packet. A `PacketProtocolTag` **should** therefore be there, and carry a valid pointer to a protocol.

The `getTag` method throws an exception if no `PacketProtocolTag` is found, but the possibility remains that a `PacketProtocolTag` is present, but the protocol pointer inside is `nullptr`. Said pointer is dereferenced multiple time in the remainder of the method, making a segfault possible. Since this pointer is needed to correctly send the packet to the upper layers, making it compulsory by throwing an error if not valid prevents segfaults, and enforces the constraints of the API.

I'm available for any question or suggestion you might have.

Best,

Aymeric Agon-Rambosson