### PR TITLE
fix: add @toString to Coord so that coordinates can be printed

### DIFF
--- a/src/inet/common/geometry/Geometry.msg
+++ b/src/inet/common/geometry/Geometry.msg
@@ -18,6 +18,7 @@ namespace inet;
 class Coord
 {
     @existingClass;
+    @toString(.str());
     double x;
     double y;
     double z;


### PR DESCRIPTION
With INET 4.4.0, Coord cannot be easily printed anymore, e.g. if it is part of a packet. Since we do this all the time, could you add the .str() toString annotation so it works as before?