### PR TITLE
Revert "ProtocolGroup: deallocate dynamically added protocols in the destructor"

### DIFF
--- a/src/inet/common/ProtocolGroup.cc
+++ b/src/inet/common/ProtocolGroup.cc
@@ -22,12 +22,6 @@ ProtocolGroup::ProtocolGroup(const char *name, const Protocols& protocolNumberTo
     }
 }
 
-ProtocolGroup::~ProtocolGroup()
-{
-    for (auto p : dynamicallyAddedProtocols)
-        delete p;
-}
-
 const Protocol *ProtocolGroup::findProtocol(int protocolNumber) const
 {
     auto it = protocolNumberToProtocol.find(protocolNumber);
@@ -63,8 +57,6 @@ void ProtocolGroup::addProtocol(int protocolId, const Protocol *protocol)
     protocols.push_back(protocol);
     protocolNumberToProtocol[protocolId] = protocol;
     protocolToProtocolNumber[protocol] = protocolId;
-
-    dynamicallyAddedProtocols.push_back(protocol);  // assume it was dynamically allocated
 }
 
 // FIXME use constants instead of numbers

--- a/src/inet/common/ProtocolGroup.h
+++ b/src/inet/common/ProtocolGroup.h
@@ -20,12 +20,9 @@ class INET_API ProtocolGroup
     std::map<int, const Protocol *> protocolNumberToProtocol;
     std::map<const Protocol *, int> protocolToProtocolNumber;
 
-    std::vector<const Protocol *> dynamicallyAddedProtocols; // the items in protocols[] that need to be deallocated in destructor
-
   public:
     typedef std::map<int, const Protocol *> Protocols;
     ProtocolGroup(const char *name, const Protocols& protocolNumberToProtocol);
-    ~ProtocolGroup();
 
     const char *getName() const { return name; }
     int getNumElements() const { return protocols.size(); }


### PR DESCRIPTION
This commit assumes that every `Protocol` added with `ProtocolGroup::addProtocol` has been dynamically allocated (it admits as much in the comment).

Firstly, this assumption is simply wrong. It is perfectly possible to have a `Protocol` as a global variable. In this case, the destructor of the `ProtocolGroup` class attempts to free an address of the data segment, which produces an error at the end of a simulation ("free() : invalid pointer").

Secondly, this commit also assumes (implicitly this time) that a dynamically allocated `Protocol` hasn't already been freed by the time the destructor of `ProtocolGroup` is called, which turns out to be also wrong. If we transform our previous `Protocol` instantiated as a global variable in a dynamically allocated one, whose pointer is stored in a global `Protocol *` variable, then we get another error at the end of a simulation (more along the lines of "free() : double free or corruption").

I am not entirely sure why this commit was added in the first place. It seems to be inside a series of commits that change the `ProtocolGroup` API, but is AFAICT independent from it.

If someone has dynamically allocated a `Protocol`, it should be their own responsibility to free it, and it shouldn't have anything to do with the fact that they have decided to register said `Protocol` inside a `ProtocolGroup`.

Please revert this commit.

Best regards,

Aymeric Agon-Rambosson