### PR TITLE
HtbQueue: Dequeue DRR bugfix, corrected typos, and implemented PHY layer overhead parameter

### DIFF
--- a/examples/htb/omnetpp.ini
+++ b/examples/htb/omnetpp.ini
@@ -108,6 +108,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
 
+**.phyLayerHeaderLength = 7B
+
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
 
@@ -174,6 +176,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -237,6 +241,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
+
+**.phyLayerHeaderLength = 7B
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
@@ -302,6 +308,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -365,6 +373,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043)]
+
+**.phyLayerHeaderLength = 7B
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
@@ -430,6 +440,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -493,6 +505,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
+
+**.phyLayerHeaderLength = 7B
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
@@ -558,6 +572,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(udp) && udp.destPort == 1042), expr(has(udp) && udp.destPort == 1043), expr(has(udp) && udp.destPort == 1044), expr(has(udp) && udp.destPort == 1045), expr(has(udp) && udp.destPort == 1046)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -621,6 +637,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
+
+**.phyLayerHeaderLength = 7B
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
@@ -686,6 +704,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -749,6 +769,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
+
+**.phyLayerHeaderLength = 7B
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
@@ -814,6 +836,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -877,6 +901,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043)]
+
+**.phyLayerHeaderLength = 7B
 
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
@@ -942,6 +968,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043)]
 
+**.phyLayerHeaderLength = 8B
+
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms
 
@@ -1006,6 +1034,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.ppp[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.ppp[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
 
+**.phyLayerHeaderLength = 7B
+
 **.connFIX0.datarate = 50Mbps
 **.connFIX0.delay = 1ms
 
@@ -1069,6 +1099,8 @@ output-scalar-file = "${resultdir}/${configname}/${configname}-${runnumber}.sca"
 *.serverFDO*.eth[0].queue.queue[*].packetCapacity = 500
 *.serverFDO*.eth[0].queue.classifier.defaultGateIndex = 1
 *.serverFDO*.eth[0].queue.classifier.packetFilters = [expr(has(tcp) && tcp.srcPort == 1042), expr(has(tcp) && tcp.srcPort == 1043), expr(has(tcp) && tcp.srcPort == 1044), expr(has(tcp) && tcp.srcPort == 1045), expr(has(tcp) && tcp.srcPort == 1046)]
+
+**.phyLayerHeaderLength = 8B
 
 **.connFIX0.datarate = 100Mbps
 **.connFIX0.delay = 1ms

--- a/src/inet/queueing/scheduler/HtbScheduler.cc
+++ b/src/inet/queueing/scheduler/HtbScheduler.cc
@@ -259,6 +259,7 @@ void HtbScheduler::initialize(int stage)
     PacketSchedulerBase::initialize(stage); // Initialize the packet scheduler module
     if (stage == INITSTAGE_LOCAL) {
         mtu = par("mtu");
+        phyHeaderSize = par("phyLayerHeaderLength");
         valueCorectnessCheck = par("checkHTBTreeValuesForCorectness");
         valueCorectnessAdj = par("adjustHTBTreeValuesForCorectness");
         getParentModule()->subscribe(packetPushEndedSignal, this);
@@ -653,7 +654,7 @@ int HtbScheduler::htbDequeue(int priority, int level)
         if (cl->leaf.deficit[level] < 0) {
             throw cRuntimeError("The class %s deficit on level %d is negative!", cl->name, level);
         }
-        cl->leaf.deficit[level] -= (thePacketToPop->getByteLength() + 7);
+        cl->leaf.deficit[level] -= (thePacketToPop->getByteLength() + phyHeaderSize);
         emit(cl->leaf.deficitSig[level], cl->leaf.deficit[level]);
         if (cl->leaf.deficit[level] < 0) {
             cl->leaf.deficit[level] += cl->quantum;
@@ -932,7 +933,7 @@ void HtbScheduler::htbRemoveFromWaitTree(htbClass *cl)
 
 void HtbScheduler::chargeClass(htbClass *leafCl, int borrowLevel, Packet *packetToDequeue)
 {
-    long long bytes = (long long) packetToDequeue->getByteLength() + 7;
+    long long bytes = (long long) packetToDequeue->getByteLength() + phyHeaderSize;
     int old_mode;
     long long diff;
 

--- a/src/inet/queueing/scheduler/HtbScheduler.cc
+++ b/src/inet/queueing/scheduler/HtbScheduler.cc
@@ -43,7 +43,7 @@ void HtbScheduler::printClass(htbClass *cl)
     EV_INFO << "   - cburst size: " << cl->cburstSize << endl;
 //    EV_INFO << "   - quantum: " << cl->quantum << endl;
 //    EV_INFO << "   - mbuffer: " << cl->mbuffer << endl;
-    EV_INFO << "   - chackpoint time: " << cl->checkpointTime << endl;
+    EV_INFO << "   - checkpoint time: " << cl->checkpointTime << endl;
     EV_INFO << "   - level: " << cl->level << endl;
     EV_INFO << "   - number of children: " << cl->numChildren << endl;
     if (cl->parent != NULL) {
@@ -104,7 +104,7 @@ HtbScheduler::htbClass *HtbScheduler::createAndAddNewClass(cXMLElement* oneClass
     }
     else {
         burstTemp = std::max(rate / 8000, mtu);
-        EV_INFO << "User did not specify cburst. Configuring automatically to: " << burstTemp << " Bytes." << endl;
+        EV_INFO << "User did not specify burst. Configuring automatically to: " << burstTemp << " Bytes." << endl;
     }
     if (oneClass->getFirstChildWithTag("cburst") != nullptr) {
         cburstTemp = atoi(oneClass->getFirstChildWithTag("cburst")->getNodeValue()); // Cburst specified in Bytes
@@ -132,7 +132,7 @@ HtbScheduler::htbClass *HtbScheduler::createAndAddNewClass(cXMLElement* oneClass
     long long burstChosen = burstTemp;
     long long cburstChosen = cburstTemp;
     if (valueCorectnessAdj == true) {
-        if (burstTemp < ceil / 8000) {
+        if (burstTemp < rate / 8000) {
             burstChosen = std::max(burstTemp, rate / 8000); // Burst should not be smaller than mtu + 1ms worth of sending at rate
             EV_WARN << "Burst adjusted to " << burstChosen << "Bytes" << endl;
         }
@@ -661,21 +661,15 @@ int HtbScheduler::htbDequeue(int priority, int level)
             htbClass *tempNode = cl;
             while (tempNode != rootClass) {
                 if (tempNode->parent->inner.innerFeeds[priority].size() > 1 && tempNode->mode == may_borrow) {
-                    if (tempNode->parent->inner.nextToDequeue[priority] == cl) {
+                    if (tempNode->parent->inner.nextToDequeue[priority] == tempNode) {
                         tempNode->parent->inner.nextToDequeue[priority] = *std::next(tempNode->parent->inner.innerFeeds[priority].find(tempNode));
                         if (tempNode->parent->inner.nextToDequeue[priority] == *tempNode->parent->inner.innerFeeds[priority].cend()) {
                             tempNode->parent->inner.nextToDequeue[priority] = *tempNode->parent->inner.innerFeeds[priority].cbegin();
                         }
-                        else {
-                            break;
-                        }
-                    }
-                    else {
-                        break;
                     }
                 }
                 else if (levels[tempNode->level]->selfFeeds[priority].size() > 1 && tempNode->mode == can_send) {
-                    if (levels[tempNode->level]->nextToDequeue[priority] == cl) {
+                    if (levels[tempNode->level]->nextToDequeue[priority] == tempNode) {
                         levels[tempNode->level]->nextToDequeue[priority] = *std::next(levels[tempNode->level]->selfFeeds[priority].find(tempNode));
                         if (levels[tempNode->level]->nextToDequeue[priority] == *levels[tempNode->level]->selfFeeds[priority].cend()) {
                             levels[tempNode->level]->nextToDequeue[priority] = *levels[tempNode->level]->selfFeeds[priority].cbegin();

--- a/src/inet/queueing/scheduler/HtbScheduler.h
+++ b/src/inet/queueing/scheduler/HtbScheduler.h
@@ -57,6 +57,7 @@ class INET_API HtbScheduler : public PacketSchedulerBase, public IPacketCollecti
     double linkDatarate; // The datarate of connected link
 
     long long mtu;
+    int phyHeaderSize;
     bool valueCorectnessCheck;
     bool valueCorectnessAdj;
 

--- a/src/inet/queueing/scheduler/HtbScheduler.ned
+++ b/src/inet/queueing/scheduler/HtbScheduler.ned
@@ -33,8 +33,10 @@ simple HtbScheduler extends PacketSchedulerBase like IPacketScheduler
         xml htbTreeConfig; // The htb tree structure
 
         bool htbHysterisis = default(false);
-
+		
         int mtu @unit(B) = default(1500B);
+        int phyLayerHeaderLength @unit(B) = default(7B); // Adjust the PHY layer header size depending on the PHY MAC used. 7 Bytes for PPP and 8 Bytes for Ethernet. Default 7B for PPP interfaces.
+        
         bool checkHTBTreeValuesForCorectness = default(true); // Check if some important (burst, cburst, quantum) inputted values in the XML Tree are correct. Will throw errors on incorrect values!
         bool adjustHTBTreeValuesForCorectness = default(true); // Adjust some important (burst, cburst, quantum) inputted values in the XML Tree if they are incorrect. Will just adjust incorrect values if the above check is disabled
 

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -104,13 +104,22 @@
 /examples/geometry/,                 -f omnetpp.ini -c General -r 0,                100s,            75d0-cba9/tplx;ce1d-d136/~tNl;51b3-9d40/~tND;900d-aaeb/tyf, PASS, wireless
 
 /examples/htb/,                      -f omnetpp.ini -c scenarioUDP1 -r 0,           11s,         934a-67cc/tplx;78bb-2faf/~tNl;04f5-a63e/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2 -r 0,           11s,         c4b0-9b80/tplx;8cfb-b76a/~tNl;7a81-6a38/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2 -r 0,           11s,         0934-5941/tplx;10d9-a10c/~tNl;69da-d80f/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioUDP3 -r 0,           11s,         0cda-0dfd/tplx;bd2f-b11a/~tNl;2a20-a8c2/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioUDP4 -r 0,           11s,         de56-78e0/tplx;3b2b-8f9c/~tNl;b39a-e108/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP4 -r 0,           11s,         54fc-6be0/tplx;3b2b-8f9c/~tNl;444d-a0c3/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioTCP1 -r 0,           15s,         c36a-33dc/tplx;bdef-4aa6/~tNl;b182-3255/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2 -r 0,           15s,         f44f-36f8/tplx;8268-307a/~tNl;90a4-b597/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2 -r 0,           15s,         b639-e489/tplx;44fa-a3b8/~tNl;94f4-c20a/~tND, PASS,
 /examples/htb/,                      -f omnetpp.ini -c scenarioTCP3 -r 0,           15s,         ab4e-c953/tplx;477c-a439/~tNl;3ddf-840f/~tND, PASS,
-/examples/htb/,                      -f omnetpp.ini -c scenarioTCP4 -r 0,           15s,         f743-1545/tplx;1246-a746/~tNl;82e7-8d86/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP4 -r 0,           15s,         8087-4665/tplx;e1c8-8608/~tNl;052f-15d7/~tND, PASS,
+
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP1Eth -r 0,           11s,         1f56-9ec7/tplx;aac0-3936/~tNl;0554-9a2a/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP2Eth -r 0,           11s,         5d6e-649e/tplx;f263-8eb0/~tNl;afc4-1793/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP3Eth -r 0,           11s,         69b9-eab9/tplx;82fd-4a8e/~tNl;db8f-5ad2/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioUDP4Eth -r 0,           11s,         7a90-5320/tplx;e931-9075/~tNl;23a0-880d/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP1Eth -r 0,           15s,         4d1a-ade5/tplx;2fea-8ecd/~tNl;41b2-e9aa/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP2Eth -r 0,           15s,         2ebd-3aaf/tplx;dd44-f7bf/~tNl;4647-e76e/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP3Eth -r 0,           15s,         e148-d1de/tplx;b4ec-52df/~tNl;e059-bc8b/~tND, PASS,
+/examples/htb/,                      -f omnetpp.ini -c scenarioTCP4Eth -r 0,           15s,         f75f-b703/tplx;d3c6-6d13/~tNl;5bf9-1a63/~tND, PASS,
 
 /examples/httptools/direct/flashdirect/, -f omnetpp.ini -c General -r 0,               500000s,      f607-5921/tplx;428e-2e61/~tNl;8154-c757/tyf, PASS,
 /examples/httptools/direct/pairdirect/, -f omnetpp.ini -c random -r 0,                 500000s,      6fc8-681d/tplx;128c-5b0a/~tNl;f06b-220a/tyf, PASS,


### PR DESCRIPTION
Fixed a bug where classes on higher levels would not be considered as candidates for dequeue in DRR:
- Classes of `level >= 1` while in inner feed of their parent would not get updated as candidates for next to dequeue.
- Caused classes that were not selected as initial next to dequeue on `level >= 1` to starve while in may_borrow mode.
- Bug caused by a typo in the comparison of classes. Instead of comparing the class on currently considered level in DRR, the corresponding leaf was always compared. That lead to problems if more than 2 levels were present and `ceil > rate` for inner nodes.

Implemented a parameter for physical layer overhead as discussed [here](https://github.com/inet-framework/inet/pull/739#issuecomment-1021235190).

Added fingerprint tests for configs with Ethernet.

Fixed a few other typos in the code.