### PR TITLE
[FIX] [IPv6] Use correct destination address so packets with multicast destination are properly handled

### DIFF
--- a/src/inet/networklayer/ipv6/Ipv6.cc
+++ b/src/inet/networklayer/ipv6/Ipv6.cc
@@ -401,14 +401,15 @@ void Ipv6::handleMessageFromHL(Packet *packet)
 void Ipv6::datagramLocalOut(Packet *packet, const NetworkInterface *destIE, Ipv6Address requestedNextHopAddress)
 {
     const auto& ipv6Header = packet->peekAtFront<Ipv6Header>();
+
     // route packet
     if (destIE != nullptr)
-        fragmentPostRouting(packet, destIE, MacAddress::BROADCAST_ADDRESS, true); // FIXME what MAC address to use?
+        fragmentPostRouting(packet, destIE, ipv6Header->getDestAddress(), true);
     else if (!ipv6Header->getDestAddress().isMulticast())
         routePacket(packet, destIE, nullptr, requestedNextHopAddress, true);
     else
         routeMulticastPacket(packet, destIE, nullptr, true);
-}
+ }
 
 void Ipv6::routePacket(Packet *packet, const NetworkInterface *destIE, const NetworkInterface *fromIE, Ipv6Address requestedNextHopAddress, bool fromHL)
 {

--- a/src/inet/networklayer/ipv6/Ipv6.cc
+++ b/src/inet/networklayer/ipv6/Ipv6.cc
@@ -409,7 +409,7 @@ void Ipv6::datagramLocalOut(Packet *packet, const NetworkInterface *destIE, Ipv6
         routePacket(packet, destIE, nullptr, requestedNextHopAddress, true);
     else
         routeMulticastPacket(packet, destIE, nullptr, true);
- }
+}
 
 void Ipv6::routePacket(Packet *packet, const NetworkInterface *destIE, const NetworkInterface *fromIE, Ipv6Address requestedNextHopAddress, bool fromHL)
 {


### PR DESCRIPTION
The previous version was inefficient because it used the broadcast address as the destination address for any multicast packet. 