### PR TITLE
Fix memory leak in MessageDispatcher when outGate->deliver returns false

### DIFF
--- a/src/inet/common/MessageDispatcher.cc
+++ b/src/inet/common/MessageDispatcher.cc
@@ -110,7 +110,11 @@ void MessageDispatcher::arrived(cMessage *message, cGate *inGate, const SendOpti
     }
     else
         outGate = handleMessage(check_and_cast<Message *>(message), inGate);
-    outGate->deliver(message, options, time);
+    bool keepMsg = outGate->deliver(message, options, time);
+    if (!keepMsg) {
+        take(message);
+        delete message;
+    }
 #ifdef INET_WITH_QUEUEING
 #endif // #ifdef INET_WITH_QUEUEING
 }


### PR DESCRIPTION
This PR fixes a packet memory leak in `inet/common/MessageDispatcher.cc`.

If `outGate->deliver(...)` returns false (meaning the message could not be delivered natively by the channel), the current code effectively discards the pointer without deleting it, resulting in a memory leak. 

This PR adds a `keepMsg` check to capture the return value of `deliver()`, and strictly deletes the message if it was not taken by the gate, matching OMNeT++ ownership semantics.

*Note: This supersedes PR #1091 with a clean functional-only patch that strictly preserves the original file formatting.*