### PR TITLE
Fix memory leak in MessageDispatcher when outGate->deliver returns false

### DIFF
--- a/src/inet/common/MessageDispatcher.cc
+++ b/src/inet/common/MessageDispatcher.cc
@@ -110,7 +110,11 @@ void MessageDispatcher::arrived(cMessage *message, cGate *inGate, const SendOpti
     }
     else
         outGate = handleMessage(check_and_cast<Message *>(message), inGate);
-    outGate->deliver(message, options, time);
+    bool keepMsg = outGate->deliver(message, options, time);
+    if (!keepMsg) {
+        take(message);
+        delete message;
+    }
 #ifdef INET_WITH_QUEUEING
 #endif // #ifdef INET_WITH_QUEUEING
 }


### PR DESCRIPTION
This is a clean recreation of PR #1091 with only the minimal functional changes required to fix the memory leak, as requested in the review comments.

Original PR body:
When a network interface goes down (e.g. in failure simulations), the local deliver() returns false. MessageDispatcher ignored this boolean return value, causing dropped packets to remain undeleted in memory. This commit deletes the packet correctly and calls take() prior to deletion to satisfy OMNeT++ object tracking conventions.