### PR TITLE
Fix PcapngWriter timestamps

### DIFF
--- a/src/inet/common/packet/recorder/PcapngWriter.cc
+++ b/src/inet/common/packet/recorder/PcapngWriter.cc
@@ -211,8 +211,8 @@ void PcapngWriter::writePacket(simtime_t stime, const Packet *packet, Direction 
     struct pcapng_packet_block_header pbh;
     pbh.blockTotalLength = blockTotalLength;
     pbh.interfaceId = pcapngInterfaceId;
-    pbh.timestampHigh = (int32_t)stime.inUnit(SIMTIME_S);
-    pbh.timestampLow = (uint32_t)(stime.inUnit(SIMTIME_US) - (uint32_t)1000000 * stime.inUnit(SIMTIME_S));
+    pbh.timestampHigh = (uint32_t)((stime.inUnit(SIMTIME_US) & 0xFFFFFFFF00000000LL) >> 32);
+    pbh.timestampLow = (uint32_t)(stime.inUnit(SIMTIME_US) & 0xFFFFFFFFLL);
     pbh.capturedPacketLength = packet->getByteLength();
     pbh.originalPacketLength = packet->getByteLength();
     fwrite(&pbh, sizeof(pbh), 1, dumpfile);


### PR DESCRIPTION
Timestamp (High) and Timestamp (Low): upper 32 bits and lower 32 bits of a 64-bit timestamp. The timestamp is a single 64-bit unsigned integer that represents the number of units of time that have elapsed since 1970-01-01 00:00:00 UTC. The length of a unit of time is specified by the 'if_tsresol' option (see [Figure 10](https://www.ietf.org/staging/draft-tuexen-opsawg-pcapng-02.html#format_idb)) of the Interface Description Block referenced by this packet (Default: 10^-6). Note that, unlike timestamps in the libpcap file format, timestamps in Enhanced Packet Blocks are not saved as two 32-bit values that represent the seconds and microseconds that have elapsed since 1970-01-01 00:00:00 UTC. Timestamps in Enhanced Packet Blocks are saved as two 32-bit words that represent the upper and lower 32 bits of a single 64-bit quantity.