### PR TITLE
HTBQueue: Fix & add examples working with Ethernet interface

### DIFF
--- a/examples/htb/omnetpp.ini
+++ b/examples/htb/omnetpp.ini
@@ -158,7 +158,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.hostFDO[0].eth[0].queue.numQueues = 5
 *.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
 *.hostFDO[0].eth[0].queue.htbHysterisis = false
-*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario1.xml")
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario1Eth.xml")
 *.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
 *.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
 *.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.srcPort == 1042), expr(has(udp) && udp.srcPort == 1043), expr(has(udp) && udp.srcPort == 1044), expr(has(udp) && udp.srcPort == 1045), expr(has(udp) && udp.srcPort == 1046)]
@@ -167,7 +167,7 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.numQueues = 5
 *.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
 *.serverFDO*.eth[0].queue.htbHysterisis = false
-*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario1.xml")
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario1Eth.xml")
 *.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]

--- a/examples/htb/omnetpp.ini
+++ b/examples/htb/omnetpp.ini
@@ -232,11 +232,75 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].typename = "DropTailQueue"
 *.serverFDO*.ppp[0].queue.htbHysterisis = false
 *.serverFDO*.ppp[0].queue.htbTreeConfig = xmldoc("tree_scenario2.xml")
-*.hostFDO[0].ppp[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
 
 **.connFIX0.datarate = 50Mbps
+**.connFIX0.delay = 1ms
+
+[Config scenarioUDP2Eth]
+description = "HTB Evaluation scenario II"
+network = htbEvaluationEth
+sim-time-limit=11s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 5
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasUdp = true
+*.hostFDO[0].app[*].typename = "UdpSink"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = 1042 + index # port number to listen on
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+
+*.hostFDO[0].app[*].startTime = 0s # time first session begins
+*.hostFDO[0].app[*].stopTime = -1s # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasUdp = true
+*.serverFDO.numApps = 5
+*.serverFDO.app[*].destAddresses = "hostFDO[0]"
+*.serverFDO.app[*].destPort = 1042 + index
+*.serverFDO.app[*].messageLength = 1465B
+*.serverFDO.app[*].sendInterval = 0.1ms
+*.serverFDO.app[*].packetName = "UDPData"
+*.serverFDO.app[*].typename = "UdpBasicApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = -1 # localPort number to listen on
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
+
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 5
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2Eth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.srcPort == 1042), expr(has(udp) && udp.srcPort == 1043), expr(has(udp) && udp.srcPort == 1044), expr(has(udp) && udp.srcPort == 1045), expr(has(udp) && udp.srcPort == 1046)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 5
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2Eth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
+
+**.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
 [Config scenarioUDP3]
@@ -303,6 +367,70 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
 
+[Config scenarioUDP3Eth]
+description = "HTB Evaluation scenario II"
+network = htbEvaluationEth
+sim-time-limit=11s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 2
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasUdp = true
+*.hostFDO[0].app[*].typename = "UdpSink"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = 1042 + index # port number to listen on
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+
+*.hostFDO[0].app[*].startTime = 0s # time first session begins
+*.hostFDO[0].app[*].stopTime = -1s # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasUdp = true
+*.serverFDO.numApps = 2
+*.serverFDO.app[*].destAddresses = "hostFDO[0]"
+*.serverFDO.app[*].destPort = 1042 + index
+*.serverFDO.app[*].messageLength = 1465B
+*.serverFDO.app[*].sendInterval = 0.1ms
+*.serverFDO.app[*].packetName = "UDPData"
+*.serverFDO.app[*].typename = "UdpBasicApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = -1 # localPort number to listen on
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
+
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 2
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenarioPrioEth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.srcPort == 1042), expr(has(udp) && udp.srcPort == 1043)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 2
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenarioPrioEth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043)]
+
+**.connFIX0.datarate = 100Mbps
+**.connFIX0.delay = 1ms
+
 [Config scenarioUDP4]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
@@ -365,6 +493,70 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
 
 **.connFIX0.datarate = 50Mbps
+**.connFIX0.delay = 1ms
+
+[Config scenarioUDP4Eth]
+description = "HTB Evaluation scenario II"
+network = htbEvaluationEth
+sim-time-limit=11s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 5
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasUdp = true
+*.hostFDO[0].app[*].typename = "UdpSink"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = 1042 + index # port number to listen on
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+
+*.hostFDO[0].app[*].startTime = 0s # time first session begins
+*.hostFDO[0].app[*].stopTime = -1s # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasUdp = true
+*.serverFDO.numApps = 5
+*.serverFDO.app[*].destAddresses = "hostFDO[0]"
+*.serverFDO.app[*].destPort = 1042 + index
+*.serverFDO.app[*].messageLength = 1465B
+*.serverFDO.app[*].sendInterval = 0.1ms
+*.serverFDO.app[*].packetName = "UDPData"
+*.serverFDO.app[*].typename = "UdpBasicApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = -1 # localPort number to listen on
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s # timeout value for lifecycle stop operation
+
+*.serverFDO.app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.serverFDO.app[*].stopTime = replaceUnit(1*index+5, "s") # time of finishing sending, negative values mean forever
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 5
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2PrioEth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.srcPort == 1042), expr(has(udp) && udp.srcPort == 1043), expr(has(udp) && udp.srcPort == 1044), expr(has(udp) && udp.srcPort == 1045), expr(has(udp) && udp.srcPort == 1046)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 5
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2PrioEth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
+
+**.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
 [Config scenarioTCP1]
@@ -431,6 +623,70 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
 
+[Config scenarioTCP1Eth]
+description = "HTB Evaluation scenario I"
+network = htbEvaluationEth
+sim-time-limit=15s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 5
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasTcp = true
+*.hostFDO[0].app[*].typename = "TcpBasicClientApp"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = -1 # port number to listen on
+*.hostFDO[0].app[*].connectAddress = "serverFDO" # server address (may be symbolic)
+*.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
+*.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
+*.hostFDO[0].app[*].requestLength = 800B # length of a request
+*.hostFDO[0].app[*].replyLength = 8MiB # length of a reply
+*.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
+*.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
+*.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasTcp = true
+*.serverFDO.numApps = 5
+*.serverFDO.app[*].typename = "TcpGenericServerApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = 1042 + index # localPort number to listen on
+*.serverFDO.app[*].replyDelay = 0s
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 5
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario1Eth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.destPort == 1042), expr(has(tcp) && tcp.destPort == 1043), expr(has(tcp) && tcp.destPort == 1044), expr(has(tcp) && tcp.destPort == 1045), expr(has(tcp) && tcp.destPort == 1046)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 5
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario1Eth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
+
+**.connFIX0.datarate = 100Mbps
+**.connFIX0.delay = 1ms
+
 [Config scenarioTCP2]
 description = "HTB Evaluation scenario II"
 network = htbEvaluation
@@ -493,6 +749,70 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
 
 **.connFIX0.datarate = 50Mbps
+**.connFIX0.delay = 1ms
+
+[Config scenarioTCP2Eth]
+description = "HTB Evaluation scenario II"
+network = htbEvaluationEth
+sim-time-limit=15s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 5
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasTcp = true
+*.hostFDO[0].app[*].typename = "TcpBasicClientApp"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = -1 # port number to listen on
+*.hostFDO[0].app[*].connectAddress = "serverFDO" # server address (may be symbolic)
+*.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
+*.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
+*.hostFDO[0].app[*].requestLength = 800B # length of a request
+*.hostFDO[0].app[*].replyLength = 8MiB # length of a reply
+*.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
+*.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
+*.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasTcp = true
+*.serverFDO.numApps = 5
+*.serverFDO.app[*].typename = "TcpGenericServerApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = 1042 + index # localPort number to listen on
+*.serverFDO.app[*].replyDelay = 0s
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 5
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2Eth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.destPort == 1042), expr(has(tcp) && tcp.destPort == 1043), expr(has(tcp) && tcp.destPort == 1044), expr(has(tcp) && tcp.destPort == 1045), expr(has(tcp) && tcp.destPort == 1046)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 5
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2Eth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
+
+**.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
 [Config scenarioTCP3]
@@ -559,6 +879,70 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
 
+[Config scenarioTCP3Eth]
+description = "HTB Evaluation scenario II"
+network = htbEvaluationEth
+sim-time-limit=15s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 2
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasTcp = true
+*.hostFDO[0].app[*].typename = "TcpBasicClientApp"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = -1 # port number to listen on
+*.hostFDO[0].app[*].connectAddress = "serverFDO" # server address (may be symbolic)
+*.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
+*.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
+*.hostFDO[0].app[*].requestLength = 800B # length of a request
+*.hostFDO[0].app[*].replyLength = 6MiB # length of a reply
+*.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
+*.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
+*.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasTcp = true
+*.serverFDO.numApps = 2
+*.serverFDO.app[*].typename = "TcpGenericServerApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = 1042 + index # localPort number to listen on
+*.serverFDO.app[*].replyDelay = 0s
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 2
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenarioPrioEth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.destPort == 1042), expr(has(tcp) && tcp.destPort == 1043)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 2
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenarioPrioEth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043)]
+
+**.connFIX0.datarate = 100Mbps
+**.connFIX0.delay = 1ms
+
 [Config scenarioTCP4]
 description = "HTB Evaluation scenario I"
 network = htbEvaluation
@@ -622,4 +1006,69 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
+
+[Config scenarioTCP4Eth]
+description = "HTB Evaluation scenario I"
+network = htbEvaluationEth
+sim-time-limit=15s
+
+output-vector-file = "${resultdir}/${configname}/${configname}-${runnumber}.vec"
+output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
+
+**.crcMode = "computed"
+*.host*.numApps = 5
+
+*.configurator.config = xmldoc("configs/baseQoS/router_htbEvalIEth.xml")
+
+# File download client
+*.hostFDO[0].hasTcp = true
+*.hostFDO[0].app[*].typename = "TcpBasicClientApp"
+*.hostFDO[0].app[*].localAddress = ""
+*.hostFDO[0].app[*].localPort = -1 # port number to listen on
+*.hostFDO[0].app[*].connectAddress = "serverFDO" # server address (may be symbolic)
+*.hostFDO[0].app[*].connectPort = 1042 + index # port number to connect to
+*.hostFDO[0].app[*].numRequestsPerSession = 1 # number of requests sent per session
+*.hostFDO[0].app[*].requestLength = 800B # length of a request
+*.hostFDO[0].app[*].replyLength = 8MiB # length of a reply
+*.hostFDO[0].app[*].thinkTime = 0.01s # time gap between requests
+*.hostFDO[0].app[*].idleInterval = 1000s # time gap between sessions
+*.hostFDO[0].app[*].reconnectInterval = 1s # if connection breaks, waits this much before trying to reconnect
+*.hostFDO[0].app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.hostFDO[0].app[*].stopOperationTimeout = 2s # timeout value for lifecycle stop operation
+*.hostFDO[0].app[*].startTime = replaceUnit(1*index+1, "s") # time first session begins
+*.hostFDO[0].app[*].stopTime = replaceUnit(1*index+15, "s") # time of finishing sending, negative values mean forever
+
+# File download server
+*.serverFDO.hasTcp = true
+*.serverFDO.numApps = 5
+*.serverFDO.app[*].typename = "TcpGenericServerApp"
+*.serverFDO.app[*].localAddress = "" # local address; may be left empty ("")
+*.serverFDO.app[*].localPort = 1042 + index # localPort number to listen on
+*.serverFDO.app[*].replyDelay = 0s
+*.serverFDO.app[*].stopOperationExtraTime = -1s # extra time after lifecycle stop operation finished
+*.serverFDO.app[*].stopOperationTimeout  = 2s
+
+*.nFDO =  1
+
+*.hostFDO[0].eth[0].queue.typename = "HtbQueue"
+*.hostFDO[0].eth[0].queue.numQueues = 5
+*.hostFDO[0].eth[0].queue.queue[*].typename = "DropTailQueue"
+*.hostFDO[0].eth[0].queue.htbHysterisis = false
+*.hostFDO[0].eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2PrioEth.xml")
+*.hostFDO[0].eth[0].queue.queue[*].packetCapacity = 500
+*.hostFDO[0].eth[0].queue.classifier.defaultGateIndex = 1
+*.hostFDO[0].eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.destPort == 1042), expr(has(tcp) && tcp.destPort == 1043), expr(has(tcp) && tcp.destPort == 1044), expr(has(tcp) && tcp.destPort == 1045), expr(has(tcp) && tcp.destPort == 1046)]
+
+*.serverFDO*.eth[0].queue.typename = "HtbQueue"
+*.serverFDO*.eth[0].queue.numQueues = 5
+*.serverFDO*.eth[0].queue.queue[*].typename = "DropTailQueue"
+*.serverFDO*.eth[0].queue.htbHysterisis = false
+*.serverFDO*.eth[0].queue.htbTreeConfig = xmldoc("tree_scenario2PrioEth.xml")
+*.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
+*.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
+*.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
+
+**.connFIX0.datarate = 100Mbps
+**.connFIX0.delay = 1ms
+
 

--- a/examples/htb/tree_scenario1Eth.xml
+++ b/examples/htb/tree_scenario1Eth.xml
@@ -1,0 +1,89 @@
+<!--Hierarchical Token Bucket Implementation for OMNeT++ & INET Framework
+Copyright (C) 2021 Marija Gajić (NTNU), Marcin Bosk (TUM), Susanna Schwarzmann (TU Berlin), Stanislav Lange (NTNU), and Thomas Zinner (NTNU)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<config>
+	<class id="root">
+		<parentId>NULL</parentId>
+		<rate type="int">50000</rate>
+		<ceil type="int">50000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">1</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="leafhostFDO0">
+		<parentId>root</parentId>
+		<rate type="int">3000</rate>
+		<ceil type="int">20000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">0</queueNum>
+	</class>
+	<class id="leafhostFDO1">
+		<parentId>root</parentId>
+		<rate type="int">6000</rate>
+		<ceil type="int">25000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">1</queueNum>
+	</class>
+	<class id="leafhostFDO2">
+		<parentId>root</parentId>
+		<rate type="int">9000</rate>
+		<ceil type="int">30000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">2</queueNum>
+	</class>
+	<class id="leafhostFDO3">
+		<parentId>root</parentId>
+		<rate type="int">12000</rate>
+		<ceil type="int">35000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">3</queueNum>
+	</class>
+	<class id="leafhostFDO4">
+		<parentId>root</parentId>
+		<rate type="int">15000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">4</queueNum>
+	</class>
+</config>

--- a/examples/htb/tree_scenario2Eth.xml
+++ b/examples/htb/tree_scenario2Eth.xml
@@ -1,0 +1,109 @@
+<!--Hierarchical Token Bucket Implementation for OMNeT++ & INET Framework
+Copyright (C) 2021 Marija Gajić (NTNU), Marcin Bosk (TUM), Susanna Schwarzmann (TU Berlin), Stanislav Lange (NTNU), and Thomas Zinner (NTNU)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<config>
+	<class id="root">
+		<parentId>NULL</parentId>
+		<rate type="int">50000</rate>
+		<ceil type="int">50000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">2</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="innerC1">
+		<parentId>root</parentId>
+		<rate type="int">20000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">1</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="innerC2">
+		<parentId>root</parentId>
+		<rate type="int">30000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">1</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="leafhostFDO0">
+		<parentId>innerC1</parentId>
+		<rate type="int">3000</rate>
+		<ceil type="int">20000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">0</queueNum>
+	</class>
+	<class id="leafhostFDO1">
+		<parentId>innerC1</parentId>
+		<rate type="int">6000</rate>
+		<ceil type="int">25000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">1</queueNum>
+	</class>
+	<class id="leafhostFDO2">
+		<parentId>innerC1</parentId>
+		<rate type="int">9000</rate>
+		<ceil type="int">30000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">2</queueNum>
+	</class>
+	<class id="leafhostFDO3">
+		<parentId>innerC2</parentId>
+		<rate type="int">12000</rate>
+		<ceil type="int">35000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">3</queueNum>
+	</class>
+	<class id="leafhostFDO4">
+		<parentId>innerC2</parentId>
+		<rate type="int">15000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">4</queueNum>
+	</class>
+</config>

--- a/examples/htb/tree_scenario2PrioEth.xml
+++ b/examples/htb/tree_scenario2PrioEth.xml
@@ -1,0 +1,109 @@
+<!--Hierarchical Token Bucket Implementation for OMNeT++ & INET Framework
+Copyright (C) 2021 Marija Gajić (NTNU), Marcin Bosk (TUM), Susanna Schwarzmann (TU Berlin), Stanislav Lange (NTNU), and Thomas Zinner (NTNU)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<config>
+	<class id="root">
+		<parentId>NULL</parentId>
+		<rate type="int">50000</rate>
+		<ceil type="int">50000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">2</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="innerC1">
+		<parentId>root</parentId>
+		<rate type="int">20000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">1</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="innerC2">
+		<parentId>root</parentId>
+		<rate type="int">30000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">1</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="leafhostFDO0">
+		<parentId>innerC1</parentId>
+		<rate type="int">3000</rate>
+		<ceil type="int">20000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">0</queueNum>
+	</class>
+	<class id="leafhostFDO1">
+		<parentId>innerC1</parentId>
+		<rate type="int">6000</rate>
+		<ceil type="int">25000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>1</priority>
+		<queueNum type="int">1</queueNum>
+	</class>
+	<class id="leafhostFDO2">
+		<parentId>innerC1</parentId>
+		<rate type="int">9000</rate>
+		<ceil type="int">30000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>2</priority>
+		<queueNum type="int">2</queueNum>
+	</class>
+	<class id="leafhostFDO3">
+		<parentId>innerC2</parentId>
+		<rate type="int">12000</rate>
+		<ceil type="int">35000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>1</priority>
+		<queueNum type="int">3</queueNum>
+	</class>
+	<class id="leafhostFDO4">
+		<parentId>innerC2</parentId>
+		<rate type="int">15000</rate>
+		<ceil type="int">40000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>2</priority>
+		<queueNum type="int">4</queueNum>
+	</class>
+</config>

--- a/examples/htb/tree_scenarioPrioEth.xml
+++ b/examples/htb/tree_scenarioPrioEth.xml
@@ -1,0 +1,53 @@
+<!--Hierarchical Token Bucket Implementation for OMNeT++ & INET Framework
+Copyright (C) 2021 Marija Gajić (NTNU), Marcin Bosk (TUM), Susanna Schwarzmann (TU Berlin), Stanislav Lange (NTNU), and Thomas Zinner (NTNU)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+<config>
+	<class id="root">
+		<parentId>NULL</parentId>
+		<rate type="int">50000</rate>
+		<ceil type="int">50000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">1</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+	</class>
+	<class id="leafhostFDO0">
+		<parentId>root</parentId>
+		<rate type="int">5000</rate>
+		<ceil type="int">30000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>0</priority>
+		<queueNum type="int">0</queueNum>
+	</class>
+	<class id="leafhostFDO1">
+		<parentId>root</parentId>
+		<rate type="int">5000</rate>
+		<ceil type="int">30000</ceil>
+		<!-- <burst type="int">2000</burst>
+		<cburst type="int">2000</cburst> -->
+		<level type="int">0</level>
+		<quantum type="int">1550</quantum>
+		<mbuffer type="int">60</mbuffer>
+		<priority>1</priority>
+		<queueNum type="int">1</queueNum>
+	</class>
+</config>


### PR DESCRIPTION
In HTBQueue Example with Ethernet interface, the `HtbScheduler::htbDequeue()` method was throwing the error: "The class leafhostFDO0 deficit on level 0 is negative!"

This error occurred due to the "quantum" value in the HTB tree being set too low. What happens when this value is too low, is that the "deficit" controlling the Deficit Round Robin part of the scheduling algorithm (DRR prevents flow starvation) could never recover above 0. "Quantum" essentially governs how the deficit is replenished after a packet transmission. It needs to be set to a value greater or equal the maximum packet size (including all headers, also PHY). The misconfiguration meant that the given class would not be able to be selected for dequeue. Hence the check for deficit < 0 that threw the error.

The quantum was set too low because the ethernet examples were based on PPP examples. Changing the interface type from PPP to Ethernet brings along a few necessary modifications. First, is a change in the quantum values ( in the xml tree configurations). Namely, the quantum value should be at least 1519 bytes, corresponding to the Ethernet MTU. In this fix we provide new configurations for the example with ethernet interfaces, including HTB trees with the quantum parameter being set slightly higher (to 1550 bytes) to allow for larger ethernet headers compared to ppp headers. Included are ethernet configurations for all previous examples. We did not touch the fingerprint tests.

Furthermore, in the current HTB implementation we only account for a fixed (hard-coded) physical layer header size. This value is needed to calculate the full packet size placed on the wire. We use the value for class deficit calculation as well as for token accounting in the nested token buckets. The physical layer header size is hard-coded to be 7 Bytes what corresponds to PPP PHY layer header size. As a different example, for ethernet this value should be 8 Bytes. A solution would be to implement a dynamic check that verifies what physical layer header size the used interface adds on top of the link-layer packet. We are currently unsure how to solve this. Any suggestions are welcome.