### PR TITLE
Add ModuleIdAddress and ModulePathAddress to get L3AddressResolver::findHostWithAddress

### DIFF
--- a/src/inet/networklayer/common/L3AddressResolver.cc
+++ b/src/inet/networklayer/common/L3AddressResolver.cc
@@ -531,30 +531,30 @@ cModule *L3AddressResolver::findHostWithAddress(const L3Address& add)
             for (int i = 0; i < itable->getNumInterfaces(); i++) {
                 NetworkInterface *entry = itable->getInterface(i);
                 switch (add.getType()) {
-#ifdef INET_WITH_IPv6
-                    case L3Address::IPv6: {
-                        auto protocolData = entry->findProtocolData<Ipv6InterfaceData>();
-                        if (protocolData != nullptr && protocolData->hasAddress(add.toIpv6()))
-                            return mod;
-                        break;
-                    }
-
-#endif // ifdef INET_WITH_IPv6
-#ifdef INET_WITH_IPv4
-                    case L3Address::IPv4: {
-                        auto protocolData = entry->findProtocolData<Ipv4InterfaceData>();
-                        if (protocolData != nullptr && protocolData->getIPAddress() == add.toIpv4())
-                            return mod;
-                        break;
-                    }
-
-#endif // ifdef INET_WITH_IPv4
+#ifdef WITH_IPv6
+                    case L3Address::IPv6:
+#endif // ifdef WITH_IPv6
+#ifdef WITH_IPv4
+                    case L3Address::IPv4:
+#endif // ifdef WITH_IPv4
                     case L3Address::MAC:
-                        if (entry->getMacAddress() == add.toMac())
+                        if (entry->hasNetworkAddress(add))
                             return mod;
                         break;
+                    case L3Address::MODULEPATH: {
+                        if(entry->getModulePathAddress() == add.toModulePath()){
+                            return mod;
+                        }
+                        break;
+                    }
+                    case L3Address::MODULEID: {
+                        if(entry->getModuleIdAddress() == add.toModuleId()){
+                            return mod;
+                        }
+                        break;
+                    }
                     default:
-                        (void)entry; // eliminate warning: unused variable 'entry'
+                        (void)entry;    // eliminate warning: unused variable 'entry'
                         throw cRuntimeError("findHostWithAddress() doesn't accept AddressType '%s', yet", L3Address::getTypeName(add.getType()));
                         break;
                 }

--- a/src/inet/networklayer/common/L3AddressResolver.cc
+++ b/src/inet/networklayer/common/L3AddressResolver.cc
@@ -531,12 +531,8 @@ cModule *L3AddressResolver::findHostWithAddress(const L3Address& add)
             for (int i = 0; i < itable->getNumInterfaces(); i++) {
                 NetworkInterface *entry = itable->getInterface(i);
                 switch (add.getType()) {
-#ifdef WITH_IPv6
                     case L3Address::IPv6:
-#endif // ifdef WITH_IPv6
-#ifdef WITH_IPv4
                     case L3Address::IPv4:
-#endif // ifdef WITH_IPv4
                     case L3Address::MAC:
                         if (entry->hasNetworkAddress(add))
                             return mod;


### PR DESCRIPTION
Created to replace #682 

Replaced the logic to check Ipv6, Ipv4 and Mac L3Address types with a call to the NetworkInterface::hasNetworkAddress(L3address ) which duplicated the logic.

Possibly the ModulePath and ModuleId addresses should also use the function too but it's unclear in the function description for findHostWithAddress whether it should exclusively look for Hosts with NetworkInterfaces with NextHopInterfaceData or whether it is sufficient for it to just be the node with the right module id or module path.

Currently in InterfaceTable::findInterfaceByAddress(L3Address ) it matches interfaces without NextHopInterfaceData