### PR TITLE
HTBQueue: Shorter fingerprint tests and fixed std::set determinism with pointers

### DIFF
--- a/examples/htb/omnetpp.ini
+++ b/examples/htb/omnetpp.ini
@@ -48,7 +48,7 @@ record-eventlog = false
 [Config scenarioUDP1]
 description = "HTB Evaluation scenario I"
 network = htbEvaluation
-sim-time-limit=100s
+sim-time-limit=11s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -75,7 +75,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].destAddresses = "hostFDO[0]"
 *.serverFDO.app[*].destPort = 1042 + index
 *.serverFDO.app[*].messageLength = 1465B
-*.serverFDO.app[*].sendInterval = uniform(0.1ms, 0.11ms)
+*.serverFDO.app[*].sendInterval = 0.1ms
 *.serverFDO.app[*].packetName = "UDPData"
 *.serverFDO.app[*].typename = "UdpBasicApp"
 *.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
@@ -83,8 +83,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
 
-*.serverFDO.app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.serverFDO.app[*].stopTime = replaceUnit(10*index+uniform(50,50.1), "s") # time of finishing sending, negative values mean forever
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
 
 *.nFDO =  1
 
@@ -116,7 +116,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioUDP2]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
-sim-time-limit=100s
+sim-time-limit=11s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -143,7 +143,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].destAddresses = "hostFDO[0]"
 *.serverFDO.app[*].destPort = 1042 + index
 *.serverFDO.app[*].messageLength = 1465B
-*.serverFDO.app[*].sendInterval = uniform(0.1ms, 0.11ms)
+*.serverFDO.app[*].sendInterval = 0.1ms
 *.serverFDO.app[*].packetName = "UDPData"
 *.serverFDO.app[*].typename = "UdpBasicApp"
 *.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
@@ -151,8 +151,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
 
-*.serverFDO.app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.serverFDO.app[*].stopTime = replaceUnit(10*index+uniform(50,50.1), "s") # time of finishing sending, negative values mean forever
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
 
 *.nFDO =  1
 
@@ -184,7 +184,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioUDP3]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
-sim-time-limit=40s
+sim-time-limit=11s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -211,7 +211,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].destAddresses = "hostFDO[0]"
 *.serverFDO.app[*].destPort = 1042 + index
 *.serverFDO.app[*].messageLength = 1465B
-*.serverFDO.app[*].sendInterval = replaceUnit(uniform(0.1,0.11), "ms")
+*.serverFDO.app[*].sendInterval = 0.1ms
 *.serverFDO.app[*].packetName = "UDPData"
 *.serverFDO.app[*].typename = "UdpBasicApp"
 *.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
@@ -219,8 +219,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
 
-*.serverFDO.app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.serverFDO.app[*].stopTime = replaceUnit(10*index+uniform(20,20.1), "s") # time of finishing sending, negative values mean forever
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
 
 *.nFDO =  1
 
@@ -251,7 +251,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioUDP4]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
-sim-time-limit=100s
+sim-time-limit=11s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -278,7 +278,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].destAddresses = "hostFDO[0]"
 *.serverFDO.app[*].destPort = 1042 + index
 *.serverFDO.app[*].messageLength = 1465B
-*.serverFDO.app[*].sendInterval = replaceUnit(uniform(0.1,0.11), "ms")
+*.serverFDO.app[*].sendInterval = 0.1ms
 *.serverFDO.app[*].packetName = "UDPData"
 *.serverFDO.app[*].typename = "UdpBasicApp"
 *.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
@@ -286,8 +286,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
 
-*.serverFDO.app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.serverFDO.app[*].stopTime = replaceUnit(10*index+uniform(50,50.1), "s") # time of finishing sending, negative values mean forever
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
 
 *.nFDO =  1
 
@@ -318,7 +318,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioTCP1]
 description = "HTB Evaluation scenario I"
 network = htbEvaluation
-sim-time-limit=80s
+sim-time-limit=15s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -337,14 +337,14 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
 *.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
 *.hostFDO[0].app[*].requestLength = 800B # length of a request
-*.hostFDO[0].app[*].replyLength = 80MiB # length of a reply
+*.hostFDO[0].app[*].replyLength = 8MiB # length of a reply
 *.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
 *.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
 *.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
 *.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
-*.hostFDO[0].app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.hostFDO[0].app[*].stopTime = replaceUnit(10*index+uniform(71,71.1), "s") # time of finishing sending, negative values mean forever
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
 
 # File download server
 *.serverFDO.hasTcp = true
@@ -386,7 +386,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioTCP2]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
-sim-time-limit=90s
+sim-time-limit=15s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -405,14 +405,14 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
 *.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
 *.hostFDO[0].app[*].requestLength = 800B # length of a request
-*.hostFDO[0].app[*].replyLength = 80MiB # length of a reply
+*.hostFDO[0].app[*].replyLength = 8MiB # length of a reply
 *.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
 *.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
 *.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
 *.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
-*.hostFDO[0].app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.hostFDO[0].app[*].stopTime = replaceUnit(10*index+uniform(71,71.1), "s") # time of finishing sending, negative values mean forever
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
 
 # File download server
 *.serverFDO.hasTcp = true
@@ -454,7 +454,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioTCP3]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
-sim-time-limit=40s
+sim-time-limit=15s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -473,14 +473,14 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
 *.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
 *.hostFDO[0].app[*].requestLength = 800B # length of a request
-*.hostFDO[0].app[*].replyLength = 60MiB # length of a reply
+*.hostFDO[0].app[*].replyLength = 6MiB # length of a reply
 *.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
 *.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
 *.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
 *.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
-*.hostFDO[0].app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.hostFDO[0].app[*].stopTime = replaceUnit(10*index+uniform(71,71.1), "s") # time of finishing sending, negative values mean forever
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
 
 # File download server
 *.serverFDO.hasTcp = true
@@ -522,7 +522,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 [Config scenarioTCP4]
 description = "HTB Evaluation scenario I"
 network = htbEvaluation
-sim-time-limit=90s
+sim-time-limit=15s
 
 output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
 output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
@@ -541,14 +541,14 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
 *.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
 *.hostFDO[0].app[*].requestLength = 800B # length of a request
-*.hostFDO[0].app[*].replyLength = 80MiB # length of a reply
+*.hostFDO[0].app[*].replyLength = 8MiB # length of a reply
 *.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
 *.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
 *.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
 *.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
 *.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
-*.hostFDO[0].app[*].startTime = replaceUnit(10*index+uniform(1,1.1), "s") # time first session begins
-*.hostFDO[0].app[*].stopTime = replaceUnit(10*index+uniform(71,71.1), "s") # time of finishing sending, negative values mean forever
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
 
 # File download server
 *.serverFDO.hasTcp = true

--- a/src/inet/queueing/scheduler/HtbScheduler.cc
+++ b/src/inet/queueing/scheduler/HtbScheduler.cc
@@ -326,7 +326,7 @@ simtime_t HtbScheduler::doEvents(int level) {
         return 0;
     }
 
-    for (auto it = levels[level]->waitingClasses.begin(); it != levels[level]->waitingClasses.end(); ) {
+    for (auto it = levels[level]->waitingClasses.cbegin(); it != levels[level]->waitingClasses.cend(); ) {
         htbClass *cl = *it; // Class to update
         it++;
 
@@ -539,11 +539,11 @@ void HtbScheduler::htbEnqueue(int index) {
 HtbScheduler::htbClass* HtbScheduler::getLeaf(int priority, int level) {
     htbClass *cl = levels[level]->nextToDequeue[priority];
     printClass(cl);
-    if (levels[level]->selfFeeds[priority].find(cl) == levels[level]->selfFeeds[priority].end()) {
+    if (levels[level]->selfFeeds[priority].find(cl) == levels[level]->selfFeeds[priority].cend()) {
         levels[cl->level]->selfFeeds[priority].insert(cl);
         levels[cl->level]->nextToDequeue[priority] = *std::next(levels[cl->level]->selfFeeds[priority].find(cl));
-        if (levels[cl->level]->nextToDequeue[priority] == *levels[cl->level]->selfFeeds[priority].end()) {
-            levels[cl->level]->nextToDequeue[priority] = *levels[cl->level]->selfFeeds[priority].begin();
+        if (levels[cl->level]->nextToDequeue[priority] == *levels[cl->level]->selfFeeds[priority].cend()) {
+            levels[cl->level]->nextToDequeue[priority] = *levels[cl->level]->selfFeeds[priority].cbegin();
         }
         levels[cl->level]->selfFeeds[priority].erase(cl);
         cl = levels[cl->level]->nextToDequeue[priority];
@@ -560,11 +560,11 @@ HtbScheduler::htbClass* HtbScheduler::getLeaf(int priority, int level) {
         htbClass *parent = cl;
         cl = parent->inner.nextToDequeue[priority];
         printClass(cl);
-        if (parent->inner.innerFeeds[priority].find(cl) == parent->inner.innerFeeds[priority].end()) {
+        if (parent->inner.innerFeeds[priority].find(cl) == parent->inner.innerFeeds[priority].cend()) {
             parent->inner.innerFeeds[priority].insert(cl);
             parent->inner.nextToDequeue[priority] = *std::next(parent->inner.innerFeeds[priority].find(cl));
-            if (parent->inner.nextToDequeue[priority] == *parent->inner.innerFeeds[priority].end()) {
-                parent->inner.nextToDequeue[priority] = *parent->inner.innerFeeds[priority].begin();
+            if (parent->inner.nextToDequeue[priority] == *parent->inner.innerFeeds[priority].cend()) {
+                parent->inner.nextToDequeue[priority] = *parent->inner.innerFeeds[priority].cbegin();
             }
             parent->inner.innerFeeds[priority].erase(cl);
             cl = parent->inner.nextToDequeue[priority];
@@ -631,8 +631,8 @@ int HtbScheduler::htbDequeue(int priority, int level) {
                 if (tempNode->parent->inner.innerFeeds[priority].size() > 1 && tempNode->mode == may_borrow) {
                     if (tempNode->parent->inner.nextToDequeue[priority] == cl) {
                         tempNode->parent->inner.nextToDequeue[priority] = *std::next(tempNode->parent->inner.innerFeeds[priority].find(tempNode));
-                        if (tempNode->parent->inner.nextToDequeue[priority] == *tempNode->parent->inner.innerFeeds[priority].end()) {
-                            tempNode->parent->inner.nextToDequeue[priority] = *tempNode->parent->inner.innerFeeds[priority].begin();
+                        if (tempNode->parent->inner.nextToDequeue[priority] == *tempNode->parent->inner.innerFeeds[priority].cend()) {
+                            tempNode->parent->inner.nextToDequeue[priority] = *tempNode->parent->inner.innerFeeds[priority].cbegin();
                         } else {
                             break;
                         }
@@ -642,8 +642,8 @@ int HtbScheduler::htbDequeue(int priority, int level) {
                 } else if (levels[tempNode->level]->selfFeeds[priority].size() > 1 && tempNode->mode == can_send) {
                     if (levels[tempNode->level]->nextToDequeue[priority] == cl) {
                         levels[tempNode->level]->nextToDequeue[priority] = *std::next(levels[tempNode->level]->selfFeeds[priority].find(tempNode));
-                        if (levels[tempNode->level]->nextToDequeue[priority] == *levels[tempNode->level]->selfFeeds[priority].end()) {
-                            levels[tempNode->level]->nextToDequeue[priority] = *levels[tempNode->level]->selfFeeds[priority].begin();
+                        if (levels[tempNode->level]->nextToDequeue[priority] == *levels[tempNode->level]->selfFeeds[priority].cend()) {
+                            levels[tempNode->level]->nextToDequeue[priority] = *levels[tempNode->level]->selfFeeds[priority].cbegin();
                         }
                         if (levels[tempNode->level]->nextToDequeue[priority] == nullptr) {
                             throw cRuntimeError("Next to dequeue would be null even though it shouldn't be!");
@@ -752,7 +752,7 @@ void HtbScheduler::activateClassPrios(htbClass *cl) {
         for (int i = 0; i < maxHtbNumPrio; i++) { // i = priority level
             if (tempActivity[i]) { // Check if parent shoudl be actie for priority
                 parent->activePriority[i] = true; // Set parent to active on priority
-                if (parent->inner.innerFeeds[i].find(cl) == parent->inner.innerFeeds[i].end()) { // Check if we are in parent's inner feed
+                if (parent->inner.innerFeeds[i].find(cl) == parent->inner.innerFeeds[i].cend()) { // Check if we are in parent's inner feed
                     if (parent->inner.nextToDequeue[i] == NULL) {
                         parent->inner.nextToDequeue[i] = cl;
                     }
@@ -769,7 +769,7 @@ void HtbScheduler::activateClassPrios(htbClass *cl) {
     if (cl->mode == can_send && std::any_of(std::begin(newActivity), std::end(newActivity), [](bool b) {return b;})){
         for (int i = 0; i < maxHtbNumPrio; i++) { // i = priority level
             if (newActivity[i]) {
-                if (levels[cl->level]->selfFeeds[i].find(cl) == levels[cl->level]->selfFeeds[i].end()) {
+                if (levels[cl->level]->selfFeeds[i].find(cl) == levels[cl->level]->selfFeeds[i].cend()) {
                     if (levels[cl->level]->nextToDequeue[i] == NULL) {
                         levels[cl->level]->nextToDequeue[i] = cl;
                     }
@@ -796,7 +796,7 @@ void HtbScheduler::deactivateClassPrios(htbClass *cl) {
         
         for (int i = 0; i < maxHtbNumPrio; i++) { // i = priority level
             if (tempActivity[i]) {
-                if (parent->inner.innerFeeds[i].find(cl) != parent->inner.innerFeeds[i].end()) {
+                if (parent->inner.innerFeeds[i].find(cl) != parent->inner.innerFeeds[i].cend()) {
                     parent->inner.innerFeeds[i].erase(cl);
                 }
                 if (parent->inner.innerFeeds[i].empty()) {
@@ -875,7 +875,7 @@ void HtbScheduler::accountCTokens(htbClass *cl, long long bytes, long long diff)
 
 void HtbScheduler::htbAddToWaitTree(htbClass *cl, long long delay) {
     cl->nextEventTime = simTime() + SimTime(delay, SIMTIME_NS);
-    if (levels[cl->level]->waitingClasses.find(cl) != levels[cl->level]->waitingClasses.end()) {
+    if (levels[cl->level]->waitingClasses.find(cl) != levels[cl->level]->waitingClasses.cend()) {
         throw cRuntimeError("Class added to waiting classes even though it was already there!");
     }
     levels[cl->level]->waitingClasses.insert(cl);
@@ -885,7 +885,7 @@ void HtbScheduler::htbAddToWaitTree(htbClass *cl, long long delay) {
 
 void HtbScheduler::htbRemoveFromWaitTree(htbClass *cl) {
     std::multiset<htbClass*, waitComp>::iterator hit(levels[cl->level]->waitingClasses.find(cl));
-    while (hit != levels[cl->level]->waitingClasses.end()) {
+    while (hit != levels[cl->level]->waitingClasses.cend()) {
         if (*hit == cl) {
             levels[cl->level]->waitingClasses.erase(hit);
             break;

--- a/src/inet/queueing/scheduler/HtbScheduler.cc
+++ b/src/inet/queueing/scheduler/HtbScheduler.cc
@@ -943,7 +943,7 @@ void HtbScheduler::receiveSignal(cComponent *source, simsignal_t signal, cObject
     Enter_Method("%s", cComponent::getSignalName(signal));
     if (signal == packetPushedSignal) {
         if (std::string(source->getClassName()).find("inet::queueing::PacketQueue") != std::string::npos) { // Might need adjustment so that we can use compound packet queues as queues
-            int index = dynamic_cast<cModule*>(source)->getIndex();
+            int index = static_cast<cModule*>(source)->getIndex();
             EV_INFO << "HtbScheduler::receiveSignal: PacketQueue " << index << " emitted a packetPushed signal! Call htbEnqueue for leaf " << index << endl;
             htbEnqueue(index);
         }

--- a/src/inet/queueing/scheduler/HtbScheduler.cc
+++ b/src/inet/queueing/scheduler/HtbScheduler.cc
@@ -72,6 +72,8 @@ void HtbScheduler::printClass(htbClass *cl) {
 HtbScheduler::htbClass *HtbScheduler::createAndAddNewClass(cXMLElement* oneClass, int queueId) {
     // Create class, set its name and parents' name
     htbClass* newClass = new htbClass();
+    lastGlobalIdUsed += 1;
+    newClass->classId = lastGlobalIdUsed;
     newClass->name = oneClass->getAttribute("id");
     const char* parentName = oneClass->getFirstChildWithTag("parentId")->getNodeValue();
 

--- a/src/inet/queueing/scheduler/HtbScheduler.h
+++ b/src/inet/queueing/scheduler/HtbScheduler.h
@@ -98,8 +98,13 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
             simsignal_t deficitSig[maxHtbDepth]; // Signal for queue level statistics collection
             int queueId; // Id of the corresponding queue
         } leaf;
+        struct htbClassSetComp { // Comparator to sort the waiting classes according to their expected mode change time
+            bool operator()(htbClass* const & a, htbClass* const & b) const {
+                return a->name < b->name;
+            }
+        };
         struct htbClassInner { // Special class information for inner/root
-            std::set<htbClass*> innerFeeds[maxHtbNumPrio]; // Inner feeds of inner/root class
+            std::set<htbClass*, htbClassSetComp> innerFeeds[maxHtbNumPrio]; // Inner feeds of inner/root class
             htbClass* nextToDequeue[maxHtbNumPrio]; // DRR -> which class to dequeue next from inner feed
         } inner;
 
@@ -122,7 +127,7 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
     // Struct for the tree level
     struct htbLevel {
         unsigned int levelId; // Level number. 0 = Leaf
-        std::set<htbClass*> selfFeeds[maxHtbNumPrio]; // Self feeds for each priority. Contain active green classes
+        std::set<htbClass*, htbClass::htbClassSetComp> selfFeeds[maxHtbNumPrio]; // Self feeds for each priority. Contain active green classes
         htbClass* nextToDequeue[maxHtbNumPrio]; // Next green class to dequeue on level
         std::multiset<htbClass*, waitComp> waitingClasses; // Red classes waiting to become non-red.
     };

--- a/src/inet/queueing/scheduler/HtbScheduler.h
+++ b/src/inet/queueing/scheduler/HtbScheduler.h
@@ -60,6 +60,8 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
     bool valueCorectnessCheck;
     bool valueCorectnessAdj;
 
+    int lastGlobalIdUsed = 0;
+
     // Structure for the class
     struct htbClass {
         const char *name = "";
@@ -100,10 +102,11 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
         } leaf;
         struct htbClassSetComp { // Comparator to sort the waiting classes according to their expected mode change time
             bool operator()(htbClass* const & a, htbClass* const & b) const {
-                if (a->name == b->name) {
-                    return false;
-                }
-                return a->name < b->name;
+                // if (a->name == b->name) {
+                //     return false;
+                // }
+                // return a->name < b->name;
+                return a->classId < b->classId;
             }
         };
         struct htbClassInner { // Special class information for inner/root
@@ -116,15 +119,18 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
         simsignal_t ctokenBucket;
         simsignal_t classMode;
 
+        int classId; // Uniquie, deterministic, ID for class sorting
+
     };
 
     struct waitComp { // Comparator to sort the waiting classes according to their expected mode change time
         bool operator()(htbClass* const & a, htbClass* const & b) const {
             if (a->nextEventTime == b->nextEventTime) {
-                if (a->name == b->name) {
-                    return false;
-                }
-                return a->name < b->name;
+                // if (a->name == b->name) {
+                //     return false;
+                // }
+                // return a->name < b->name;
+                return a->classId < b->classId;
                 // return std::less<htbClass*>{}(a, b); // Care for DRR ordering
             }
             return a->nextEventTime < b->nextEventTime;

--- a/src/inet/queueing/scheduler/HtbScheduler.h
+++ b/src/inet/queueing/scheduler/HtbScheduler.h
@@ -100,6 +100,9 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
         } leaf;
         struct htbClassSetComp { // Comparator to sort the waiting classes according to their expected mode change time
             bool operator()(htbClass* const & a, htbClass* const & b) const {
+                if (a->name == b->name) {
+                    return false;
+                }
                 return a->name < b->name;
             }
         };
@@ -118,6 +121,9 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
     struct waitComp { // Comparator to sort the waiting classes according to their expected mode change time
         bool operator()(htbClass* const & a, htbClass* const & b) const {
             if (a->nextEventTime == b->nextEventTime) {
+                if (a->name == b->name) {
+                    return false;
+                }
                 return a->name < b->name;
                 // return std::less<htbClass*>{}(a, b); // Care for DRR ordering
             }

--- a/src/inet/queueing/scheduler/HtbScheduler.h
+++ b/src/inet/queueing/scheduler/HtbScheduler.h
@@ -118,7 +118,8 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
     struct waitComp { // Comparator to sort the waiting classes according to their expected mode change time
         bool operator()(htbClass* const & a, htbClass* const & b) const {
             if (a->nextEventTime == b->nextEventTime) {
-                return std::less<htbClass*>{}(a, b); // Care for DRR ordering
+                return a->name < b->name;
+                // return std::less<htbClass*>{}(a, b); // Care for DRR ordering
             }
             return a->nextEventTime < b->nextEventTime;
         }

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -125,14 +125,14 @@
 
 /examples/geometry/,                 -f omnetpp.ini -c General -r 0,                100s,            75d0-cba9/tplx;ce1d-d136/~tNl;51b3-9d40/~tND;900d-aaeb/tyf, PASS, wireless
 
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP1 -r 0,           110s,         aea3-b585/tplx;dc4b-1c5e/~tNl;f062-63b1/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2 -r 0,           100s,         dfb3-dd1f/tplx;9f45-fedb/~tNl;bedc-acdc/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP3 -r 0,           40s,         2e5e-a510/tplx;d05e-bd70/~tNl;4767-cda1/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP4 -r 0,           100s,         80ab-116c/tplx;607d-5010/~tNl;de9f-c2dd/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP1 -r 0,           100s,         1a2c-182a/tplx;a987-b345/~tNl;6340-8ea3/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2 -r 0,           90s,         4562-27ef/tplx;60da-62b3/~tNl;ec81-bec9/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP3 -r 0,           40s,         dbe9-46ae/tplx;4ffe-5787/~tNl;d686-26fe/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP4 -r 0,           90s,         9928-3662/tplx;01ba-05e6/~tNl;32eb-80be/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP1 -r 0,           11s,         0d52-d591/tplx;78bb-2faf/~tNl;04f5-a63e/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2 -r 0,           11s,         7eb1-8937/tplx;8cfb-b76a/~tNl;7a81-6a38/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP3 -r 0,           11s,         85de-b1b8/tplx;bd2f-b11a/~tNl;2a20-a8c2/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP4 -r 0,           11s,         e148-ae6b/tplx;3b2b-8f9c/~tNl;b39a-e108/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP1 -r 0,           15s,         3c96-3421/tplx;bdef-4aa6/~tNl;b182-3255/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2 -r 0,           15s,         45fa-26b7/tplx;8268-307a/~tNl;90a4-b597/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP3 -r 0,           15s,         cc46-134f/tplx;477c-a439/~tNl;3ddf-840f/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP4 -r 0,           15s,         bfff-6c2e/tplx;1246-a746/~tNl;82e7-8d86/~tND, PASS,
 
 /examples/httptools/direct/flashdirect/, -f omnetpp.ini -c General -r 0,               500000s,      f607-5921/tplx;428e-2e61/~tNl;8154-c757/tyf, PASS,
 /examples/httptools/direct/pairdirect/, -f omnetpp.ini -c random -r 0,                 500000s,      6fc8-681d/tplx;128c-5b0a/~tNl;f06b-220a/tyf, PASS,

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -125,12 +125,12 @@
 
 /examples/geometry/,                 -f omnetpp.ini -c General -r 0,                100s,            75d0-cba9/tplx;ce1d-d136/~tNl;51b3-9d40/~tND;900d-aaeb/tyf, PASS, wireless
 
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP1 -r 0,           110s,         a6ce-e384/tplx;9710-1016/~tNl;82b4-1fea/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2 -r 0,           100s,         e3ab-9af4/tplx;709d-a44b/~tNl;42ff-a0f2/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP1 -r 0,           110s,         aea3-b585/tplx;dc4b-1c5e/~tNl;f062-63b1/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2 -r 0,           100s,         dfb3-dd1f/tplx;9f45-fedb/~tNl;bedc-acdc/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioUDP3 -r 0,           40s,         2e5e-a510/tplx;d05e-bd70/~tNl;4767-cda1/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioUDP4 -r 0,           100s,         80ab-116c/tplx;607d-5010/~tNl;de9f-c2dd/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP1 -r 0,           100s,         c489-5df7/tplx;1469-3bad/~tNl;e222-9b8f/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2 -r 0,           90s,         d4cd-6af0/tplx;2feb-4705/~tNl;55f8-33e3/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP1 -r 0,           100s,         1a2c-182a/tplx;a987-b345/~tNl;6340-8ea3/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2 -r 0,           90s,         4562-27ef/tplx;60da-62b3/~tNl;ec81-bec9/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioTCP3 -r 0,           40s,         dbe9-46ae/tplx;4ffe-5787/~tNl;d686-26fe/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioTCP4 -r 0,           90s,         9928-3662/tplx;01ba-05e6/~tNl;32eb-80be/~tND, PASS,
 


### PR DESCRIPTION
Shortened HTB fingerprint tests to at most 15 seconds each.

Also, added comparators to all uses of std::set and std::multiset to make them behave deterministically - i.e. each HTB class now has unique, deterministically assigned ID that is compared within the sets and multiset instead of the pointer itself.

A few words to the fingerprint tests. We have run the full suite on two separate machines multiple times and the tests were passing each time. So nothing changes between the runs. However, when the fingerprints are run on a new platform for the first time, some of them still fail. After an update to the fingerprints though, the tests pass every single time (at least for the multiple tries we did on a new machine). We are not 100% sure why that happens. We think that might have something to do with the platform dependencies...