### PR TITLE
inline mis-redeclaration fixed on two *TagSet.h files

### DIFF
--- a/src/inet/common/packet/tag/SharingRegionTagSet.h
+++ b/src/inet/common/packet/tag/SharingRegionTagSet.h
@@ -123,7 +123,7 @@ class INET_API SharingRegionTagSet : public cObject
     Ptr<SharedVector<RegionTag<TagBase>>> regionTags;
 
   protected:
-    void setTag(int index, const Ptr<const TagBase>& tag);
+    inline void setTag(int index, const Ptr<const TagBase>& tag);
     void addTag(b offset, b length, const Ptr<const TagBase>& tag);
     std::vector<SharingRegionTagSet::RegionTag<TagBase>> addTagsWhereAbsent(const std::type_info& typeInfo, b offset, b length, const Ptr<const TagBase>& tag);
     const Ptr<TagBase> removeTag(int index);
@@ -139,7 +139,7 @@ class INET_API SharingRegionTagSet : public cObject
 
     void ensureTagsVectorAllocated();
     void prepareTagsVectorForUpdate();
-    void sortTagsVector();
+    inline void sortTagsVector();
 
   public:
     /** @name Constructors and operators */
@@ -148,8 +148,8 @@ class INET_API SharingRegionTagSet : public cObject
     SharingRegionTagSet(const SharingRegionTagSet& other) : regionTags(other.regionTags) {}
     SharingRegionTagSet(SharingRegionTagSet&& other) : regionTags(other.regionTags) { other.regionTags = nullptr; }
 
-    SharingRegionTagSet& operator=(const SharingRegionTagSet& other);
-    SharingRegionTagSet& operator=(SharingRegionTagSet&& other);
+    inline SharingRegionTagSet& operator=(const SharingRegionTagSet& other);
+    inline SharingRegionTagSet& operator=(SharingRegionTagSet&& other);
 
     virtual void parsimPack(cCommBuffer *buffer) const override;
     virtual void parsimUnpack(cCommBuffer *buffer) override;
@@ -160,27 +160,27 @@ class INET_API SharingRegionTagSet : public cObject
     /**
      * Returns the number of tags.
      */
-    int getNumTags() const;
+    inline int getNumTags() const;
 
     /**
      * Returns the shared tag at the given index.
      */
-    const Ptr<const TagBase>& getTag(int index) const;
+    inline const Ptr<const TagBase>& getTag(int index) const;
 
     /**
      * Returns the exclusively owned tag at the given index for update.
      */
-    const Ptr<TagBase> getTagForUpdate(int index);
+    inline const Ptr<TagBase> getTagForUpdate(int index);
 
     /**
      * Returns the shared region tag at the given index.
      */
-    const RegionTag<TagBase>& getRegionTag(int index) const;
+    inline const RegionTag<TagBase>& getRegionTag(int index) const;
 
     /**
      * Returns the exclusively owned region tag at the given index.
      */
-    const RegionTag<TagBase> getRegionTagForUpdate(int index);
+    inline const RegionTag<TagBase> getRegionTagForUpdate(int index);
 
     /**
      * Clears the set of tags in the given region.

--- a/src/inet/common/packet/tag/SharingTagSet.h
+++ b/src/inet/common/packet/tag/SharingTagSet.h
@@ -40,7 +40,7 @@ class INET_API SharingTagSet : public cObject
     Ptr<SharedVector<Ptr<const TagBase>>> tags;
 
   protected:
-    void setTag(int index, const Ptr<const TagBase>& tag);
+    inline void setTag(int index, const Ptr<const TagBase>& tag);
     void addTag(const Ptr<const TagBase>& tag);
     const Ptr<TagBase> removeTag(int index);
 
@@ -57,8 +57,8 @@ class INET_API SharingTagSet : public cObject
     SharingTagSet(const SharingTagSet& other) : tags(other.tags) {}
     SharingTagSet(SharingTagSet&& other) : tags(other.tags) { other.tags = nullptr; }
 
-    SharingTagSet& operator=(const SharingTagSet& other);
-    SharingTagSet& operator=(SharingTagSet&& other);
+    inline SharingTagSet& operator=(const SharingTagSet& other);
+    inline SharingTagSet& operator=(SharingTagSet&& other);
 
     virtual void parsimPack(cCommBuffer *buffer) const override;
     virtual void parsimUnpack(cCommBuffer *buffer) override;


### PR DESCRIPTION
Some methods in files SharingRegionTagSet.h and SharingTagSet.h were declared as inline, but in a way that the compiler doesn't like. Typically this leaded just to some warnings. However, third-party projects linking might fail because of that (as linker found duplicate symbols).

Resolves #778 