### PR TITLE
Fix ChunkSerializerRegistry type_info matching on Windows

### DIFF
--- a/src/inet/common/packet/serializer/ChunkSerializerRegistry.h
+++ b/src/inet/common/packet/serializer/ChunkSerializerRegistry.h
@@ -17,7 +17,13 @@ namespace inet {
 class INET_API ChunkSerializerRegistry
 {
   protected:
-    std::map<const std::type_info *, const ChunkSerializer *> serializers;
+    struct compareTypeInfo {
+        bool operator ()(const std::type_info* a, const std::type_info* b) const {
+            return a->before(*b);
+        }
+    };
+
+    std::map<const std::type_info *, const ChunkSerializer *, compareTypeInfo> serializers;
 
   public:
     ~ChunkSerializerRegistry();


### PR DESCRIPTION
Fixes error that the registry is not finding serializers on Windows.

type_info addresses and names are not guaranteed to be unique. To my knowledge before() is the only reliable way to compare type_info. This worked on Windows 11 24H2 and Ubuntu 24.04 for me.
