### PR TITLE
Fix merging of two ByteCountChunks with different data

### DIFF
--- a/src/inet/common/packet/chunk/ByteCountChunk.cc
+++ b/src/inet/common/packet/chunk/ByteCountChunk.cc
@@ -107,17 +107,17 @@ bool ByteCountChunk::containsSameData(const Chunk& other) const
 
 bool ByteCountChunk::canInsertAtFront(const Ptr<const Chunk>& chunk) const
 {
-    return chunk->getChunkType() == CT_BYTECOUNT;
+    return chunk->getChunkType() == CT_BYTECOUNT && this->data == staticPtrCast<const ByteCountChunk>(chunk)->data;
 }
 
 bool ByteCountChunk::canInsertAtBack(const Ptr<const Chunk>& chunk) const
 {
-    return chunk->getChunkType() == CT_BYTECOUNT;
+    return chunk->getChunkType() == CT_BYTECOUNT && this->data == staticPtrCast<const ByteCountChunk>(chunk)->data;
 }
 
 bool ByteCountChunk::canInsertAt(const Ptr<const Chunk>& chunk, b offset) const
 {
-    return chunk->getChunkType() == CT_BYTECOUNT;
+    return chunk->getChunkType() == CT_BYTECOUNT && this->data == staticPtrCast<const ByteCountChunk>(chunk)->data;
 }
 
 void ByteCountChunk::doInsertAtFront(const Ptr<const Chunk>& chunk)


### PR DESCRIPTION
Just increasing the length of a ByteCountChunk when inserting a ByteCountChunk with different data leads to incorrect packets.

Example: Ethernet padding (PaddingInserter) with 0 when payload is also a ByteCountChunk with default 0x3f data.
