### PR TITLE
[SimpleCcBattery feature] Implement series battery pack module

### DIFF
--- a/src/inet/power/storage/CcBatteryPack.ned
+++ b/src/inet/power/storage/CcBatteryPack.ned
@@ -1,0 +1,31 @@
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+// 
+
+package inet.power.storage;
+
+import inet.power.storage.SimpleCcBattery;
+
+simple CcBatteryPack extends SimpleCcBattery 
+{
+   parameters:
+     int numberOfCells = default(1); // number of cells in the battery pack
+     string arrangement @enum("serial", "parallel") = default ("serial");                                                                      
+     double cellNominalCapacity @unit(C) = default(7200 C); // typical capacity of AA battery is 2 Ah = 7200 C
+     double cellNominalVoltage @unit(V) = default(1.5 V);
+     double cellInternalResistance @unit(Ohm) = default(0.1 Ohm);
+     nominalCapacity = default(numberOfCells * cellNominalCapacity); // cell capacities are added when arranged in parallel
+     nominalVoltage = default(arrangement == "serial" ? numberOfCells * cellNominalVoltage : cellNominalVoltage); // voltage is added when cells arranged in series 	
+     internalResistance = default(arrangement == "serial" ? numberOfCells * cellInternalResistance : cellInternalResistance / numberOfCells); // internal resistance is added when cells arranged in series
+}


### PR DESCRIPTION
Derives the `SimpleCcBattery` module to create an energy storage module that simulates a number of cells connected in a series or parallel arrangement.

Addresses issue: https://github.com/inet-framework/inet/issues/843