### PR TITLE
allow arbitrary wireless interface names (default: wlan cellular)

### DIFF
--- a/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.cc
+++ b/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.cc
@@ -57,6 +57,12 @@ void L3NetworkConfiguratorBase::initialize(int stage)
         minLinkWeight = par("minLinkWeight");
         configureIsolatedNetworksSeparatly = par("configureIsolatedNetworksSeparatly").boolValue();
         configuration = par("config");
+
+        std::string wirelessIfStr = par("wirelessInterfaces").stdstringValue();
+        cStringTokenizer tokenizer(wirelessIfStr.c_str(), " ,;\t\n\r\f");
+        for(const auto& s : tokenizer.asVector()){
+            wirelessInterfaceNames.push_back(std::make_pair(s, s.size()));
+        }
     }
 }
 
@@ -268,7 +274,14 @@ bool L3NetworkConfiguratorBase::isBridgeNode(Node *node)
 
 bool L3NetworkConfiguratorBase::isWirelessInterface(NetworkInterface *networkInterface)
 {
-    return !strncmp(networkInterface->getInterfaceName(), "wlan", 4);
+    // If the name of networkInterface starts with any of known wireless interface names,
+    // it is considered a wireless interface.
+    for(const auto& e : wirelessInterfaceNames){
+        if (!strncmp(networkInterface->getInterfaceName(), e.first.c_str(), e.second)){
+            return true;
+        }
+    }
+    return false;
 }
 
 Topology::Link *L3NetworkConfiguratorBase::findLinkOut(Node *node, int gateId)

--- a/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.h
+++ b/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.h
@@ -135,6 +135,7 @@ class INET_API L3NetworkConfiguratorBase : public cSimpleModule, public L3Addres
     double minLinkWeight = NaN;
     bool configureIsolatedNetworksSeparatly = false;
     cXMLElement *configuration = nullptr;
+    std::vector<std::pair<std::string, int>> wirelessInterfaceNames;
 
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }

--- a/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.ned
+++ b/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.ned
@@ -17,5 +17,6 @@ simple L3NetworkConfiguratorBase like IL3NetworkConfigurator
     parameters:
         double minLinkWeight = default(1E-3);
         bool configureIsolatedNetworksSeparatly = default(false);
+        string wirelessInterfaces = default("wlan cellular");
 }
 


### PR DESCRIPTION
A minor extension of the `L3NetworkConfiguratorBase` class to allow other wireless interface names than "_wlan_".

Background: Currently, network layer configurators such as the `IPv4NetworkConfigurator` check if an interface is a wirless interface by comparing the interface name: if the interface name starts with "wlan", it is assumed to be a wireless interface. (see https://github.com/inet-framework/inet/blob/98e3ec7fc076fc4d974fa28a82092cc318a9966e/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.cc#L269) 

As a result, a wireless interface name has to start with "wlan". For some of our simulations, where we combine wlan interfaces (from inet) with cellular network interfaces (from simulte/simu5g), this had the ugly consequence that wlan0 could be a wlan and wlan1 a LteNic. Since this is misleading, it would be great if we could get this small change (which should have no side-effects) upstream.

BTW: Of course, we can (and do) extend the class ourselves to get the desired behavior - however, from our point of view having this upstream would be a much cleaner implementation since it is then in the base class, where it belongs.

Any comments welcome ;-)

Lars