### PR TITLE
Fix to asynchronous shaper with scheduler groups 

### DIFF
--- a/src/inet/protocolelement/shaper/GroupEligibilityTimeMeter.h
+++ b/src/inet/protocolelement/shaper/GroupEligibilityTimeMeter.h
@@ -13,7 +13,7 @@
 
 namespace inet {
 
-class GroupEligibilityTimeMeter : public EligibilityTimeMeter
+class INET_API GroupEligibilityTimeMeter : public EligibilityTimeMeter
 {
     protected:
         ModuleRefByPar<GroupEligibilityTimeTable> groupEligibilityTimeTable;

--- a/src/inet/protocolelement/shaper/GroupEligibilityTimeMeter.ned
+++ b/src/inet/protocolelement/shaper/GroupEligibilityTimeMeter.ned
@@ -20,5 +20,5 @@ simple GroupEligibilityTimeMeter extends EligibilityTimeMeter
 {
 	parameters:
         string groupEligibilityTimeTableModule; // Relative path to the eligibilityTimeTable
-        @class(inet::MyEligibilityTimeMeter);
+        @class(GroupEligibilityTimeMeter);
 }

--- a/src/inet/protocolelement/shaper/GroupEligibilityTimeTable.ned
+++ b/src/inet/protocolelement/shaper/GroupEligibilityTimeTable.ned
@@ -19,5 +19,5 @@ simple GroupEligibilityTimeTable
 {
     parameters:
         @display("i=block/table");
-        @class(inet::GroupEligibilityTimeTable);
+        @class(GroupEligibilityTimeTable);
 }


### PR DESCRIPTION
The class names for the GroupEligibilityTimeMeter and GroupEligibilityTimeTable in  PR #973 were wrong, which lead to errors trying to use the ATSIeee8021qFilter. 
This pull request fixes these class names.