### PR TITLE
Fix missing `INET_API` in nested `NetworkInterface::LocalGate` with vtable

### DIFF
--- a/src/inet/networklayer/common/NetworkInterface.h
+++ b/src/inet/networklayer/common/NetworkInterface.h
@@ -128,7 +128,7 @@ class INET_API NetworkInterface : public queueing::PacketProcessorBase, public q
     std::vector<MacEstimateCostProcess *> estimateCostProcessArray;
 
   protected:
-    class LocalGate : public cGate {
+    class INET_API LocalGate : public cGate {
       protected:
         NetworkInterface *networkInterface;
 


### PR DESCRIPTION
Creating a custom network interface in an inet dependant project causes a linking error in `lld` on Windows.

This is because the vtable for the `NetworkInterface::LocalGate` is not exported into the DLL symbols list.