### PR TITLE
StreamFilter looks now at StreamInd Tag of packets

### DIFF
--- a/src/inet/protocolelement/redundancy/StreamFilter.cc
+++ b/src/inet/protocolelement/redundancy/StreamFilter.cc
@@ -33,8 +33,13 @@ cGate *StreamFilter::getRegistrationForwardingGate(cGate *gate)
 bool StreamFilter::matchesPacket(const Packet *packet) const
 {
     auto streamReq = packet->findTag<StreamReq>();
+    auto streamInd = packet->findTag<StreamInd>();
     if (streamReq != nullptr) {
         auto streamName = streamReq->getStreamName();
+        cMatchableString matchableString(streamName);
+        return const_cast<cMatchExpression *>(&streamNameFilter)->matches(&matchableString);
+    } else if (streamInd != nullptr) {
+        auto streamName = streamInd->getStreamName();
         cMatchableString matchableString(streamName);
         return const_cast<cMatchExpression *>(&streamNameFilter)->matches(&matchableString);
     }


### PR DESCRIPTION
This is addressing the issue [860](https://github.com/inet-framework/inet/issues/860) that the StreamFilter does not look at the StreamInd Tag of packets.