### PR TITLE
Consistent use of EligibilityTimeGate and Ieee8021qAsynchronousShaper

### DIFF
--- a/showcases/tsn/trafficshaping/asynchronousshaper/doc/index.rst
+++ b/showcases/tsn/trafficshaping/asynchronousshaper/doc/index.rst
@@ -77,7 +77,7 @@ To enable asynchronous traffic shaping in a TSN switch, the following is require
 - Set the type of the ``queue`` and ``transmissionSelectionAlgorithm`` submodules in ``eth[*].macLayer.queue``:
 
   ``*.switch.eth[*].macLayer.queue.queue[*].typename = "EligibilityTimeQueue"``
-  ``*.switch.eth[*].macLayer.queue.transmissionSelectionAlgorithm[*].typename = "Ieee8021qAsynchronousShaper"``
+  ``*.switch.eth[*].macLayer.queue.transmissionSelectionAlgorithm[*].typename = "EligibilityTimeGate"``
 
 - We can override the number of traffic classes (8 by default) in the time-aware shaper modules (``eth[*].macLayer.queue``):
 

--- a/src/inet/linklayer/ieee8021q/Ieee8021qAsynchronousShaper.ned
+++ b/src/inet/linklayer/ieee8021q/Ieee8021qAsynchronousShaper.ned
@@ -11,6 +11,7 @@ import inet.protocolelement.shaper.EligibilityTimeGate;
 
 //
 // This module implements the IEEE 802.1Q asynchronous shaper.
+// This module is an alias for the EligibilityTimeGate module.
 //
 module Ieee8021qAsynchronousShaper extends EligibilityTimeGate
 {

--- a/tests/validation/tsn/trafficshaping/asynchronousshaper/core4inet/omnetpp.ini
+++ b/tests/validation/tsn/trafficshaping/asynchronousshaper/core4inet/omnetpp.ini
@@ -128,7 +128,7 @@ sim-time-limit = 1s
 *.switch.bridging.streamFilter.ingress.meter[1].committedBurstSize = 322B - 22B # 4B (802.1Q) + 14B (ETH MAC) + 4B (ETH FCS)
 
 *.switch.eth[*].macLayer.queue.queue[5..6].typename = "EligibilityTimeQueue"
-*.switch.eth[*].macLayer.queue.transmissionSelectionAlgorithm[5..6].typename = "Ieee8021qAsynchronousShaper"
+*.switch.eth[*].macLayer.queue.transmissionSelectionAlgorithm[5..6].typename = "EligibilityTimeGate"
 
 ###############################
 # Traffic Shaping Configuration
@@ -140,7 +140,7 @@ sim-time-limit = 1s
 *.switch.eth[*].macLayer.queue.queue[*].packetCapacity = 4
 *.switch.eth[*].macLayer.queue.queue[*].dropperClass = "inet::queueing::PacketAtCollectionBeginDropper"
 *.switch.eth[*].macLayer.queue.queue[5..6].typename = "EligibilityTimeQueue"
-*.switch.eth[*].macLayer.queue.transmissionSelectionAlgorithm[5..6].typename = "Ieee8021qAsynchronousShaper"
+*.switch.eth[*].macLayer.queue.transmissionSelectionAlgorithm[5..6].typename = "EligibilityTimeGate"
 
 ##########################
 # Visualizer Configuration

--- a/tests/validation/tsn/trafficshaping/asynchronousshaper/icct/omnetpp.ini
+++ b/tests/validation/tsn/trafficshaping/asynchronousshaper/icct/omnetpp.ini
@@ -349,9 +349,9 @@ sim-time-limit = 0.1s
 
 # asynchronous shaper for AVB classes
 *.N*.eth[*].macLayer.queue.queue[6].typename = "EligibilityTimeQueue"
-*.N*.eth[*].macLayer.queue.transmissionSelectionAlgorithm[6].typename = "Ieee8021qAsynchronousShaper"
+*.N*.eth[*].macLayer.queue.transmissionSelectionAlgorithm[6].typename = "EligibilityTimeGate"
 *.*.eth[*].macLayer.queue.queue[4..5].typename = "EligibilityTimeQueue"
-*.*.eth[*].macLayer.queue.transmissionSelectionAlgorithm[4..5].typename = "Ieee8021qAsynchronousShaper"
+*.*.eth[*].macLayer.queue.transmissionSelectionAlgorithm[4..5].typename = "EligibilityTimeGate"
 
 ##########################
 # Visualizer Configuration


### PR DESCRIPTION
To me the ATS showcase description was quite confusing because it took me a while to figure out that the Ieee8021qAsynchronousShaper is exactly the same as the EligibilityTimeGate.

To this end, I added a comment in the NED file of the Ieee8021qAsynchronousShaper and consistently use the EligibilityTimeGate module in showcase descriptions and configurations.

For the cbsandats showcase I was usure what to do and decided to not change it as it helps here for clarification which queue uses which shaper.