### PR TITLE
[TSN bug] IEEE8021qTimeAwareShaper PeriodicGate did not check lenght of first packet

### DIFF
--- a/src/inet/queueing/gate/PeriodicGate.cc
+++ b/src/inet/queueing/gate/PeriodicGate.cc
@@ -45,8 +45,8 @@ void PeriodicGate::handleParameterChange(const char *name)
 void PeriodicGate::handleMessage(cMessage *message)
 {
     if (message == changeTimer) {
-        processChangeTimer();
         scheduleChangeTimer();
+        processChangeTimer();
     }
     else
         throw cRuntimeError("Unknown message");


### PR DESCRIPTION
# Update PeriodicGate::handleMessage
Switch schedule and processing of changeTimer within PeriodicGate::handleMessage.
This pull request should resolve issue #822.