### PR TITLE
Backport fix for TcpBasicClientApp to v4.4.x

### DIFF
--- a/src/inet/applications/tcpapp/TcpBasicClientApp.cc
+++ b/src/inet/applications/tcpapp/TcpBasicClientApp.cc
@@ -132,7 +132,7 @@ void TcpBasicClientApp::socketEstablished(TcpSocket *socket)
 
 void TcpBasicClientApp::rescheduleAfterOrDeleteTimer(simtime_t d, short int msgKind)
 {
-    if (stopTime < SIMTIME_ZERO || d < stopTime) {
+    if (stopTime < SIMTIME_ZERO || simTime() + d < stopTime) {
         timeoutMsg->setKind(msgKind);
         rescheduleAfter(d, timeoutMsg);
     }


### PR DESCRIPTION
Backport a fix (c6b052d4f507c6d2b4f2eb5ddcf3c1c293f88a4c) for TcpBasicClientApp.
This fix makes the stopTime parameter work as intended.