### PR TITLE
Fixed bug with negative offsets in PeriodicGate

### DIFF
--- a/src/inet/queueing/gate/PeriodicGate.cc
+++ b/src/inet/queueing/gate/PeriodicGate.cc
@@ -96,7 +96,11 @@ void PeriodicGate::initializeGating()
 {
     index = 0;
     isOpen_ = initiallyOpen;
-    offset.setRaw(totalDuration != 0 ? initialOffset.raw() % totalDuration.raw() : 0);
+    if (totalDuration.raw() == 0) {
+        offset.setRaw(0);
+    } else {
+        offset.setRaw((initialOffset.raw() % totalDuration.raw() + totalDuration.raw()) % totalDuration.raw());
+    }
     while (offset > CLOCKTIME_ZERO) {
         clocktime_t duration = durations[index];
         if (offset >= duration) {


### PR DESCRIPTION
When the offset of a PeriodicGate is negative, the state is inconsistent until the end of the first cycle, as the initialization phase is not executed properly.

This PR fixed this, by ensuring the modulo calculation for the offset always produces a positive result.