### PR TITLE
replace isWirelessInterface in L3NetworkConfigurator with isWireless()

### DIFF
--- a/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.h
+++ b/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.h
@@ -158,7 +158,6 @@ class INET_API L3NetworkConfiguratorBase : public cSimpleModule, public L3Addres
     virtual double computeWiredLinkWeight(Link *link, const char *metric, cXMLElement *parameters);
     virtual double computeWirelessLinkWeight(Link *link, const char *metric, cXMLElement *parameters);
     virtual bool isBridgeNode(Node *node);
-    virtual bool isWirelessInterface(NetworkInterface *networkInterface);
     virtual std::string getWirelessId(NetworkInterface *networkInterface);
     virtual InterfaceInfo *createInterfaceInfo(Topology& topology, Node *node, LinkInfo *linkInfo, NetworkInterface *networkInterface);
     virtual Topology::Link *findLinkOut(Node *node, int gateId);

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.cc
@@ -852,7 +852,7 @@ void Ipv4NetworkConfigurator::dumpConfig(Topology& topology)
         bool hasWireless = false;
         for (auto& element : linkInfo->interfaceInfos) {
             InterfaceInfo *interfaceInfo = static_cast<InterfaceInfo *>(element);
-            if (isWirelessInterface(interfaceInfo->networkInterface))
+            if (interfaceInfo->networkInterface->isWireless())
                 hasWireless = true;
         }
         if (hasWireless) {
@@ -863,7 +863,7 @@ void Ipv4NetworkConfigurator::dumpConfig(Topology& topology)
                 if (!first)
                     stream << " ";
                 InterfaceInfo *interfaceInfo = static_cast<InterfaceInfo *>(element);
-                if (isWirelessInterface(interfaceInfo->networkInterface)) {
+                if (interfaceInfo->networkInterface->isWireless()) {
                     stream << interfaceInfo->node->module->getFullPath() << "%" << interfaceInfo->networkInterface->getInterfaceName();
                     first = false;
                 }


### PR DESCRIPTION
A minor modification/cleanup of the `L3NetworkConfiguratorBase` class to allow other wireless interface names than "_wlan_".

Background: Currently, network layer configurators such as the `IPv4NetworkConfigurator` check if an interface is a wirless interface by comparing the interface name: if the interface name starts with "wlan", it is assumed to be a wireless interface. (see https://github.com/inet-framework/inet/blob/98e3ec7fc076fc4d974fa28a82092cc318a9966e/src/inet/networklayer/configurator/base/L3NetworkConfiguratorBase.cc#L269) 

As a result, a wireless interface name has to start with "wlan". For some of our simulations, where we combine wlan interfaces (from inet) with cellular network interfaces (from simulte/simu5g), this had the ugly consequence that wlan0 could be a wlan and wlan1 a LteNic. Since this is misleading, it would be great if we could get this small change (which should have no side-effects) upstream.

This solution using isWireless (as suggested by @levy ) - is from my point of view - a much better solution to this problem than the one proposed in #753 

Therefore, I would suggest to close #753 and use the approach in this pull request instead.