### PR TITLE
CreditBasedGate: Credit updates on closed gate

### DIFF
--- a/src/inet/queueing/gate/CreditBasedGate.h
+++ b/src/inet/queueing/gate/CreditBasedGate.h
@@ -9,6 +9,8 @@
 #define __INET_CREDITBASEDGATE_H
 
 #include "inet/queueing/base/PacketGateBase.h"
+#include "inet/queueing/gate/PeriodicGate.h"
+#include "inet/common/ModuleRef.h"
 
 namespace inet {
 namespace queueing {
@@ -19,12 +21,15 @@ class INET_API CreditBasedGate : public PacketGateBase, public cListener
     static simsignal_t creditsChangedSignal;
 
   protected:
+    ModuleRef<PeriodicGate> periodicGate;
+
     // parameters
     double idleCreditGainRate = NaN;
     double transmitCreditSpendRate = NaN;
     double transmitCreditLimit = NaN;
     double minCredit = NaN;
     double maxCredit = NaN;
+    bool isAccumulatingBeforeGateClose;
 
     // state
     bool isTransmitting = false;
@@ -32,6 +37,7 @@ class INET_API CreditBasedGate : public PacketGateBase, public cListener
     double currentCredit = NaN;
     double currentCreditGainRate = NaN;
     double lastCurrentCreditEmitted = NaN;
+    simtime_t preClosingStartTime = -1;
     simtime_t lastCurrentCreditEmittedTime = -1;
 
     cMessage *changeTimer = nullptr;
@@ -44,8 +50,11 @@ class INET_API CreditBasedGate : public PacketGateBase, public cListener
 
     virtual void processPacket(Packet *packet) override;
     virtual bool hasAvailablePacket() const { return provider->canPullSomePacket(inputGate->getPathStartGate()); }
+    virtual bool isTransmissionGateOpen() const {return periodicGate->isOpen();}
+    virtual bool canPacketBeTransmitted() const {return periodicGate->canPullSomePacket(outputGate->getPathEndGate());}
     virtual void updateCurrentCredit();
     virtual void updateCurrentCreditGainRate();
+    virtual void isInPreClosingTime();
     virtual void emitCurrentCredit();
     virtual void scheduleChangeTimer();
     virtual void processChangeTimer();
@@ -59,6 +68,7 @@ class INET_API CreditBasedGate : public PacketGateBase, public cListener
 
     virtual void receiveSignal(cComponent *source, simsignal_t signal, double value, cObject *details) override;
     virtual void receiveSignal(cComponent *source, simsignal_t signal, cObject *object, cObject *details) override;
+    virtual void receiveSignal(cComponent *source, simsignal_t signal, bool value, cObject *details) override;
 };
 
 } // namespace queueing

--- a/src/inet/queueing/gate/CreditBasedGate.ned
+++ b/src/inet/queueing/gate/CreditBasedGate.ned
@@ -38,6 +38,7 @@ simple CreditBasedGate extends PacketGateBase like IPacketGate
         double transmitCreditLimit = default(0); // credit limit above which the gate is open
         double minCredit = default(-inf); // minimum number of credits
         double maxCredit = default(inf); // maximum number of credits
+        bool isAccumulatingBeforeGateClose = default(false); // whether credit increases before gate close event when no packets can be sent anymore
         displayStringTextFormat = default("contains %n cr\nserved %p pk (%l)"); // determines display string text above the submodule
         @class(CreditBasedGate);
         @signal[creditsChanged](type=double);


### PR DESCRIPTION
This change addresses the issue that the credit of CreditBasedGates was increasing on  while the corresponding PeriodicGate was closed. Per IEEE 802.Q-2018 credit should be frozen on closed gates. Moreover an option was added to toggle the accumulation of credit during pre-closing time, i.e. when the PeriodicGate is open but not long enough anymore to send the next package. According to IEEE credit should still increase, which leads to higher usage of bandwidth but fairness between different queues isn't as good anymore and credit could be unbounded. Therefore a parameter allows to switch the behavior to accommodate different use cases. For reference see #848 