### PR TITLE
Fix memory leak in MessageDispatcher when outGate->deliver returns false

### DIFF
--- a/src/inet/common/MessageDispatcher.cc
+++ b/src/inet/common/MessageDispatcher.cc
@@ -10,6 +10,7 @@
 #include "inet/common/ProtocolTag_m.h"
 #include "inet/common/socket/SocketTag_m.h"
 #include "inet/linklayer/common/InterfaceTag_m.h"
+#include "inet/queueing/common/PassivePacketSinkRef.h"
 
 namespace inet {
 
@@ -25,10 +26,73 @@ void MessageDispatcher::initialize(int stage) {
   if (stage == INITSTAGE_LOCAL) {
     forwardServiceRegistration = par("forwardServiceRegistration");
     forwardProtocolRegistration = par("forwardProtocolRegistration");
+    interfaceTable.reference(this, "interfaceTableModule", true);
     WATCH_MAP(socketIdToGateIndex);
     WATCH_MAP(interfaceIdToGateIndex);
     WATCH_MAP(serviceToGateIndex);
     WATCH_MAP(protocolToGateIndex);
+  } else if (stage == INITSTAGE_LAST) {
+    cValueMap *interfaceMapping =
+        check_and_cast<cValueMap *>(par("interfaceMapping").objectValue());
+    for (int i = 0; i < interfaceMapping->size(); i++) {
+      auto &entry = interfaceMapping->getEntry(i);
+      auto moduleName = entry.second.stringValue();
+      auto gateIndex = getGateIndexToConnectedModule(moduleName);
+      auto interfaceName = entry.first;
+      if (interfaceName == "*") {
+        for (auto &entry : interfaceIdToGateIndex)
+          entry.second = gateIndex;
+      } else if (interfaceName == "?")
+        interfaceIdToGateIndex[-1] = gateIndex;
+      else {
+        auto networkInterface =
+            interfaceTable->findInterfaceByName(interfaceName.c_str());
+        if (networkInterface == nullptr)
+          throw cRuntimeError("Cannot find network interface: %s",
+                              interfaceName.c_str());
+        interfaceIdToGateIndex[networkInterface->getInterfaceId()] = gateIndex;
+      }
+    }
+    cValueMap *serviceMapping =
+        check_and_cast<cValueMap *>(par("serviceMapping").objectValue());
+    for (int i = 0; i < serviceMapping->size(); i++) {
+      auto &entry = serviceMapping->getEntry(i);
+      auto moduleName = entry.second.stringValue();
+      auto gateIndex = getGateIndexToConnectedModule(moduleName);
+      auto protocolName = entry.first;
+      if (protocolName == "*") {
+        for (auto &entry : serviceToGateIndex)
+          if (entry.first.servicePrimitive == SP_REQUEST)
+            entry.second = gateIndex;
+      } else if (protocolName == "?") {
+        Key key(-1, SP_REQUEST);
+        serviceToGateIndex[key] = gateIndex;
+      } else {
+        Key key(Protocol::getProtocol(protocolName.c_str())->getId(),
+                SP_REQUEST);
+        serviceToGateIndex[key] = gateIndex;
+      }
+    }
+    cValueMap *protocolMapping =
+        check_and_cast<cValueMap *>(par("protocolMapping").objectValue());
+    for (int i = 0; i < protocolMapping->size(); i++) {
+      auto &entry = protocolMapping->getEntry(i);
+      auto moduleName = entry.second.stringValue();
+      auto gateIndex = getGateIndexToConnectedModule(moduleName);
+      auto protocolName = entry.first;
+      if (protocolName == "*") {
+        for (auto &entry : protocolToGateIndex)
+          if (entry.first.servicePrimitive == SP_INDICATION)
+            entry.second = gateIndex;
+      } else if (protocolName == "?") {
+        Key key(-1, SP_INDICATION);
+        protocolToGateIndex[key] = gateIndex;
+      } else {
+        Key key(Protocol::getProtocol(protocolName.c_str())->getId(),
+                SP_INDICATION);
+        protocolToGateIndex[key] = gateIndex;
+      }
+    }
   }
 }
 
@@ -50,12 +114,11 @@ void MessageDispatcher::arrived(cMessage *message, cGate *inGate,
     delete message;
   }
 #ifdef INET_WITH_QUEUEING
-  updateDisplayString();
 #endif // #ifdef INET_WITH_QUEUEING
 }
 
 #ifdef INET_WITH_QUEUEING
-bool MessageDispatcher::canPushSomePacket(cGate *inGate) const {
+bool MessageDispatcher::canPushSomePacket(const cGate *inGate) const {
   int size = gateSize("out");
   for (int i = 0; i < size; i++) {
     auto outGate = const_cast<MessageDispatcher *>(this)->gate("out", i);
@@ -67,7 +130,8 @@ bool MessageDispatcher::canPushSomePacket(cGate *inGate) const {
   return true;
 }
 
-bool MessageDispatcher::canPushPacket(Packet *packet, cGate *inGate) const {
+bool MessageDispatcher::canPushPacket(Packet *packet,
+                                      const cGate *inGate) const {
   auto outGate =
       const_cast<MessageDispatcher *>(this)->handlePacket(packet, inGate);
   auto consumer = findConnectedModule<queueing::IPassivePacketSink>(outGate);
@@ -75,38 +139,38 @@ bool MessageDispatcher::canPushPacket(Packet *packet, cGate *inGate) const {
          consumer->canPushPacket(packet, outGate->getPathEndGate());
 }
 
-void MessageDispatcher::pushPacket(Packet *packet, cGate *inGate) {
+void MessageDispatcher::pushPacket(Packet *packet, const cGate *inGate) {
   Enter_Method("pushPacket");
   take(packet);
   auto outGate = handlePacket(packet, inGate);
-  auto consumer = findConnectedModule<IPassivePacketSink>(outGate);
+  queueing::PassivePacketSinkRef consumer;
+  consumer.reference(outGate, false);
   handlePacketProcessed(packet);
   pushOrSendPacket(packet, outGate, consumer);
-  updateDisplayString();
 }
 
-void MessageDispatcher::pushPacketStart(Packet *packet, cGate *inGate,
+void MessageDispatcher::pushPacketStart(Packet *packet, const cGate *inGate,
                                         bps datarate) {
   Enter_Method("pushPacketStart");
   take(packet);
   auto outGate = handlePacket(packet, inGate);
-  auto consumer = findConnectedModule<IPassivePacketSink>(outGate);
+  queueing::PassivePacketSinkRef consumer;
+  consumer.reference(outGate, false);
   pushOrSendPacketStart(packet, outGate, consumer, datarate,
                         packet->getTransmissionId());
-  updateDisplayString();
 }
 
-void MessageDispatcher::pushPacketEnd(Packet *packet, cGate *inGate) {
+void MessageDispatcher::pushPacketEnd(Packet *packet, const cGate *inGate) {
   Enter_Method("pushPacketEnd");
   take(packet);
   auto outGate = handlePacket(packet, inGate);
-  auto consumer = findConnectedModule<IPassivePacketSink>(outGate);
+  queueing::PassivePacketSinkRef consumer;
+  consumer.reference(outGate, false);
   handlePacketProcessed(packet);
   pushOrSendPacketEnd(packet, outGate, consumer, packet->getTransmissionId());
-  updateDisplayString();
 }
 
-void MessageDispatcher::handleCanPushPacketChanged(cGate *outGate) {
+void MessageDispatcher::handleCanPushPacketChanged(const cGate *outGate) {
   int size = gateSize("in");
   for (int i = 0; i < size; i++) {
     auto inGate = gate("in", i);
@@ -117,12 +181,13 @@ void MessageDispatcher::handleCanPushPacketChanged(cGate *outGate) {
   }
 }
 
-void MessageDispatcher::handlePushPacketProcessed(Packet *packet, cGate *gate,
+void MessageDispatcher::handlePushPacketProcessed(Packet *packet,
+                                                  const cGate *gate,
                                                   bool successful) {}
 
 #endif // #ifdef INET_WITH_QUEUEING
 
-cGate *MessageDispatcher::handlePacket(Packet *packet, cGate *inGate) {
+cGate *MessageDispatcher::handlePacket(Packet *packet, const cGate *inGate) {
   const auto &socketInd = packet->findTag<SocketInd>();
   if (socketInd != nullptr) {
     int socketId = socketInd->getSocketId();
@@ -173,12 +238,15 @@ cGate *MessageDispatcher::handlePacket(Packet *packet, cGate *inGate) {
                   << EV_FIELD(outGate) << EV_FIELD(packet) << EV_ENDL;
           return outGate;
         } else
-          throw cRuntimeError("handlePacket(): Unknown protocol: protocolId = "
-                              "%d, protocolName = %s, servicePrimitive = "
-                              "REQUEST, pathStartGate = %s, pathEndGate = %s",
-                              protocol->getId(), protocol->getName(),
-                              inGate->getPathStartGate()->getFullPath().c_str(),
-                              inGate->getPathEndGate()->getFullPath().c_str());
+          throw cRuntimeError(
+              "handlePacket(): Unknown service: protocolId = %d, protocolName "
+              "= %s, servicePrimitive = REQUEST, pathStartGate = %s, "
+              "pathEndGate = %s\nConnected protocols can register using "
+              "registerService() or the serviceMapping parameter can be used "
+              "to specify the output gate",
+              protocol->getId(), protocol->getName(),
+              inGate->getPathStartGate()->getFullPath().c_str(),
+              inGate->getPathEndGate()->getFullPath().c_str());
       }
     } else if (servicePrimitive == SP_INDICATION) {
       auto it =
@@ -202,7 +270,9 @@ cGate *MessageDispatcher::handlePacket(Packet *packet, cGate *inGate) {
           throw cRuntimeError(
               "handlePacket(): Unknown protocol: protocolId = %d, protocolName "
               "= %s, servicePrimitive = INDICATION, pathStartGate = %s, "
-              "pathEndGate = %s",
+              "pathEndGate = %s\nConnected protocols can register using "
+              "registerProtocol() or the protocolMapping parameter can be used "
+              "to specify the output gate",
               protocol->getId(), protocol->getName(),
               inGate->getPathStartGate()->getFullPath().c_str(),
               inGate->getPathEndGate()->getFullPath().c_str());
@@ -221,16 +291,27 @@ cGate *MessageDispatcher::handlePacket(Packet *packet, cGate *inGate) {
     auto it = interfaceIdToGateIndex.find(interfaceId);
     if (it != interfaceIdToGateIndex.end()) {
       auto outGate = gate("out", it->second);
-      EV_INFO << "Dispatching packet to interface" << EV_FIELD(interfaceId)
-              << EV_FIELD(inGate) << EV_FIELD(outGate) << EV_FIELD(packet)
-              << EV_ENDL;
+      EV_INFO << "Dispatching packet to network interface"
+              << EV_FIELD(interfaceId) << EV_FIELD(inGate) << EV_FIELD(outGate)
+              << EV_FIELD(packet) << EV_ENDL;
       return outGate;
-    } else
-      throw cRuntimeError("handlePacket(): Unknown interface: interfaceId = "
-                          "%d, pathStartGate = %s, pathEndGate = %s",
-                          interfaceId,
-                          inGate->getPathStartGate()->getFullPath().c_str(),
-                          inGate->getPathEndGate()->getFullPath().c_str());
+    } else {
+      auto it = interfaceIdToGateIndex.find(-1);
+      if (it != interfaceIdToGateIndex.end()) {
+        auto outGate = gate("out", it->second);
+        EV_INFO << "Dispatching packet to network interface"
+                << EV_FIELD(interfaceId) << EV_FIELD(inGate)
+                << EV_FIELD(outGate) << EV_FIELD(packet) << EV_ENDL;
+        return outGate;
+      } else
+        throw cRuntimeError(
+            "handlePacket(): Unknown network interface: interfaceId = %d, "
+            "pathStartGate = %s, pathEndGate = %s\nConnected network "
+            "interfaces can register using registerInterface() or the "
+            "interfaceMapping parameter can be used to specify the output gate",
+            interfaceId, inGate->getPathStartGate()->getFullPath().c_str(),
+            inGate->getPathEndGate()->getFullPath().c_str());
+    }
   }
   throw cRuntimeError("handlePacket(): Unknown packet: %s(%s), pathStartGate = "
                       "%s, pathEndGate = %s",
@@ -299,12 +380,15 @@ cGate *MessageDispatcher::handleMessage(Message *message, cGate *inGate) {
                   << EV_FIELD(outGate) << EV_FIELD(message) << EV_ENDL;
           return outGate;
         } else
-          throw cRuntimeError("handleMessage(): Unknown protocol: protocolId = "
-                              "%d, protocolName = %s, servicePrimitive = "
-                              "REQUEST, pathStartGate = %s, pathEndGate = %s",
-                              protocol->getId(), protocol->getName(),
-                              inGate->getPathStartGate()->getFullPath().c_str(),
-                              inGate->getPathEndGate()->getFullPath().c_str());
+          throw cRuntimeError(
+              "handleMessage(): Unknown service: protocolId = %d, protocolName "
+              "= %s, servicePrimitive = REQUEST, pathStartGate = %s, "
+              "pathEndGate = %s\nConnected protocols can register using "
+              "registerService() or the serviceMapping parameter can be used "
+              "to specify the output gate",
+              protocol->getId(), protocol->getName(),
+              inGate->getPathStartGate()->getFullPath().c_str(),
+              inGate->getPathEndGate()->getFullPath().c_str());
       }
     } else if (servicePrimitive == SP_INDICATION) {
       auto it =
@@ -328,7 +412,9 @@ cGate *MessageDispatcher::handleMessage(Message *message, cGate *inGate) {
           throw cRuntimeError(
               "handleMessage(): Unknown protocol: protocolId = %d, "
               "protocolName = %s, servicePrimitive = INDICATION, pathStartGate "
-              "= %s, pathEndGate = %s",
+              "= %s, pathEndGate = %s\nConnected protocols can register using "
+              "registerProtocol() or the protocolMapping parameter can be used "
+              "to specify the output gate",
               protocol->getId(), protocol->getName(),
               inGate->getPathStartGate()->getFullPath().c_str(),
               inGate->getPathEndGate()->getFullPath().c_str());
@@ -347,16 +433,18 @@ cGate *MessageDispatcher::handleMessage(Message *message, cGate *inGate) {
     auto it = interfaceIdToGateIndex.find(interfaceId);
     if (it != interfaceIdToGateIndex.end()) {
       auto outGate = gate("out", it->second);
-      EV_INFO << "Dispatching message to interface" << EV_FIELD(interfaceId)
-              << EV_FIELD(inGate) << EV_FIELD(outGate) << EV_FIELD(message)
-              << EV_ENDL;
+      EV_INFO << "Dispatching message to network interface"
+              << EV_FIELD(interfaceId) << EV_FIELD(inGate) << EV_FIELD(outGate)
+              << EV_FIELD(message) << EV_ENDL;
       return outGate;
     } else
-      throw cRuntimeError("handleMessage(): Unknown interface: interfaceId = "
-                          "%d, pathStartGate = %s, pathEndGate = %s",
-                          interfaceId,
-                          inGate->getPathStartGate()->getFullPath().c_str(),
-                          inGate->getPathEndGate()->getFullPath().c_str());
+      throw cRuntimeError(
+          "handleMessage(): Unknown network interface: interfaceId = %d, "
+          "pathStartGate = %s, pathEndGate = %s\nConnected network interfaces "
+          "can register using registerInterface() or the interfaceMapping "
+          "parameter can be used to specify the output gate",
+          interfaceId, inGate->getPathStartGate()->getFullPath().c_str(),
+          inGate->getPathEndGate()->getFullPath().c_str());
   }
   throw cRuntimeError("handleMessage(): Unknown message: %s(%s), pathStartGate "
                       "= %s, pathEndGate = %s",
@@ -522,6 +610,19 @@ void MessageDispatcher::handleRegisterInterface(
       if (i != in->getIndex())
         registerInterface(interface, gate("in", i), gate("out", i));
   }
+}
+
+int MessageDispatcher::getGateIndexToConnectedModule(const char *moduleName) {
+  int size = gateSize("out");
+  for (int i = 0; i < size; i++) {
+    auto g = gate("out", i);
+    while (g != nullptr) {
+      if (!strcmp(g->getOwnerModule()->getFullName(), moduleName))
+        return i;
+      g = g->getNextGate();
+    }
+  }
+  throw cRuntimeError("Cannot find module: %s", moduleName);
 }
 
 } // namespace inet


### PR DESCRIPTION
When a network interface goes down (e.g. in failure simulations), the local deliver() returns false. MessageDispatcher ignored this boolean return value, causing dropped packets to remain undeleted in memory. This commit deletes the packet correctly and calls take() prior to deletion to satisfy OMNeT++ object tracking conventions.