### PR TITLE
Fix missing MTU parameter in LayeredEthernetInterface

### DIFF
--- a/src/inet/linklayer/ethernet/LayeredEthernetInterface.ned
+++ b/src/inet/linklayer/ethernet/LayeredEthernetInterface.ned
@@ -26,6 +26,7 @@ module LayeredEthernetInterface extends NetworkInterface like IEthernetInterface
         bool multicast = default(true);
         string address @mutable = default("auto");
         double bitrate @unit(bps);
+        int mtu @unit(B) = default(1500B);
         string interfaceTableModule;
         *.bitrate = default(this.bitrate);
     gates:


### PR DESCRIPTION
Without this parameter the ipv4 always assumes an infinite MTU when combined with the LayeredEthernetInterface.
Now its configurable with the Ethernet default MTU as the default value.