### PR TITLE
Implement TCP graceful shutdown in lifecycle interface.

### DIFF
--- a/examples/inet/shutdownrestart/omnetpp.ini
+++ b/examples/inet/shutdownrestart/omnetpp.ini
@@ -8,6 +8,10 @@ sim-time-limit = 100s
 
 **.hasStatus = true
 
+# this timer had to modified to reduce the amount of time to wait for segments after the FYN is received
+# what else can we do?
+**.msl = 0s
+
 *.scenarioManager.script = xmldoc(${scenario = "scenario_node.xml", "scenario_app.xml", "scenario_iface.xml"})
 
 [Config Ping]

--- a/src/inet/applications/tcpapp/TelnetApp.cc
+++ b/src/inet/applications/tcpapp/TelnetApp.cc
@@ -74,8 +74,8 @@ void TelnetApp::handleStopOperation(LifecycleOperation *operation)
 {
     cancelEvent(timeoutMsg);
     if (socket.isOpen()) {
-        close();
-        delayActiveOperationFinish(par("stopOperationTimeout"));
+//        close();
+//        delayActiveOperationFinish(par("stopOperationTimeout"));
     }
 }
 
@@ -190,10 +190,10 @@ void TelnetApp::socketClosed(TcpSocket *socket)
         timeoutMsg->setKind(MSGKIND_CONNECT);
         checkedScheduleAt(simTime() + par("idleInterval"), timeoutMsg);
     }
-    else if (operationalState == State::STOPPING_OPERATION) {
-        if (!this->socket.isOpen())
-            startActiveOperationExtraTimeOrFinish(par("stopOperationExtraTime"));
-    }
+//    else if (operationalState == State::STOPPING_OPERATION) {
+//        if (!this->socket.isOpen())
+//            startActiveOperationExtraTimeOrFinish(par("stopOperationExtraTime"));
+//    }
 }
 
 void TelnetApp::socketFailure(TcpSocket *socket, int code)

--- a/src/inet/common/TemporarySharedPtr.h
+++ b/src/inet/common/TemporarySharedPtr.h
@@ -61,6 +61,8 @@ class TemporarySharedPtrClassDescriptor : public cClassDescriptor
     virtual const char *getFieldStructName(int field) const override { return classDescriptor->getFieldStructName(field); }
     virtual any_ptr getFieldStructValuePointer(any_ptr object, int field, int i) const override { return classDescriptor->getFieldStructValuePointer(getObjectPointer(object), field, i); }
     virtual void setFieldStructValuePointer(any_ptr object, int field, int i, any_ptr ptr) const override { classDescriptor->setFieldStructValuePointer(getObjectPointer(object), field, i, ptr); }
+    virtual cValue getFieldValue(any_ptr object, int field, int i) const override { return classDescriptor->getFieldValue(object, field, i); }
+    virtual void setFieldValue(any_ptr object, int field, int i, const cValue& value) const override { classDescriptor->setFieldValue(object, field, i, value); }
 };
 
 /**

--- a/src/inet/common/lifecycle/OperationalMixinImpl.h
+++ b/src/inet/common/lifecycle/OperationalMixinImpl.h
@@ -84,8 +84,8 @@ void OperationalMixin<T>::handleMessageWhenDown(cMessage *message)
         throw cRuntimeError("Self message '%s' received when %s is down", message->getName(), T::getComponentType()->getName());
     else if (simTime() == lastChange)
         EV_WARN << T::getComponentType()->getName() << " is down, dropping '" << message->getName() << "' message\n";
-    else
-        throw cRuntimeError("Message '%s' received when %s is down", message->getName(), T::getComponentType()->getName());
+//    else
+//        throw cRuntimeError("Message '%s' received when %s is down", message->getName(), T::getComponentType()->getName());
     delete message;
 }
 

--- a/src/inet/physicallayer/wireless/common/contract/packetlevel/IModulation.msg
+++ b/src/inet/physicallayer/wireless/common/contract/packetlevel/IModulation.msg
@@ -34,6 +34,6 @@ class IApskModulation
 {
     @existingClass;
     @descriptor(readonly);
-    int codeWordSize;
-    int constellationSize;
+    unsigned int codeWordSize;
+    unsigned int constellationSize;
 };

--- a/src/inet/transportlayer/tcp/Tcp.cc
+++ b/src/inet/transportlayer/tcp/Tcp.cc
@@ -227,6 +227,9 @@ void Tcp::removeConnection(TcpConnection *conn)
 
     emit(tcpConnectionRemovedSignal, conn);
     conn->deleteModule();
+
+    if (operationalState == State::STOPPING_OPERATION && tcpAppConnMap.empty())
+        startActiveOperationExtraTimeOrFinish(par("stopOperationExtraTime"));
 }
 
 TcpConnection *Tcp::findConnForSegment(const Ptr<const TcpHeader>& tcpHeader, L3Address srcAddr, L3Address destAddr)
@@ -382,10 +385,26 @@ void Tcp::handleStartOperation(LifecycleOperation *operation)
 
 void Tcp::handleStopOperation(LifecycleOperation *operation)
 {
-    // FIXME close connections??? yes, because the applications may not close them!!!
-    reset();
-    delayActiveOperationFinish(par("stopOperationTimeout"));
-    startActiveOperationExtraTimeOrFinish(par("stopOperationExtraTime"));
+    if (tcpAppConnMap.empty())
+        startActiveOperationExtraTimeOrFinish(par("stopOperationExtraTime"));
+    else {
+        for (auto& elem : tcpAppConnMap) {
+            auto connection = elem.second;
+            auto state = connection->getFsmState();
+            if (state != TCP_S_FIN_WAIT_1 &&
+                state != TCP_S_FIN_WAIT_2 &&
+                state != TCP_S_CLOSING &&
+                state != TCP_S_LAST_ACK &&
+                state != TCP_S_TIME_WAIT)
+            {
+                auto request = new Request("CLOSE", TCP_C_CLOSE);
+                TcpCommand *cmd = new TcpCommand();
+                request->setControlInfo(cmd);
+                connection->processAppCommand(request);
+            }
+        }
+        delayActiveOperationFinish(par("stopOperationTimeout"));
+    }
 }
 
 void Tcp::handleCrashOperation(LifecycleOperation *operation)


### PR DESCRIPTION
This change was created during the 2021 summit. It's incomplete, see the comments.