### PR TITLE
findModuleSomewhereUp : from parameter cannot be const

### DIFF
--- a/src/inet/common/ModuleAccess.h
+++ b/src/inet/common/ModuleAccess.h
@@ -24,7 +24,7 @@ INET_API bool isNetworkNode(const cModule *mod);
  * Operation: gradually rises in the module hierarchy, and looks for a submodule
  * of the given name.
  */
-INET_API cModule *findModuleSomewhereUp(const char *name, const cModule *from);
+INET_API cModule *findModuleSomewhereUp(const char *name, cModule *from);
 
 /**
  * Find the node containing the given module.


### PR DESCRIPTION
The signatures of the declaration and the implementation of `findModuleSomewhereUp` must match. (more specifically, there must be at least one implementation of `findModuleSomewhereUp` whose signature matches that of the definition)

In the current state of INET, this is not the case : because of implementation details (pointer aliasing in `ModuleAccess.cc`), the `from` parameter cannot be declared `const`, so there is no implemention for the signature chosen in the definition.

If one tries to use `findModuleSomewhereUp`, the linker complains that reference to it is undefined.

The commit corrects this by dropping the `const` from parameter `from`.

Best,

Aymeric