### PR TITLE
Bgp: add Adj-RIB-In support and route withdrawal failover

### DIFF
--- a/examples/bgpv4/BgpDiamondFailover/BGPConfig.xml
+++ b/examples/bgpv4/BgpDiamondFailover/BGPConfig.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<BGPConfig xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="BGP.xsd">
+
+    <AS id="65001">
+        <Router interAddr="10.0.1.1">
+            <Network address="10.0.1.0"/>
+        </Router>
+    </AS>
+
+    <AS id="65002">
+        <Router interAddr="10.0.12.2"/>
+    </AS>
+
+    <AS id="65003">
+        <Router interAddr="10.0.3.1">
+            <Network address="10.0.3.0"/>
+        </Router>
+    </AS>
+
+    <AS id="65004">
+        <Router interAddr="10.0.14.4"/>
+    </AS>
+
+    <Session id="1">
+        <Router exterAddr="10.0.12.1"/>
+        <Router exterAddr="10.0.12.2"/>
+    </Session>
+
+    <Session id="2">
+        <Router exterAddr="10.0.23.2"/>
+        <Router exterAddr="10.0.23.3"/>
+    </Session>
+
+    <Session id="10">
+        <Router exterAddr="10.0.14.1"/>
+        <Router exterAddr="10.0.14.4"/>
+    </Session>
+
+    <Session id="11">
+        <Router exterAddr="10.0.43.4"/>
+        <Router exterAddr="10.0.43.3"/>
+    </Session>
+
+</BGPConfig>

--- a/examples/bgpv4/BgpDiamondFailover/BgpDiamondFailover.ned
+++ b/examples/bgpv4/BgpDiamondFailover/BgpDiamondFailover.ned
@@ -1,0 +1,93 @@
+package inet.examples.bgpv4.BgpDiamondFailover;
+
+import inet.common.misc.ThruputMeteringChannel;
+import inet.common.scenario.ScenarioManager;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.Router;
+import inet.node.inet.StandardHost;
+import inet.visualizer.canvas.integrated.IntegratedCanvasVisualizer;
+
+network BgpDiamondFailover
+{
+    types:
+        channel FastLink extends ThruputMeteringChannel
+        {
+            parameters:
+                delay = 50us;
+                datarate = 100Mbps;
+                displayAsTooltip = true;
+                thruputDisplayFormat = "#N";
+        }
+        channel SlowLink extends ThruputMeteringChannel
+        {
+            parameters:
+                delay = 300us;
+                datarate = 100Mbps;
+                displayAsTooltip = true;
+                thruputDisplayFormat = "#N";
+        }
+    submodules:
+        visualizer: IntegratedCanvasVisualizer {
+            parameters:
+                @display("p=100,100;is=s");
+        }
+        configurator: Ipv4NetworkConfigurator {
+            parameters:
+                @display("p=100,200;is=s");
+                config = xmldoc("IPv4Config.xml");
+                addStaticRoutes = false;
+                addDefaultRoutes = false;
+                addSubnetRoutes = false;
+        }
+        scenarioManager: ScenarioManager {
+            parameters:
+                @display("p=100,300;is=s");
+        }
+        hostA: StandardHost {
+            parameters:
+                @display("p=220,200;i=device/laptop");
+        }
+        A: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                @display("p=360,200");
+            gates:
+                ethg[3];
+        }
+        B: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                @display("p=520,120");
+            gates:
+                ethg[2];
+        }
+        D: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                @display("p=520,280");
+            gates:
+                ethg[2];
+        }
+        C: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                @display("p=700,200");
+            gates:
+                ethg[3];
+        }
+        hostC: StandardHost {
+            parameters:
+                @display("p=860,200;i=device/laptop");
+        }
+    connections:
+        hostA.ethg++ <--> FastLink <--> A.ethg[0];
+        A.ethg[1] <--> FastLink <--> B.ethg[0];
+        B.ethg[1] <--> FastLink <--> C.ethg[0];
+        A.ethg[2] <--> SlowLink <--> D.ethg[0];
+        D.ethg[1] <--> SlowLink <--> C.ethg[1];
+        C.ethg[2] <--> FastLink <--> hostC.ethg++;
+}

--- a/examples/bgpv4/BgpDiamondFailover/IPv4Config.xml
+++ b/examples/bgpv4/BgpDiamondFailover/IPv4Config.xml
@@ -1,0 +1,21 @@
+<config>
+  <interface hosts='hostA' names='eth0' address='10.0.1.100' netmask='255.255.255.0'/>
+  <interface hosts='A' names='eth0' address='10.0.1.1' netmask='255.255.255.0'/>
+
+  <interface hosts='A' names='eth1' address='10.0.12.1' netmask='255.255.255.0'/>
+  <interface hosts='B' names='eth0' address='10.0.12.2' netmask='255.255.255.0'/>
+
+  <interface hosts='B' names='eth1' address='10.0.23.2' netmask='255.255.255.0'/>
+  <interface hosts='C' names='eth0' address='10.0.23.3' netmask='255.255.255.0'/>
+
+  <interface hosts='A' names='eth2' address='10.0.14.1' netmask='255.255.255.0'/>
+  <interface hosts='D' names='eth0' address='10.0.14.4' netmask='255.255.255.0'/>
+
+  <interface hosts='D' names='eth1' address='10.0.43.4' netmask='255.255.255.0'/>
+  <interface hosts='C' names='eth1' address='10.0.43.3' netmask='255.255.255.0'/>
+
+  <interface hosts='C' names='eth2' address='10.0.3.1' netmask='255.255.255.0'/>
+  <interface hosts='hostC' names='eth0' address='10.0.3.100' netmask='255.255.255.0'/>
+
+  <route hosts='hostA hostC' destination='*' netmask='*' interface='eth0'/>
+</config>

--- a/examples/bgpv4/BgpDiamondFailover/README.md
+++ b/examples/bgpv4/BgpDiamondFailover/README.md
@@ -1,0 +1,24 @@
+# BgpDiamondFailover
+
+This example demonstrates IPv4 BGP failover and failback in a pure-BGP diamond topology:
+
+`hostA - A - B - C - hostC`
+
+`hostA - A - D - C - hostC`
+
+Routers `A`, `B`, `C`, and `D` are in different ASes. The preferred path initially goes through `A-B-C`.
+The `A-B-C` branch also uses lower link delays than `A-D-C`, so the active path change is visible in the ping RTT results.
+
+At `60s`, router `B` is shut down. After the shortened BGP hold timer expires, traffic switches to the alternate `A-D-C` path using the routes already stored in Adj-RIB-In.
+
+At `100s`, router `B` is started again. Once the BGP sessions re-establish and exchange routes again, the preferred route returns to `A-B-C`.
+
+Notes:
+
+- This example intentionally uses modified BGP timers to make the failover and failback visible in a short simulation:
+  - `connectRetryTime = 5s`
+  - `holdTime = 6s`
+  - `keepAliveTime = 2s`
+  - `startDelay = 2s`
+- The links on the alternate `A-D-C` branch use higher delay than the preferred `A-B-C` branch so failover and failback are easy to observe.
+- The timers are shorter than typical BGP defaults and are meant only for demonstration.

--- a/examples/bgpv4/BgpDiamondFailover/README.md
+++ b/examples/bgpv4/BgpDiamondFailover/README.md
@@ -1,17 +1,21 @@
 # BgpDiamondFailover
 
-This example demonstrates IPv4 BGP failover and failback in a pure-BGP diamond topology:
+This example demonstrates IPv4 BGP failover, failback, and a second failure in a pure-BGP diamond topology:
 
 `hostA - A - B - C - hostC`
 
 `hostA - A - D - C - hostC`
 
-Routers `A`, `B`, `C`, and `D` are in different ASes. The preferred path initially goes through `A-B-C`.
-The `A-B-C` branch also uses lower link delays than `A-D-C`, so the active path change is visible in the ping RTT results.
+Routers `A`, `B`, `C`, and `D` are in different ASes. Router `A` advertises the `10.0.1.0/24` network, router `C` advertises the `10.0.3.0/24` network, and the hosts use default routes toward their adjacent routers. The preferred BGP path initially goes through `A-B-C`.
 
-At `60s`, router `B` is shut down. After the shortened BGP hold timer expires, traffic switches to the alternate `A-D-C` path using the routes already stored in Adj-RIB-In.
+The `A-B-C` branch uses `50us` links and the alternate `A-D-C` branch uses `300us` links, so the active path change is visible in the ping RTT results.
 
-At `100s`, router `B` is started again. Once the BGP sessions re-establish and exchange routes again, the preferred route returns to `A-B-C`.
+The scenario timeline is:
+
+- At `20s`, `hostA` starts pinging `hostC` at `10.0.3.100`.
+- At `60s`, router `B` is shut down. After the shortened BGP hold timer expires, traffic switches to the alternate `A-D-C` path using the routes already stored in Adj-RIB-In.
+- At `100s`, router `B` is started again. Once the BGP sessions re-establish and exchange routes again, the preferred route returns to `A-B-C`.
+- At `140s`, router `B` crashes. This exercises failover again after the network has already failed back to the preferred branch.
 
 Notes:
 

--- a/examples/bgpv4/BgpDiamondFailover/omnetpp.ini
+++ b/examples/bgpv4/BgpDiamondFailover/omnetpp.ini
@@ -1,0 +1,46 @@
+[General]
+description = "IPv4 BGP diamond failover and failback with Adj-RIB-In fallback"
+network = BgpDiamondFailover
+sim-time-limit = 160s
+
+**.app[0].**.scalar-recording = true
+*.hostA.app[0].**.vector-recording = true
+**.bgp.**.scalar-recording = true
+**.scalar-recording = false
+**.vector-recording = false
+
+**.eth[*].queue.packetCapacity = 100
+
+**.tcp.typename = "Tcp"
+**.tcp.mss = 1024
+**.tcp.advertisedWindow = 14336
+**.tcp.tcpAlgorithmClass = "TcpReno"
+
+**.bgpConfig = xmldoc("BGPConfig.xml")
+**.bgp.startDelay = 2s
+**.bgp.connectRetryTime = 5s
+**.bgp.holdTime = 6s
+**.bgp.keepAliveTime = 2s
+
+*.A.bgp.routerId = "1.1.1.1"
+*.B.bgp.routerId = "2.2.2.2"
+*.C.bgp.routerId = "3.3.3.3"
+*.D.bgp.routerId = "4.4.4.4"
+
+*.visualizer.interfaceTableVisualizer.displayInterfaceTables = true
+
+*.hostA.numApps = 1
+*.hostA.app[0].typename = "PingApp"
+*.hostA.app[0].destAddr = "10.0.3.100"
+*.hostA.app[0].startTime = 20s
+*.hostA.app[0].sendInterval = 1s
+
+*.hostC.numApps = 1
+*.hostC.app[0].typename = "PingApp"
+*.hostC.app[0].destAddr = ""
+
+*.scenarioManager.script = xml( \
+        "<script>\n" + \
+        "<at t='60s'><shutdown module='B'/></at>\n" + \
+        "<at t='100s'><startup module='B'/></at>\n" + \
+        "</script>")

--- a/examples/bgpv4/BgpDiamondFailover/omnetpp.ini
+++ b/examples/bgpv4/BgpDiamondFailover/omnetpp.ini
@@ -43,4 +43,5 @@ sim-time-limit = 160s
         "<script>\n" + \
         "<at t='60s'><shutdown module='B'/></at>\n" + \
         "<at t='100s'><startup module='B'/></at>\n" + \
+        "<at t='140s'><crash module='B'/></at>\n" + \
         "</script>")

--- a/examples/bgpv4/BgpDiamondFailover6/BgpConfig6.xml
+++ b/examples/bgpv4/BgpDiamondFailover6/BgpConfig6.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<BGPConfig>
+
+    <AS id="65001">
+        <Router interAddr="2001:db8:1::1">
+            <Network address="2001:db8:1::"/>
+        </Router>
+    </AS>
+
+    <AS id="65002">
+        <Router interAddr="2001:db8:12::2"/>
+    </AS>
+
+    <AS id="65003">
+        <Router interAddr="2001:db8:3::1">
+            <Network address="2001:db8:3::"/>
+        </Router>
+    </AS>
+
+    <AS id="65004">
+        <Router interAddr="2001:db8:14::4"/>
+    </AS>
+
+    <Session id="1">
+        <Router exterAddr="2001:db8:12::1"/>
+        <Router exterAddr="2001:db8:12::2"/>
+    </Session>
+
+    <Session id="2">
+        <Router exterAddr="2001:db8:23::2"/>
+        <Router exterAddr="2001:db8:23::3"/>
+    </Session>
+
+    <Session id="10">
+        <Router exterAddr="2001:db8:14::1"/>
+        <Router exterAddr="2001:db8:14::4"/>
+    </Session>
+
+    <Session id="11">
+        <Router exterAddr="2001:db8:43::4"/>
+        <Router exterAddr="2001:db8:43::3"/>
+    </Session>
+
+</BGPConfig>

--- a/examples/bgpv4/BgpDiamondFailover6/BgpDiamondFailover6.ned
+++ b/examples/bgpv4/BgpDiamondFailover6/BgpDiamondFailover6.ned
@@ -1,0 +1,99 @@
+package inet.examples.bgpv4.BgpDiamondFailover6;
+
+import inet.common.misc.ThruputMeteringChannel;
+import inet.common.scenario.ScenarioManager;
+import inet.networklayer.configurator.ipv6.Ipv6NetworkConfigurator;
+import inet.node.inet.Router;
+import inet.node.ipv6.StandardHost6;
+import inet.visualizer.canvas.integrated.IntegratedCanvasVisualizer;
+
+network BgpDiamondFailover6
+{
+    types:
+        channel FastLink extends ThruputMeteringChannel
+        {
+            parameters:
+                delay = 50us;
+                datarate = 100Mbps;
+                displayAsTooltip = true;
+                thruputDisplayFormat = "#N";
+        }
+        channel SlowLink extends ThruputMeteringChannel
+        {
+            parameters:
+                delay = 300us;
+                datarate = 100Mbps;
+                displayAsTooltip = true;
+                thruputDisplayFormat = "#N";
+        }
+    submodules:
+        visualizer: IntegratedCanvasVisualizer {
+            parameters:
+                @display("p=100,100;is=s");
+        }
+        configurator: Ipv6NetworkConfigurator {
+            parameters:
+                @display("p=100,200;is=s");
+                config = xmldoc("Ipv6Config.xml");
+                addRemoteRoutes = false;
+        }
+        scenarioManager: ScenarioManager {
+            parameters:
+                @display("p=100,300;is=s");
+        }
+        hostA: StandardHost6 {
+            parameters:
+                @display("p=220,200;i=device/laptop");
+        }
+        A: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                hasIpv4 = false;
+                hasIpv6 = true;
+                @display("p=360,200");
+            gates:
+                ethg[3];
+        }
+        B: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                hasIpv4 = false;
+                hasIpv6 = true;
+                @display("p=520,120");
+            gates:
+                ethg[2];
+        }
+        D: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                hasIpv4 = false;
+                hasIpv6 = true;
+                @display("p=520,280");
+            gates:
+                ethg[2];
+        }
+        C: Router {
+            parameters:
+                hasBgp = true;
+                hasStatus = true;
+                hasIpv4 = false;
+                hasIpv6 = true;
+                @display("p=700,200");
+            gates:
+                ethg[3];
+        }
+        hostC: StandardHost6 {
+            parameters:
+                @display("p=860,200;i=device/laptop");
+        }
+    connections:
+        hostA.ethg++ <--> FastLink <--> A.ethg[0];
+        A.ethg[1] <--> FastLink <--> B.ethg[0];
+        B.ethg[1] <--> FastLink <--> C.ethg[0];
+        A.ethg[2] <--> SlowLink <--> D.ethg[0];
+        D.ethg[1] <--> SlowLink <--> C.ethg[1];
+        C.ethg[2] <--> FastLink <--> hostC.ethg++;
+}

--- a/examples/bgpv4/BgpDiamondFailover6/Ipv6Config.xml
+++ b/examples/bgpv4/BgpDiamondFailover6/Ipv6Config.xml
@@ -1,0 +1,19 @@
+<config>
+    <interface hosts="hostA" address="2001:db8:1::100"/>
+    <interface hosts="A" towards="hostA" address="2001:db8:1::1"/>
+
+    <interface hosts="A" towards="B" address="2001:db8:12::1"/>
+    <interface hosts="B" towards="A" address="2001:db8:12::2"/>
+
+    <interface hosts="B" towards="C" address="2001:db8:23::2"/>
+    <interface hosts="C" towards="B" address="2001:db8:23::3"/>
+
+    <interface hosts="A" towards="D" address="2001:db8:14::1"/>
+    <interface hosts="D" towards="A" address="2001:db8:14::4"/>
+
+    <interface hosts="D" towards="C" address="2001:db8:43::4"/>
+    <interface hosts="C" towards="D" address="2001:db8:43::3"/>
+
+    <interface hosts="C" towards="hostC" address="2001:db8:3::1"/>
+    <interface hosts="hostC" address="2001:db8:3::100"/>
+</config>

--- a/examples/bgpv4/BgpDiamondFailover6/README.md
+++ b/examples/bgpv4/BgpDiamondFailover6/README.md
@@ -1,17 +1,21 @@
 # BgpDiamondFailover6
 
-This example demonstrates IPv6 MP-BGP failover and failback in a pure-BGP diamond topology:
+This example demonstrates IPv6 MP-BGP failover, failback, and a second failure in a pure-BGP diamond topology:
 
 `hostA - A - B - C - hostC`
 
 `hostA - A - D - C - hostC`
 
-Routers `A`, `B`, `C`, and `D` are in different ASes. The preferred path initially goes through `A-B-C`.
-The `A-B-C` branch also uses lower link delays than `A-D-C`, so the active path change is visible in the ping RTT results.
+Routers `A`, `B`, `C`, and `D` are in different ASes. Router `A` advertises the `2001:db8:1::/64` network, router `C` advertises the `2001:db8:3::/64` network, and the hosts use default routes toward their adjacent routers. The preferred BGP path initially goes through `A-B-C`.
 
-At `60s`, router `B` is shut down. After the shortened BGP hold timer expires, traffic switches to the alternate `A-D-C` path using the routes already stored in Adj-RIB-In.
+The `A-B-C` branch uses `50us` links and the alternate `A-D-C` branch uses `300us` links, so the active path change is visible in the ping RTT results.
 
-At `100s`, router `B` is started again. Once the BGP sessions re-establish and exchange routes again, the preferred route returns to `A-B-C`.
+The scenario timeline is:
+
+- At `20s`, `hostA` starts pinging `hostC` at `2001:db8:3::100`.
+- At `60s`, router `B` is shut down. After the shortened BGP hold timer expires, traffic switches to the alternate `A-D-C` path using the routes already stored in Adj-RIB-In.
+- At `100s`, router `B` is started again. Once the BGP sessions re-establish and exchange routes again, the preferred route returns to `A-B-C`.
+- At `140s`, router `B` crashes. This exercises failover again after the network has already failed back to the preferred branch.
 
 Notes:
 

--- a/examples/bgpv4/BgpDiamondFailover6/README.md
+++ b/examples/bgpv4/BgpDiamondFailover6/README.md
@@ -1,0 +1,24 @@
+# BgpDiamondFailover6
+
+This example demonstrates IPv6 MP-BGP failover and failback in a pure-BGP diamond topology:
+
+`hostA - A - B - C - hostC`
+
+`hostA - A - D - C - hostC`
+
+Routers `A`, `B`, `C`, and `D` are in different ASes. The preferred path initially goes through `A-B-C`.
+The `A-B-C` branch also uses lower link delays than `A-D-C`, so the active path change is visible in the ping RTT results.
+
+At `60s`, router `B` is shut down. After the shortened BGP hold timer expires, traffic switches to the alternate `A-D-C` path using the routes already stored in Adj-RIB-In.
+
+At `100s`, router `B` is started again. Once the BGP sessions re-establish and exchange routes again, the preferred route returns to `A-B-C`.
+
+Notes:
+
+- This example intentionally uses modified BGP timers to make the failover and failback visible in a short simulation:
+  - `connectRetryTime = 5s`
+  - `holdTime = 6s`
+  - `keepAliveTime = 2s`
+  - `startDelay = 2s`
+- The links on the alternate `A-D-C` branch use higher delay than the preferred `A-B-C` branch so failover and failback are easy to observe.
+- The timers are shorter than typical BGP defaults and are meant only for demonstration.

--- a/examples/bgpv4/BgpDiamondFailover6/omnetpp.ini
+++ b/examples/bgpv4/BgpDiamondFailover6/omnetpp.ini
@@ -53,4 +53,5 @@ sim-time-limit = 160s
         "<script>\n" + \
         "<at t='60s'><shutdown module='B'/></at>\n" + \
         "<at t='100s'><startup module='B'/></at>\n" + \
+        "<at t='140s'><crash module='B'/></at>\n" + \
         "</script>")

--- a/examples/bgpv4/BgpDiamondFailover6/omnetpp.ini
+++ b/examples/bgpv4/BgpDiamondFailover6/omnetpp.ini
@@ -1,0 +1,56 @@
+[General]
+description = "IPv6 BGP diamond failover and failback with Adj-RIB-In fallback"
+network = BgpDiamondFailover6
+sim-time-limit = 160s
+
+**.ipv6.configurator.networkConfiguratorModule = "configurator"
+
+**.app[0].**.scalar-recording = true
+*.hostA.app[0].**.vector-recording = true
+**.bgp.**.scalar-recording = true
+**.scalar-recording = false
+**.vector-recording = false
+
+**.eth[*].queue.packetCapacity = 100
+
+**.tcp.typename = "Tcp"
+**.tcp.mss = 1024
+**.tcp.advertisedWindow = 14336
+**.tcp.tcpAlgorithmClass = "TcpReno"
+
+*.A.bgp.addressFamily = "ipv6"
+*.B.bgp.addressFamily = "ipv6"
+*.C.bgp.addressFamily = "ipv6"
+*.D.bgp.addressFamily = "ipv6"
+*.A.bgp.routingTableModule = "^.ipv6.routingTable"
+*.B.bgp.routingTableModule = "^.ipv6.routingTable"
+*.C.bgp.routingTableModule = "^.ipv6.routingTable"
+*.D.bgp.routingTableModule = "^.ipv6.routingTable"
+**.bgpConfig = xmldoc("BgpConfig6.xml")
+**.bgp.startDelay = 2s
+**.bgp.connectRetryTime = 5s
+**.bgp.holdTime = 6s
+**.bgp.keepAliveTime = 2s
+
+*.A.bgp.routerId = "1.1.1.1"
+*.B.bgp.routerId = "2.2.2.2"
+*.C.bgp.routerId = "3.3.3.3"
+*.D.bgp.routerId = "4.4.4.4"
+
+*.visualizer.interfaceTableVisualizer.displayInterfaceTables = true
+
+*.hostA.numApps = 1
+*.hostA.app[0].typename = "PingApp"
+*.hostA.app[0].destAddr = "2001:db8:3::100"
+*.hostA.app[0].startTime = 20s
+*.hostA.app[0].sendInterval = 1s
+
+*.hostC.numApps = 1
+*.hostC.app[0].typename = "PingApp"
+*.hostC.app[0].destAddr = ""
+
+*.scenarioManager.script = xml( \
+        "<script>\n" + \
+        "<at t='60s'><shutdown module='B'/></at>\n" + \
+        "<at t='100s'><startup module='B'/></at>\n" + \
+        "</script>")

--- a/examples/bgpv4/BgpLifecycle/omnetpp.ini
+++ b/examples/bgpv4/BgpLifecycle/omnetpp.ini
@@ -49,6 +49,6 @@ output-scalar-precision = 5
 *.scenarioManager.script = xml( \
         "<script>\n" + \
         "<at t='120s'><shutdown module='A'/></at>\n" + \
-        "<at t='300s'><startup module='A'/></at>\n" + \
-        "<at t='600s'><crash module='A'/></at>\n" + \
+        "<at t='360s'><startup module='A'/></at>\n" + \
+        "<at t='480s'><crash module='A'/></at>\n" + \
         "</script>")

--- a/src/inet/common/lifecycle/ModuleOperations.h
+++ b/src/inet/common/lifecycle/ModuleOperations.h
@@ -26,6 +26,7 @@ class INET_API ModuleStartOperation : public LifecycleOperation
         STAGE_LOCAL, // for changes that don't depend on other modules
         STAGE_PHYSICAL_LAYER,
         STAGE_LINK_LAYER,
+        STAGE_NETWORK_INTERFACE_CONFIGURATION,
         STAGE_NETWORK_LAYER,
         STAGE_TRANSPORT_LAYER,
         STAGE_ROUTING_PROTOCOLS,
@@ -51,6 +52,7 @@ class INET_API ModuleStopOperation : public LifecycleOperation
         STAGE_ROUTING_PROTOCOLS,
         STAGE_TRANSPORT_LAYER,
         STAGE_NETWORK_LAYER,
+        STAGE_NETWORK_INTERFACE_CONFIGURATION,
         STAGE_LINK_LAYER,
         STAGE_PHYSICAL_LAYER,
         STAGE_LAST // for changes that others shouldn't depend on

--- a/src/inet/networklayer/ipv6/Ipv6RoutingTable.cc
+++ b/src/inet/networklayer/ipv6/Ipv6RoutingTable.cc
@@ -1043,7 +1043,7 @@ bool Ipv6RoutingTable::handleOperationStage(LifecycleOperation *operation, IDone
     Enter_Method("handleOperationStage");
     int stage = operation->getCurrentStage();
     if (dynamic_cast<ModuleStartOperation *>(operation)) {
-        if (static_cast<ModuleStartOperation::Stage>(stage) == ModuleStartOperation::STAGE_NETWORK_LAYER) {
+        if (static_cast<ModuleStartOperation::Stage>(stage) == ModuleStartOperation::STAGE_NETWORK_INTERFACE_CONFIGURATION) {
             // re-add Ipv6InterfaceData to interfaces and reconfigure
             for (int i = 0; i < ift->getNumInterfaces(); i++) {
                 NetworkInterface *ie = ift->getInterface(i);

--- a/src/inet/routing/bgpv4/Bgp.cc
+++ b/src/inet/routing/bgpv4/Bgp.cc
@@ -122,10 +122,21 @@ void Bgp::startBgp()
 {
     ASSERT(bgpRouter == nullptr);
     simtime_t startupTime = par("startupTime");
-    if (startupTime == 0)
-        createBgpRouter();
-    else
+    if (simTime() > SIMTIME_ZERO) {
+        // this is a restart
+        // use the self-message path even for 0s startup so lifecycle restarts happen after the
+        // node has finished bringing its interfaces back up.
+        if (startupTime == SIMTIME_ZERO)
+            startupTime = SimTime(1, SIMTIME_S);  // TODO what value should go here?
         scheduleAfter(startupTime, startupTimer);
+    }
+    else {
+        // this is startup at initialization
+        if (startupTime == SIMTIME_ZERO)
+            createBgpRouter();
+        else
+            scheduleAfter(startupTime, startupTimer);
+    }
 }
 
 void Bgp::stopBgp(bool abort)

--- a/src/inet/routing/bgpv4/BgpFsm.cc
+++ b/src/inet/routing/bgpv4/BgpFsm.cc
@@ -84,6 +84,9 @@ void Connect::HoldTimer_Expires()
     // - performs peer oscillation damping if the DampPeerOscillations attribute is set to True, and
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
     session.scheduleReconnect();
 }
@@ -163,6 +166,9 @@ void Active::HoldTimer_Expires()
     ++session._connectRetryCounter;
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
     session.scheduleReconnect();
 }
@@ -193,6 +199,9 @@ void Active::TcpConnectionFails()
 {
     BgpSession& session = TopState::box().getModule();
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
 }
 
@@ -237,6 +246,9 @@ void OpenSent::ConnectRetryTimer_Expires()
     // - (optionally) performs peer oscillation damping if the DampPeerOscillations attribute is set to TRUE, and
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
 }
 
@@ -255,6 +267,9 @@ void OpenSent::HoldTimer_Expires()
     // - (optionally) performs peer oscillation damping if the DampPeerOscillations attribute is set to TRUE, and
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
 }
 
@@ -330,6 +345,9 @@ void OpenConfirm::ConnectRetryTimer_Expires()
     ++session._connectRetryCounter;
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
 }
 
@@ -347,6 +365,9 @@ void OpenConfirm::HoldTimer_Expires()
     ++session._connectRetryCounter;
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
 }
 
@@ -367,6 +388,9 @@ void OpenConfirm::TcpConnectionFails()
     EV_TRACE << "OpenConfirm::TcpConnectionFails" << std::endl;
     BgpSession& session = TopState::box().getModule();
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
 }
 
@@ -457,6 +481,9 @@ void Established::ConnectRetryTimer_Expires()
     ++session._connectRetryCounter;
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
     session.scheduleReconnect();
 }
@@ -475,6 +502,9 @@ void Established::HoldTimer_Expires()
     ++session._connectRetryCounter;
     // - changes its state to Idle.
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
     session.scheduleReconnect();
 }
@@ -500,6 +530,9 @@ void Established::TcpConnectionFails()
     session._info.socket->abort();
     ++session._connectRetryCounter;
     session._info.sessionEstablished = false;
+    session.stopHoldTimer();
+    session.stopKeepAliveTimer();
+    session.stopConnectRetryTimer();
     setState<Idle>();
     session.scheduleReconnect();
 }

--- a/src/inet/routing/bgpv4/BgpFsm.cc
+++ b/src/inet/routing/bgpv4/BgpFsm.cc
@@ -117,6 +117,13 @@ void Connect::TcpConnectionConfirmed()
 
 void Connect::TcpConnectionFails()
 {
+    EV_INFO << "Processing Connect::TcpConnectionFails" << std::endl;
+    BgpSession& session = TopState::box().getModule();
+    // If the TCP connection fails (Event 18), the local
+    // system:
+    // - restarts the ConnectRetryTimer with the initial value,
+    session.restartConnectRetryTimer();
+    // - changes its state to Active.
     setState<Active>();
 }
 

--- a/src/inet/routing/bgpv4/BgpFsm.cc
+++ b/src/inet/routing/bgpv4/BgpFsm.cc
@@ -477,6 +477,7 @@ void Established::ConnectRetryTimer_Expires()
 {
     EV_TRACE << "Processing Established::ConnectRetryTimer_Expires" << std::endl;
     BgpSession& session = TopState::box().getModule();
+    session.withdrawRoutesFromSession();
     // In response to any other event (Events 9, 12-13, 20-22), the local system:
     // TODO- deletes all routes associated with this connection,
     // - sets the ConnectRetryTimer to zero,
@@ -499,6 +500,7 @@ void Established::HoldTimer_Expires()
 {
     EV_TRACE << "Processing Established::HoldTimer_Expires" << std::endl;
     BgpSession& session = TopState::box().getModule();
+    session.withdrawRoutesFromSession();
     // If the HoldTimer_Expires event occurs (Event 10), the local system:
     // - sets the ConnectRetryTimer to zero,
     session.restartConnectRetryTimer();
@@ -533,6 +535,7 @@ void Established::TcpConnectionFails()
 {
     EV_TRACE << "Processing Established::TcpConnectionFails" << std::endl;
     BgpSession& session = TopState::box().getModule();
+    session.withdrawRoutesFromSession();
     session.restartConnectRetryTimer();
     session._info.socket->abort();
     ++session._connectRetryCounter;

--- a/src/inet/routing/bgpv4/BgpRouter.cc
+++ b/src/inet/routing/bgpv4/BgpRouter.cc
@@ -34,6 +34,9 @@ BgpRouter::~BgpRouter(void)
     for (auto& elem : _bgpSessions)
         delete (elem).second;
 
+    for (auto& elem : adjRibInTable)
+        delete elem;
+
     for (auto& elem : _prefixListINOUT)
         delete elem;
 
@@ -66,6 +69,7 @@ void BgpRouter::addWatches()
     WATCH(myAsId);
     WATCH(_bgpSessions);
     WATCH(bgpRoutingTable);
+    WATCH(adjRibInTable);
     _socketMap.addWatch();
 }
 
@@ -240,6 +244,7 @@ void BgpRouter::addToAdvertiseList(const L3Address& address)
     bgpEntry->addAS(myAsId);
     bgpEntry->setPathType(IGP);
     bgpEntry->setLocalPreference(bgpModule->par("localPreference").intValue());
+    bgpEntry->setSourceSessionId(0);
     bgpRoutingTable.push_back(bgpEntry);
 }
 
@@ -331,6 +336,15 @@ void BgpRouter::processMessageFromTcp(cMessage *msg)
 {
     TcpSocket *socket = check_and_cast_nullable<TcpSocket *>(_socketMap.findSocketFor(msg));
     if (!socket) {
+        if (dynamic_cast<Packet *>(msg) != nullptr ||
+            (msg->getKind() != TCP_I_AVAILABLE && msg->getKind() != TCP_I_ESTABLISHED))
+        {
+            // A restarted peer may still deliver late TCP payloads or control indications for a
+            // socket id that has already been replaced locally. Ignore those stale messages
+            // instead of rebuilding a new TcpSocket for the defunct connection.
+            delete msg;
+            return;
+        }
         socket = new TcpSocket(msg);
         socket->setOutputGate(bgpModule->gate("socketOut"));
         L3Address peerAddr = socket->getRemoteAddress();
@@ -427,7 +441,7 @@ void BgpRouter::openTcpConnectionToPeer(SessionId sessionId)
         if (intfEntry == nullptr)
             throw cRuntimeError("No configuration interface for external peer address: %s", _bgpSessions[sessionId]->getPeerAddr().str().c_str());
         // note: port=-1 stands for ephemeral port (=0 would be literally port 0)
-        socket->bind(getInterfaceAddress(intfEntry), -1);
+        socket->bind(_bgpSessions[sessionId]->getMyAddr(), -1);
 
         int ebgpMH = _bgpSessions[sessionId]->getEbgpMultihop();
         if (ebgpMH > 1)
@@ -560,49 +574,54 @@ void BgpRouter::processMessage(const BgpUpdateMessage& msg)
     printUpdateMessage(msg);
     session->getFsm()->UpdateMsgEvent();
 
-    BgpRouteInfo *entry = createBgpRoutingTableEntry();
-    entry->setLocalPreference(bgpModule->par("localPreference").intValue());
+    std::vector<PrefixKey> affectedPrefixes;  // prefixes whose best path may need to be reselected
+    std::vector<PrefixKey> withdrawnPrefixes; // prefixes explicitly withdrawn by this peer in this UPDATE
+
+    for (size_t i = 0; i < msg.getWithdrawnRoutesArraySize(); ++i)
+        addAffectedPrefix(withdrawnPrefixes, msg.getWithdrawnRoutes(i).prefix, msg.getWithdrawnRoutes(i).length);
+
+    for (size_t i = 0; i < msg.getPathAttributesArraySize(); i++) {
+        if (msg.getPathAttributes(i)->getTypeCode() == BgpUpdateAttributeTypeCode::MP_UNREACH_NLRI) {
+            auto& mp = *check_and_cast<const BgpUpdatePathAttributesMpUnreachNlri *>(msg.getPathAttributes(i));
+            for (size_t n = 0; n < mp.getWithdrawnRoutesArraySize(); ++n)
+                addAffectedPrefix(withdrawnPrefixes, mp.getWithdrawnRoutes(n).prefix, mp.getWithdrawnRoutes(n).length);
+        }
+    }
+
     if (isIpv6()) {
-        // RFC 4760: IPv6 reachability and the next hop arrive in MP_REACH_NLRI, not the legacy fields
         for (size_t i = 0; i < msg.getPathAttributesArraySize(); i++) {
             if (msg.getPathAttributes(i)->getTypeCode() == BgpUpdateAttributeTypeCode::MP_REACH_NLRI) {
                 auto& mp = *check_and_cast<const BgpUpdatePathAttributesMpReachNlri *>(msg.getPathAttributes(i));
-                if (mp.getNlriArraySize() > 0) {
-                    entry->setDestination(mp.getNlri(0).prefix);
-                    entry->setPrefixLength(mp.getNlri(0).length);
+                for (size_t n = 0; n < mp.getNlriArraySize(); ++n) {
+                    BgpRouteInfo *entry = createBgpRoutingTableEntry();
+                    entry->setDestination(mp.getNlri(n).prefix);
+                    entry->setPrefixLength(mp.getNlri(n).length);
+                    BgpProcessResult result = decisionProcess(msg, entry, _currSessionId);
+                    if (result == NEW_ROUTE_ADDED || result == ROUTE_DESTINATION_CHANGED)
+                        addAffectedPrefix(affectedPrefixes, entry->getDestinationAsGeneric(), entry->getPrefixLength());
                 }
-                entry->setNextHop(mp.getNextHop());
             }
         }
     }
     else {
-        entry->setDestination(msg.getNlri(0).prefix);
-        entry->setPrefixLength(msg.getNlri(0).length);
-    }
-
-    for (size_t i = 0; i < msg.getPathAttributesArraySize(); i++) {
-        if (msg.getPathAttributes(i)->getTypeCode() == BgpUpdateAttributeTypeCode::AS_PATH) {
-            auto& asPath = *check_and_cast<const BgpUpdatePathAttributesAsPath *>(msg.getPathAttributes(i));
-            for (size_t k = 0; k < asPath.getValueArraySize(); k++) {
-                const BgpAsPathSegment& asPathVal = asPath.getValue(k);
-                for (size_t n = 0; n < asPathVal.getAsValueArraySize(); n++) {
-                    entry->addAS(asPathVal.getAsValue(n));
-                }
-            }
+        for (size_t i = 0; i < msg.getNlriArraySize(); ++i) {
+            BgpRouteInfo *entry = createBgpRoutingTableEntry();
+            entry->setDestination(msg.getNlri(i).prefix);
+            entry->setPrefixLength(msg.getNlri(i).length);
+            BgpProcessResult result = decisionProcess(msg, entry, _currSessionId);
+            if (result == NEW_ROUTE_ADDED || result == ROUTE_DESTINATION_CHANGED)
+                addAffectedPrefix(affectedPrefixes, entry->getDestinationAsGeneric(), entry->getPrefixLength());
         }
     }
 
-    BgpProcessResult decisionProcessResult = asLoopDetection(entry, myAsId);
-
-    if (decisionProcessResult == ASLOOP_NO_DETECTED) {
-        // RFC 4271, 9.1.  Decision Process
-        decisionProcessResult = decisionProcess(msg, entry, _currSessionId);
-        // RFC 4271, 9.2.  Update-Send Process
-        if (decisionProcessResult != 0)
-            updateSendProcess(decisionProcessResult, _currSessionId, entry);
+    for (const auto& prefix : withdrawnPrefixes) {
+        removeAdjRibInRoute(_currSessionId, prefix.prefix, prefix.prefixLength);
+        addAffectedPrefix(affectedPrefixes, prefix.prefix, prefix.prefixLength);
     }
-    else
-        delete entry;
+
+    // Re-run best-path selection only for prefixes touched by this UPDATE.
+    for (const auto& prefix : affectedPrefixes)
+        installBestRouteForPrefix(prefix.prefix, prefix.prefixLength, _currSessionId);
 }
 
 BgpProcessResult BgpRouter::asLoopDetection(BgpRouteInfo *entry, AsId myAS)
@@ -614,23 +633,8 @@ BgpProcessResult BgpRouter::asLoopDetection(BgpRouteInfo *entry, AsId myAS)
     return ASLOOP_NO_DETECTED;
 }
 
-/* add entry to routing table, or delete entry */
 BgpProcessResult BgpRouter::decisionProcess(const BgpUpdateMessage& msg, BgpRouteInfo *entry, SessionId sessionIndex)
 {
-    // Don't add the route if it exists in PrefixListINTable or in ASListINTable
-    if (isInTable(_prefixListIN, entry) != (unsigned long)-1 || isInASList(_ASListIN, entry)) {
-        delete entry;
-        return RESULT0;
-    }
-
-    /*If the AS_PATH attribute of a BGP route contains an AS loop, the BGP
-       route should be excluded from the decision process. */
-#if 0
-    entry->setPathType(msg.getPathAttributeList(0).getOrigin().getValue());
-    entry->setGateway(msg.getPathAttributeList(0).getNextHop().getValue());
-    if (msg.getPathAttributeList(0).getLocalPrefArraySize() != 0)
-        entry->setLocalPreference(msg.getPathAttributeList(0).getLocalPref(0).getValue());
-#else
     for (size_t i = 0; i < msg.getPathAttributesArraySize(); i++) {
         switch (msg.getPathAttributes(i)->getTypeCode()) {
             case BgpUpdateAttributeTypeCode::ORIGIN: {
@@ -648,11 +652,38 @@ BgpProcessResult BgpRouter::decisionProcess(const BgpUpdateMessage& msg, BgpRout
                 entry->setLocalPreference(attr->getValue());
                 break;
             }
+            case BgpUpdateAttributeTypeCode::AS_PATH: {
+                auto& asPath = *check_and_cast<const BgpUpdatePathAttributesAsPath *>(msg.getPathAttributes(i));
+                for (size_t k = 0; k < asPath.getValueArraySize(); k++) {
+                    const BgpAsPathSegment& asPathVal = asPath.getValue(k);
+                    for (size_t n = 0; n < asPathVal.getAsValueArraySize(); n++)
+                        entry->addAS(asPathVal.getAsValue(n));
+                }
+                break;
+            }
+            case BgpUpdateAttributeTypeCode::MP_REACH_NLRI: {
+                auto attr = check_and_cast<const BgpUpdatePathAttributesMpReachNlri *>(msg.getPathAttributes(i));
+                entry->setNextHop(attr->getNextHop());
+                break;
+            }
             default:
                 break;
         }
     }
-#endif
+
+    if (entry->getLocalPreference() == 0)
+        entry->setLocalPreference(bgpModule->par("localPreference").intValue());
+
+    if (asLoopDetection(entry, myAsId) != ASLOOP_NO_DETECTED) {
+        delete entry;
+        return ASLOOP_DETECTED;
+    }
+
+    // Don't add the route if it exists in PrefixListINTable or in ASListINTable
+    if (isInTable(_prefixListIN, entry) != (unsigned long)-1 || isInASList(_ASListIN, entry)) {
+        delete entry;
+        return RESULT0;
+    }
 
     BgpSessionType type = _bgpSessions[sessionIndex]->getType();
     if (type == IGP) {
@@ -663,116 +694,19 @@ BgpProcessResult BgpRouter::decisionProcess(const BgpUpdateMessage& msg, BgpRout
         entry->setAdminDist(Ipv4Route::dBGPExternal);
     else
         entry->setAdminDist(Ipv4Route::dUnknown);
-
-    // if the route already exists in BGP routing table, tieBreakingProcess();
-    // (RFC 4271: 9.1.2.2 Breaking Ties)
-    unsigned long bgpIndex = isInTable(bgpRoutingTable, entry);
-    if (bgpIndex != (unsigned long)-1) {
-        if (tieBreakingProcess(bgpRoutingTable[bgpIndex], entry)) {
-            delete entry;
-            return RESULT0;
-        }
-        else {
-            entry->setInterface(_bgpSessions[sessionIndex]->getLinkIntf());
-            bgpRoutingTable.push_back(entry);
-            rt->addRoute(entry->asRoute());
-            return ROUTE_DESTINATION_CHANGED;
-        }
-    }
-
-    int indexIp = isInRoutingTable(rt, entry->getDestinationAsGeneric());
-    // if the route already exists in the IPv4 routing table
-    if (indexIp != -1) {
-        // and it was not added by BGP before
-        if (rt->getRoute(indexIp)->getSourceType() != IRoute::BGP) {
-            // and the Update msg is coming from IGP session
-            if (_bgpSessions[sessionIndex]->getType() == IGP) {
-                // works for both IPv4 and IPv6: createBgpRoutingTableEntry() takes the
-                // generic IRoute and builds the right (v4/v6) BGP entry
-                IRoute *oldEntry = rt->getRoute(indexIp);
-                BgpRouteInfo *bgpEntry = createBgpRoutingTableEntry(oldEntry);
-                bgpEntry->addAS(myAsId);
-                bgpEntry->setPathType(IGP);
-                bgpEntry->setAdminDist(Ipv4Route::dBGPInternal);
-                bgpEntry->setIBgpLearned(true);
-                bgpEntry->setLocalPreference(entry->getLocalPreference());
-                rt->addRoute(bgpEntry->asRoute());
-                // Note: No need to delete the existing route. Let the administrative distance decides.
-//                rt->deleteRoute(oldEntry);
-            }
-            else {
-                delete entry;
-                return RESULT0;
-            }
-        }
-    }
-    else {
-        // and the Update msg is coming from IGP session
-        if (_bgpSessions[sessionIndex]->getType() == IGP) {
-            // if the next hop is reachable
-            if (isReachable(entry->getNextHopAsGeneric())) {
-                // Resolve the (i)BGP next hop recursively through the IGP. An installed route
-                // must point at an on-link next hop, but an iBGP next hop can be several IGP
-                // hops away (e.g. behind an OSPF/OSPFv3 path); in that case replace it with the
-                // IGP's immediate next hop. A directly-connected next hop resolves to
-                // "unspecified" here and is kept as-is (so directly-connected iBGP is unchanged).
-                L3Address onLinkNextHop = rt->getNextHopForDestination(entry->getNextHopAsGeneric());
-                if (!onLinkNextHop.isUnspecified())
-                    entry->setNextHop(onLinkNextHop);
-                entry->setInterface(_bgpSessions[sessionIndex]->getLinkIntf());
-                rt->addRoute(entry->asRoute());
-            }
-        }
-    }
-
+    entry->setSourceSessionId(sessionIndex);
+    entry->setSourcePeerAddress(_bgpSessions[sessionIndex]->getPeerAddr());
     entry->setInterface(_bgpSessions[sessionIndex]->getLinkIntf());
-    bgpRoutingTable.push_back(entry);
 
-    if (_bgpSessions[sessionIndex]->getType() == EGP) {
-        if (isReachable(entry->getNextHopAsGeneric()))
-            rt->addRoute(entry->asRoute());
-
-        // if redistributeInternal is true, then insert the new external route into the OSPF (if exists).
-        // The OSPF module then floods AS-External LSA into the AS and lets other routers know
-        // about the new external route.
-        if (ospfExist(rt) && redistributeInternal) {
-            NetworkInterface *ie = entry->getInterface();
-            if (!ie)
-                throw cRuntimeError("Model error: interface entry is nullptr");
-            ospfv2::Ipv4AddressRange ospfNetAddr;
-            ospfNetAddr.address = entry->getDestinationAsGeneric().toIpv4();
-            ospfNetAddr.mask = Ipv4Address::makeNetmask(entry->getPrefixLength());
-            if (!ospfModule)
-                throw cRuntimeError("Cannot find the OSPF module on router %s", bgpModule->getFullName());
-            ospfModule->insertExternalRoute(ie->getInterfaceId(), ospfNetAddr);
-        }
-    }
-    return NEW_ROUTE_ADDED; // FIXME model error: When returns NEW_ROUTE_ADDED then entry stored in bgpRoutingTable, but sometimes not stored in rt
+    // Adj-RIB-In keeps every path learned from every peer; best-path selection is deferred
+    // to installBestRouteForPrefix(), which populates the Loc-RIB and the routing table.
+    upsertAdjRibInRoute(entry);
+    return NEW_ROUTE_ADDED;
 }
 
 bool BgpRouter::tieBreakingProcess(BgpRouteInfo *oldEntry, BgpRouteInfo *entry)
 {
-    if (entry->getLocalPreference() > oldEntry->getLocalPreference()) {
-        deleteBgpRoutingEntry(oldEntry);
-        return false;
-    }
-
-    /* Remove from consideration all routes that are not tied for
-         having the smallest number of AS numbers present in their
-         AS_PATH attributes.*/
-    if (entry->getASCount() < oldEntry->getASCount()) {
-        deleteBgpRoutingEntry(oldEntry);
-        return false;
-    }
-
-    /* Remove from consideration all routes that are not tied for
-         having the lowest Origin number in their Origin attribute.*/
-    if (entry->getPathType() < oldEntry->getPathType()) {
-        deleteBgpRoutingEntry(oldEntry);
-        return false;
-    }
-
-    return true;
+    return !isBetterRoute(entry, oldEntry);
 }
 
 void BgpRouter::updateSendProcess(BgpProcessResult type, SessionId sessionIndex, BgpRouteInfo *entry)
@@ -786,7 +720,9 @@ void BgpRouter::updateSendProcess(BgpProcessResult type, SessionId sessionIndex,
         if (isInTable(_prefixListOUT, entry) != (unsigned long)-1 || isInASList(_ASListOUT, entry) ||
             ((elem).first == sessionIndex && type != NEW_SESSION_ESTABLISHED) ||
             (type == NEW_SESSION_ESTABLISHED && (elem).first != sessionIndex) ||
-            !(elem).second->isEstablished())
+            !(elem).second->isEstablished() ||
+            elem.second->getSocket() == nullptr ||
+            elem.second->getSocket()->getState() != TcpSocket::CONNECTED)
         {
             continue;
         }
@@ -907,18 +843,259 @@ void BgpRouter::updateSendProcess(BgpProcessResult type, SessionId sessionIndex,
  */
 bool BgpRouter::deleteBgpRoutingEntry(BgpRouteInfo *entry)
 {
-    for (auto it = bgpRoutingTable.begin();
-         it != bgpRoutingTable.end(); it++)
-    {
-        if ((*it)->getDestinationAsGeneric().getPrefix((*it)->getPrefixLength()) ==
-            entry->getDestinationAsGeneric().getPrefix(entry->getPrefixLength()))
-        {
-            bgpRoutingTable.erase(it);
-            rt->deleteRoute(entry->asRoute());
+    if (deleteLocRibEntry(entry))
+        return true;
+
+    for (auto it = adjRibInTable.begin(); it != adjRibInTable.end(); ++it) {
+        if (*it == entry) {
+            delete *it;
+            adjRibInTable.erase(it);
             return true;
         }
     }
     return false;
+}
+
+bool BgpRouter::deleteLocRibEntry(BgpRouteInfo *entry)
+{
+    for (auto it = bgpRoutingTable.begin();
+         it != bgpRoutingTable.end(); it++) {
+        if (*it == entry) {
+            bgpRoutingTable.erase(it);
+            for (int i = 0; i < rt->getNumRoutes(); ++i) {
+                IRoute *route = rt->getRoute(i);
+                if (route->getSourceType() == IRoute::BGP &&
+                    route->getDestinationAsGeneric().getPrefix(route->getPrefixLength()) == entry->getDestinationAsGeneric().getPrefix(entry->getPrefixLength()) &&
+                    route->getPrefixLength() == entry->getPrefixLength())
+                {
+                    rt->deleteRoute(route);
+                    break;
+                }
+            }
+            delete entry;
+            return true;
+        }
+    }
+    return false;
+}
+
+BgpRouteInfo *BgpRouter::findLocRibEntry(const L3Address& prefix, int prefixLength) const
+{
+    for (auto entry : bgpRoutingTable) {
+        if (prefixMatches(entry, prefix, prefixLength))
+            return entry;
+    }
+    return nullptr;
+}
+
+BgpRouteInfo *BgpRouter::selectBestAdjRibInRoute(const L3Address& prefix, int prefixLength) const
+{
+    BgpRouteInfo *best = nullptr;
+    for (auto entry : adjRibInTable) {
+        if (!prefixMatches(entry, prefix, prefixLength))
+            continue;
+        if (entry->isIBgpLearned() && !isReachable(entry->getNextHopAsGeneric()))
+            continue;
+        if (!entry->isIBgpLearned() && !isReachable(entry->getNextHopAsGeneric()))
+            continue;
+        if (best == nullptr || isBetterRoute(entry, best))
+            best = entry;
+    }
+    return best;
+}
+
+void BgpRouter::upsertAdjRibInRoute(BgpRouteInfo *entry)
+{
+    for (auto it = adjRibInTable.begin(); it != adjRibInTable.end(); ++it) {
+        BgpRouteInfo *current = *it;
+        if (current->getSourceSessionId() == entry->getSourceSessionId() && samePrefix(current, entry)) {
+            delete current;
+            *it = entry;
+            return;
+        }
+    }
+    adjRibInTable.push_back(entry);
+}
+
+bool BgpRouter::removeAdjRibInRoute(SessionId sessionId, const L3Address& prefix, int prefixLength)
+{
+    for (auto it = adjRibInTable.begin(); it != adjRibInTable.end(); ++it) {
+        BgpRouteInfo *entry = *it;
+        if (entry->getSourceSessionId() == sessionId && prefixMatches(entry, prefix, prefixLength)) {
+            delete entry;
+            adjRibInTable.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<BgpRouter::PrefixKey> BgpRouter::removeAdjRibInRoutesFromSession(SessionId sessionId)
+{
+    std::vector<PrefixKey> affectedPrefixes;
+    for (auto it = adjRibInTable.begin(); it != adjRibInTable.end(); ) {
+        BgpRouteInfo *entry = *it;
+        if (entry->getSourceSessionId() == sessionId) {
+            addAffectedPrefix(affectedPrefixes, entry->getDestinationAsGeneric(), entry->getPrefixLength());
+            delete entry;
+            it = adjRibInTable.erase(it);
+        }
+        else
+            ++it;
+    }
+    return affectedPrefixes;
+}
+
+void BgpRouter::installBestRouteForPrefix(const L3Address& prefix, int prefixLength, SessionId triggeringSessionId)
+{
+    BgpRouteInfo *current = findLocRibEntry(prefix, prefixLength);
+    if (current != nullptr && current->getSourceSessionId() == 0)
+        return;
+
+    BgpRouteInfo *best = selectBestAdjRibInRoute(prefix, prefixLength);
+    if (current != nullptr && best != nullptr && samePath(current, best))
+        return;
+
+    // Keep a snapshot of the old Loc-RIB route so we can send an explicit withdraw if
+    // no alternative remains after re-running the decision process.
+    BgpRouteInfo *oldEntry = current;
+    BgpRouteInfo *oldSnapshot = oldEntry != nullptr ? cloneRoute(oldEntry) : nullptr;
+    if (oldEntry != nullptr)
+        deleteLocRibEntry(oldEntry);
+
+    if (best == nullptr) {
+        if (oldSnapshot != nullptr)
+            withdrawSendProcess(triggeringSessionId, oldSnapshot);
+        delete oldSnapshot;
+        return;
+    }
+
+    BgpRouteInfo *selected = cloneRoute(best);
+    SessionId sessionId = selected->getSourceSessionId();
+    if (sessionId != 0) {
+        selected->setInterface(_bgpSessions.at(sessionId)->getLinkIntf());
+        if (selected->isIBgpLearned()) {
+            L3Address onLinkNextHop = rt->getNextHopForDestination(selected->getNextHopAsGeneric());
+            if (!onLinkNextHop.isUnspecified())
+                selected->setNextHop(onLinkNextHop);
+        }
+    }
+    bgpRoutingTable.push_back(selected);
+
+    int indexIp = isInRoutingTable(rt, selected->getDestinationAsGeneric());
+    if (indexIp != -1 && rt->getRoute(indexIp)->getSourceType() == IRoute::BGP)
+        rt->deleteRoute(rt->getRoute(indexIp));
+
+    // The Loc-RIB entry and the forwarding-table entry are kept separate so removing
+    // one cannot invalidate pointers stored in the other structure.
+    if (selected->getSourceSessionId() != 0 && isReachable(selected->getNextHopAsGeneric())) {
+        BgpRouteInfo *routeForRt = cloneRoute(selected);
+        rt->addRoute(routeForRt->asRoute());
+    }
+
+    auto selectedSession = _bgpSessions.find(selected->getSourceSessionId());
+    if (selectedSession != _bgpSessions.end() && selectedSession->second->getType() == EGP && ospfExist(rt) && redistributeInternal) {
+        NetworkInterface *ie = selected->getInterface();
+        if (!ie)
+            throw cRuntimeError("Model error: interface entry is nullptr");
+        ospfv2::Ipv4AddressRange ospfNetAddr;
+        ospfNetAddr.address = selected->getDestinationAsGeneric().toIpv4();
+        ospfNetAddr.mask = Ipv4Address::makeNetmask(selected->getPrefixLength());
+        if (!ospfModule)
+            throw cRuntimeError("Cannot find the OSPF module on router %s", bgpModule->getFullName());
+        ospfModule->insertExternalRoute(ie->getInterfaceId(), ospfNetAddr);
+    }
+
+    updateSendProcess(oldEntry == nullptr ? NEW_ROUTE_ADDED : ROUTE_DESTINATION_CHANGED, selected->getSourceSessionId(), selected);
+    delete oldSnapshot;
+}
+
+void BgpRouter::withdrawRoutesFromSession(SessionId sessionId)
+{
+    auto affectedPrefixes = removeAdjRibInRoutesFromSession(sessionId);
+    for (const auto& prefix : affectedPrefixes)
+        installBestRouteForPrefix(prefix.prefix, prefix.prefixLength, sessionId);
+}
+
+void BgpRouter::withdrawSendProcess(SessionId sessionIndex, const BgpRouteInfo *entry)
+{
+    if (entry == nullptr)
+        return;
+
+    for (auto& elem : _bgpSessions) {
+        if (isInTable(_prefixListOUT, const_cast<BgpRouteInfo *>(entry)) != (unsigned long)-1 || isInASList(_ASListOUT, const_cast<BgpRouteInfo *>(entry)) ||
+            elem.first == sessionIndex || !elem.second->isEstablished() ||
+            elem.second->getSocket() == nullptr ||
+            elem.second->getSocket()->getState() != TcpSocket::CONNECTED)
+        {
+            continue;
+        }
+
+        auto sourceSession = _bgpSessions.find(sessionIndex);
+        if (sourceSession == _bgpSessions.end())
+            continue;
+        BgpSessionType sourceType = sourceSession->second->getType();
+        if (entry->isIBgpLearned() && sourceType == IGP && elem.second->getType() == IGP)
+            continue;
+
+        if ((sourceType == IGP && elem.second->getType() == EGP) || sourceType == EGP || sourceType == INCOMPLETE)
+            elem.second->sendWithdrawMessage(entry->getDestinationAsGeneric(), entry->getPrefixLength());
+    }
+}
+
+void BgpRouter::addAffectedPrefix(std::vector<PrefixKey>& prefixes, const L3Address& prefix, int prefixLength)
+{
+    for (const auto& entry : prefixes) {
+        if (entry.prefix == prefix && entry.prefixLength == prefixLength)
+            return;
+    }
+    prefixes.push_back({prefix.getPrefix(prefixLength), prefixLength});
+}
+
+bool BgpRouter::prefixMatches(const BgpRouteInfo *entry, const L3Address& prefix, int prefixLength)
+{
+    return entry->getPrefixLength() == prefixLength &&
+           entry->getDestinationAsGeneric().getPrefix(prefixLength) == prefix.getPrefix(prefixLength);
+}
+
+bool BgpRouter::samePrefix(const BgpRouteInfo *first, const BgpRouteInfo *second)
+{
+    return prefixMatches(first, second->getDestinationAsGeneric(), second->getPrefixLength());
+}
+
+bool BgpRouter::samePath(const BgpRouteInfo *first, const BgpRouteInfo *second)
+{
+    if (!samePrefix(first, second))
+        return false;
+    if (first->getLocalPreference() != second->getLocalPreference() ||
+        first->getPathType() != second->getPathType() ||
+        first->isIBgpLearned() != second->isIBgpLearned() ||
+        first->getSourceSessionId() != second->getSourceSessionId() ||
+        first->getASCount() != second->getASCount())
+    {
+        return false;
+    }
+    for (unsigned int i = 0; i < first->getASCount(); ++i) {
+        if (first->getAS(i) != second->getAS(i))
+            return false;
+    }
+    return true;
+}
+
+bool BgpRouter::isBetterRoute(const BgpRouteInfo *candidate, const BgpRouteInfo *current) const
+{
+    if (candidate->getLocalPreference() != current->getLocalPreference())
+        return candidate->getLocalPreference() > current->getLocalPreference();
+    if (candidate->getASCount() != current->getASCount())
+        return candidate->getASCount() < current->getASCount();
+    if (candidate->getPathType() != current->getPathType())
+        return candidate->getPathType() < current->getPathType();
+    return candidate->getSourcePeerAddress() < current->getSourcePeerAddress();
+}
+
+BgpRouteInfo *BgpRouter::cloneRoute(const BgpRouteInfo *entry) const
+{
+    return entry->clone();
 }
 
 /*return index of the Ipv4 table if the route is found, -1 else*/

--- a/src/inet/routing/bgpv4/BgpRouter.h
+++ b/src/inet/routing/bgpv4/BgpRouter.h
@@ -58,7 +58,12 @@ class INET_API BgpRouter : public TcpSocket::BufferingCallback
     L3Address internalAddress;
 
     typedef std::vector<BgpRouteInfo *> RoutingTableEntryVector;
-    RoutingTableEntryVector bgpRoutingTable; // The BGP routing table
+    struct PrefixKey {
+        L3Address prefix;
+        int prefixLength = 0;
+    };
+    RoutingTableEntryVector bgpRoutingTable; // Loc-RIB: selected BGP routes
+    RoutingTableEntryVector adjRibInTable; // Adj-RIB-In: all peer-learned routes
     std::vector<L3Address> advertiseList;
     RoutingTableEntryVector _prefixListIN;
     RoutingTableEntryVector _prefixListOUT;
@@ -169,6 +174,21 @@ class INET_API BgpRouter : public TcpSocket::BufferingCallback
     void processMessage(const BgpUpdateMessage& msg);
 
     bool deleteBgpRoutingEntry(BgpRouteInfo *entry);
+    bool deleteLocRibEntry(BgpRouteInfo *entry);
+    BgpRouteInfo *findLocRibEntry(const L3Address& prefix, int prefixLength) const;
+    BgpRouteInfo *selectBestAdjRibInRoute(const L3Address& prefix, int prefixLength) const;
+    void upsertAdjRibInRoute(BgpRouteInfo *entry);
+    bool removeAdjRibInRoute(SessionId sessionId, const L3Address& prefix, int prefixLength);
+    std::vector<PrefixKey> removeAdjRibInRoutesFromSession(SessionId sessionId);
+    void installBestRouteForPrefix(const L3Address& prefix, int prefixLength, SessionId triggeringSessionId);
+    void withdrawRoutesFromSession(SessionId sessionId);
+    void withdrawSendProcess(SessionId sessionIndex, const BgpRouteInfo *entry);
+    static void addAffectedPrefix(std::vector<PrefixKey>& prefixes, const L3Address& prefix, int prefixLength);
+    static bool prefixMatches(const BgpRouteInfo *entry, const L3Address& prefix, int prefixLength);
+    static bool samePrefix(const BgpRouteInfo *first, const BgpRouteInfo *second);
+    static bool samePath(const BgpRouteInfo *first, const BgpRouteInfo *second);
+    bool isBetterRoute(const BgpRouteInfo *candidate, const BgpRouteInfo *current) const;
+    BgpRouteInfo *cloneRoute(const BgpRouteInfo *entry) const;
 
     /**
      * \brief RFC 4271: 9.1. : Decision Process used when an UPDATE message is received

--- a/src/inet/routing/bgpv4/BgpRoutingTableEntry.h
+++ b/src/inet/routing/bgpv4/BgpRoutingTableEntry.h
@@ -32,6 +32,8 @@ class INET_API BgpRouteInfo
     std::vector<AsId> _ASList;
     int localPreference = 0;
     bool iBgpLearned = false;
+    SessionId sourceSessionId = 0;
+    L3Address sourcePeerAddress;
 
   public:
     virtual ~BgpRouteInfo() {}
@@ -39,6 +41,7 @@ class INET_API BgpRouteInfo
     // the underlying address-family route (this object, viewed as an IRoute)
     virtual IRoute *asRoute() = 0;
     virtual const IRoute *asRoute() const = 0;
+    virtual BgpRouteInfo *clone() const = 0;
 
     // BGP attributes
     void setPathType(RoutingPathType type) { _pathType = type; }
@@ -51,6 +54,10 @@ class INET_API BgpRouteInfo
     void setLocalPreference(int l) { localPreference = l; }
     bool isIBgpLearned() const { return iBgpLearned; }
     void setIBgpLearned(bool i) { iBgpLearned = i; }
+    SessionId getSourceSessionId() const { return sourceSessionId; }
+    void setSourceSessionId(SessionId id) { sourceSessionId = id; }
+    const L3Address& getSourcePeerAddress() const { return sourcePeerAddress; }
+    void setSourcePeerAddress(const L3Address& addr) { sourcePeerAddress = addr; }
 
     // generic route accessors, forwarded to the underlying IRoute
     L3Address getDestinationAsGeneric() const { return asRoute()->getDestinationAsGeneric(); }
@@ -79,6 +86,7 @@ class INET_API BgpRoutingTableEntry : public Ipv4Route, public BgpRouteInfo
     virtual ~BgpRoutingTableEntry() {}
     virtual IRoute *asRoute() override { return this; }
     virtual const IRoute *asRoute() const override { return this; }
+    virtual BgpRouteInfo *clone() const override { return new BgpRoutingTableEntry(*this); }
     virtual std::string str() const override { return bgpStr(); }
 };
 
@@ -109,6 +117,7 @@ class INET_API BgpRoutingTableEntry6 : public Ipv6Route, public BgpRouteInfo
     virtual ~BgpRoutingTableEntry6() {}
     virtual IRoute *asRoute() override { return this; }
     virtual const IRoute *asRoute() const override { return this; }
+    virtual BgpRouteInfo *clone() const override { return new BgpRoutingTableEntry6(*this); }
     virtual std::string str() const override { return bgpStr(); }
 };
 

--- a/src/inet/routing/bgpv4/BgpSession.cc
+++ b/src/inet/routing/bgpv4/BgpSession.cc
@@ -137,6 +137,16 @@ void BgpSession::restartConnectRetryTimer()
     bgpRouter.scheduleAt(simTime() + _connectRetryTime, _ptrConnectRetryTimer);
 }
 
+void BgpSession::stopHoldTimer()
+{
+    bgpRouter.cancelEvent(_ptrHoldTimer);
+}
+
+void BgpSession::stopKeepAliveTimer()
+{
+    bgpRouter.cancelEvent(_ptrKeepAliveTimer);
+}
+
 void BgpSession::stopConnectRetryTimer()
 {
     bgpRouter.cancelEvent(_ptrConnectRetryTimer);

--- a/src/inet/routing/bgpv4/BgpSession.cc
+++ b/src/inet/routing/bgpv4/BgpSession.cc
@@ -36,6 +36,10 @@ void BgpSession::setInfo(SessionInfo info)
     _info.ASValue = info.ASValue;
     _info.routerId = info.routerId;
     _info.peerAddr = info.peerAddr;
+    _info.myAddr = info.myAddr;
+    _info.nextHopSelf = info.nextHopSelf;
+    _info.localPreference = info.localPreference;
+    _info.checkConnection = info.checkConnection;
     _info.sessionId = info.sessionId;
     _info.linkIntf = info.linkIntf;
     _info.ebgpMultihop = info.ebgpMultihop;
@@ -196,6 +200,11 @@ void BgpSession::sendOpenMessage()
 
 void BgpSession::sendUpdateMessage(std::vector<BgpUpdatePathAttributes *>& content, BgpUpdateNlri& nlri)
 {
+    if (_info.socket == nullptr || _info.socket->getState() != TcpSocket::CONNECTED) {
+        EV_WARN << "Skipping BGP Update to " << _info.peerAddr << ": TCP socket is not connected\n";
+        return;
+    }
+
     const auto& updateMsg = makeShared<BgpUpdateMessage>();
 
     updateMsg->setWithDrawnRoutesLength(0);
@@ -228,6 +237,11 @@ void BgpSession::sendUpdateMessage(std::vector<BgpUpdatePathAttributes *>& conte
 
 void BgpSession::sendUpdateMessage(std::vector<BgpUpdatePathAttributes *>& content)
 {
+    if (_info.socket == nullptr || _info.socket->getState() != TcpSocket::CONNECTED) {
+        EV_WARN << "Skipping BGP Update to " << _info.peerAddr << ": TCP socket is not connected\n";
+        return;
+    }
+
     // MP-BGP UPDATE (RFC 4760): reachability rides in an MP_REACH_NLRI path attribute, so the
     // legacy NLRI field is left empty.
     const auto& updateMsg = makeShared<BgpUpdateMessage>();
@@ -256,6 +270,56 @@ void BgpSession::sendUpdateMessage(std::vector<BgpUpdatePathAttributes *>& conte
     _updateMsgSent++;
 }
 
+void BgpSession::sendWithdrawMessage(const L3Address& prefix, int prefixLength)
+{
+    if (_info.socket == nullptr || _info.socket->getState() != TcpSocket::CONNECTED) {
+        EV_WARN << "Skipping BGP Withdraw to " << _info.peerAddr << ": TCP socket is not connected\n";
+        return;
+    }
+
+    const auto& updateMsg = makeShared<BgpUpdateMessage>();
+
+    if (bgpRouter.isIpv6()) {
+        auto mpUnreach = new BgpUpdatePathAttributesMpUnreachNlri();
+        mpUnreach->setAfi(2);
+        mpUnreach->setSafi(1);
+        mpUnreach->setWithdrawnRoutesArraySize(1);
+        BgpUpdateNlri6 withdrawn;
+        withdrawn.length = prefixLength;
+        withdrawn.prefix = prefix.getPrefix(prefixLength);
+        mpUnreach->setWithdrawnRoutes(0, withdrawn);
+        mpUnreach->setLength(computePathAttributeBytes(*mpUnreach) - 3);
+        updateMsg->setPathAttributesArraySize(1);
+        updateMsg->setPathAttributes(0, mpUnreach);
+        unsigned short attrLength = computePathAttributeBytes(*mpUnreach);
+        updateMsg->setTotalPathAttributeLength(attrLength);
+        updateMsg->addChunkLength(B(attrLength));
+    }
+    else {
+        BgpUpdateWithdrawnRoutes withdrawn;
+        withdrawn.length = prefixLength;
+        withdrawn.prefix = prefix.getPrefix(prefixLength).toIpv4();
+        updateMsg->setWithdrawnRoutesArraySize(1);
+        updateMsg->setWithdrawnRoutes(0, withdrawn);
+        unsigned short withdrawnLength = 1 + (prefixLength + 7) / 8;
+        updateMsg->setWithDrawnRoutesLength(withdrawnLength);
+        updateMsg->addChunkLength(B(withdrawnLength));
+    }
+
+    updateMsg->setTotalLength(updateMsg->getChunkLength().get<B>());
+
+    EV_INFO << "Sending BGP Withdraw message to " << _info.peerAddr.str()
+            << " on interface " << _info.linkIntf->getInterfaceName()
+            << "[" << _info.linkIntf->getInterfaceId() << "] with contents:\n";
+    bgpRouter.printUpdateMessage(*updateMsg);
+
+    Packet *pk = new Packet("BgpWithdraw");
+    pk->insertAtFront(updateMsg);
+
+    _info.socket->send(pk);
+    _updateMsgSent++;
+}
+
 void BgpSession::sendNotificationMessage()
 {
     // TODO
@@ -275,6 +339,11 @@ void BgpSession::sendNotificationMessage()
 
 void BgpSession::sendKeepAliveMessage()
 {
+    if (_info.socket == nullptr || _info.socket->getState() != TcpSocket::CONNECTED) {
+        EV_WARN << "Skipping BGP Keep-alive to " << _info.peerAddr << ": TCP socket is not connected\n";
+        return;
+    }
+
     const auto& keepAliveMsg = makeShared<BgpKeepAliveMessage>();
 
     EV_INFO << "Sending BGP Keep-alive message to " << _info.peerAddr.str()

--- a/src/inet/routing/bgpv4/BgpSession.h
+++ b/src/inet/routing/bgpv4/BgpSession.h
@@ -84,6 +84,7 @@ public:
     void sendOpenMessage();
     void sendUpdateMessage(std::vector<BgpUpdatePathAttributes *>& content, BgpUpdateNlri& nlri);
     void sendUpdateMessage(std::vector<BgpUpdatePathAttributes *>& content); // MP-BGP UPDATE (no legacy NLRI)
+    void sendWithdrawMessage(const L3Address& prefix, int prefixLength);
     void sendNotificationMessage();
     void sendKeepAliveMessage();
 
@@ -112,6 +113,7 @@ public:
     NetworkInterface *getLinkIntf() const { return _info.linkIntf; }
     bool getCheckConnection() const { return _info.checkConnection; }
     L3Address getPeerAddr() const { return _info.peerAddr; }
+    L3Address getMyAddr() const { return _info.myAddr; }
     bool getNextHopSelf() const { return _info.nextHopSelf; }
     int getLocalPreference() const { return _info.localPreference; }
     TcpSocket *getSocket() const { return _info.socket; }
@@ -121,6 +123,7 @@ public:
     BgpRouteInfo *createBgpRoutingTableEntry(const IRoute *from) const { return bgpRouter.createBgpRoutingTableEntry(from); }
     Macho::Machine<fsm::TopState>& getFsm() const { return *_fsm; }
     void updateSendProcess(BgpRouteInfo *entry) const { return bgpRouter.updateSendProcess(NEW_SESSION_ESTABLISHED, _info.sessionId, entry); }
+    void withdrawRoutesFromSession() const { bgpRouter.withdrawRoutesFromSession(_info.sessionId); }
     bool isRouteExcluded(const IRoute& rtEntry) const { return bgpRouter.isRouteExcluded(rtEntry); }
 };
 

--- a/src/inet/routing/bgpv4/BgpSession.h
+++ b/src/inet/routing/bgpv4/BgpSession.h
@@ -77,6 +77,8 @@ public:
     void restartHoldTimer();
     void restartKeepAliveTimer();
     void restartConnectRetryTimer();
+    void stopHoldTimer();
+    void stopKeepAliveTimer();
     void stopConnectRetryTimer();
 
     void sendOpenMessage();

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -25,14 +25,14 @@
 
 /examples/bgpv4/Bgp2RoutersInAS/,    -f omnetpp.ini -c General -r 0,                1000s,           3930-48e2/tplx;5319-01b2/~tNl;6092-282c/~tND;2ec9-a2e6/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/Bgp3Routers/,        -f omnetpp.ini -c General -r 0,                1000s,           d849-ba7b/tplx;afa4-9af2/~tNl;8307-bcb7/~tND;6015-a84e/tyf, PASS, ospf EthernetMac Ipv4
-/examples/bgpv4/BgpCompleteTest/,    -f omnetpp.ini -c General -r 0,                1000s,           d9d2-57d9/tplx;92d1-a09d/~tNl;3532-711f/~tND;092b-95fa/tyf, PASS, ospf EthernetMac Ipv4
-/examples/bgpv4/BgpLifecycle/,       -f omnetpp.ini -c General -r 0,                900s,            9689-bfd9/tplx;b33a-e09b/~tNl;8eef-283b/~tND;5cd6-6b5b/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
+/examples/bgpv4/BgpCompleteTest/,    -f omnetpp.ini -c General -r 0,                1000s,           8017-111e/tplx;f52d-dfe4/~tNl;3949-620a/~tND;1157-257f/tyf, PASS, ospf EthernetMac Ipv4
+/examples/bgpv4/BgpLifecycle/,       -f omnetpp.ini -c General -r 0,                900s,            de27-2f60/tplx;9cc8-4f58/~tNl;6a7a-7a26/~tND;18b7-cb3c/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
 /examples/bgpv4/BgpOpen/,            -f omnetpp.ini -c General -r 0,                62s,             2f45-1e34/tplx;9dce-698e/~tNl;8280-a602/~tND;083d-c5af/tyf, PASS, ospf Ipv4
 /examples/bgpv4/BgpUpdate/,          -f omnetpp.ini -c General -r 0,                30s,             9552-83f7/tplx;3a06-a4f0/~tNl;62be-5688/~tND;0573-e0b4/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpAndOspf/,         -f omnetpp.ini -c General -r 0,                1000s,           1e22-36e3/tplx;2b66-00b2/~tNl;430e-7064/~tND;de89-afd7/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpAndOspfSimple/,   -f omnetpp.ini -c General -r 0,                1000s,           dc15-38aa/tplx;dacd-0cbd/~tNl;46d3-bcb3/~tND;8a59-2347/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpIpv6Basic/,       -f omnetpp.ini -c General -r 0,                30s,             4094-e79b/tplx;a631-2b6d/~tNl;7b45-6ce9/~tND;b856-841a/tyf, PASS, EthernetMac Ipv6
-/examples/bgpv4/BgpAndOspfv3/,       -f omnetpp.ini -c General -r 0,                100s,            b677-0658/tplx;fcb0-9849/~tNl;6b37-573f/~tND, PASS, ospf EthernetMac Ipv6
+/examples/bgpv4/BgpAndOspfv3/,       -f omnetpp.ini -c General -r 0,                100s,            db4d-c9f9/tplx;2b77-a31e/~tNl;a380-0efb/~tND, PASS, ospf EthernetMac Ipv6
 
 /examples/clock/,                    -f omnetpp.ini -c General -r 0,                10ms,            35c3-8325/tplx;0000-0000/~tNl;0000-0000/~tND;a4b7-bff5/tyf, PASS,
 

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -26,7 +26,7 @@
 /examples/bgpv4/Bgp2RoutersInAS/,    -f omnetpp.ini -c General -r 0,                1000s,           3930-48e2/tplx;5319-01b2/~tNl;6092-282c/~tND;2ec9-a2e6/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/Bgp3Routers/,        -f omnetpp.ini -c General -r 0,                1000s,           d849-ba7b/tplx;afa4-9af2/~tNl;8307-bcb7/~tND;6015-a84e/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpCompleteTest/,    -f omnetpp.ini -c General -r 0,                1000s,           d9d2-57d9/tplx;92d1-a09d/~tNl;3532-711f/~tND;092b-95fa/tyf, PASS, ospf EthernetMac Ipv4
-/examples/bgpv4/BgpLifecycle/,       -f omnetpp.ini -c General -r 0,                900s,            c23b-0a8b/tplx;63a0-dda6/~tNl;39a7-2c71/~tND;3c73-4bff/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
+/examples/bgpv4/BgpLifecycle/,       -f omnetpp.ini -c General -r 0,                900s,            9689-bfd9/tplx;b33a-e09b/~tNl;8eef-283b/~tND;5cd6-6b5b/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
 /examples/bgpv4/BgpOpen/,            -f omnetpp.ini -c General -r 0,                62s,             2f45-1e34/tplx;9dce-698e/~tNl;8280-a602/~tND;083d-c5af/tyf, PASS, ospf Ipv4
 /examples/bgpv4/BgpUpdate/,          -f omnetpp.ini -c General -r 0,                30s,             9552-83f7/tplx;3a06-a4f0/~tNl;62be-5688/~tND;0573-e0b4/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpAndOspf/,         -f omnetpp.ini -c General -r 0,                1000s,           1e22-36e3/tplx;2b66-00b2/~tNl;430e-7064/~tND;de89-afd7/tyf, PASS, ospf EthernetMac Ipv4

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -33,6 +33,8 @@
 /examples/bgpv4/BgpAndOspfSimple/,   -f omnetpp.ini -c General -r 0,                1000s,           dc15-38aa/tplx;dacd-0cbd/~tNl;46d3-bcb3/~tND;8a59-2347/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpIpv6Basic/,       -f omnetpp.ini -c General -r 0,                30s,             4094-e79b/tplx;a631-2b6d/~tNl;7b45-6ce9/~tND;b856-841a/tyf, PASS, EthernetMac Ipv6
 /examples/bgpv4/BgpAndOspfv3/,       -f omnetpp.ini -c General -r 0,                100s,            db4d-c9f9/tplx;2b77-a31e/~tNl;a380-0efb/~tND, PASS, ospf EthernetMac Ipv6
+/examples/bgpv4/BgpDiamondFailover/, -f omnetpp.ini -c General -r 0,                160s,            819b-726f/tplx;759b-8711/~tNl;f690-850d/~tND;fc56-f343/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
+/examples/bgpv4/BgpDiamondFailover6/,-f omnetpp.ini -c General -r 0,                160s,            a666-6758/tplx;d51e-c4d6/~tNl;2735-bd52/~tND;5c49-0569/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
 
 /examples/clock/,                    -f omnetpp.ini -c General -r 0,                10ms,            35c3-8325/tplx;0000-0000/~tNl;0000-0000/~tND;a4b7-bff5/tyf, PASS,
 


### PR DESCRIPTION
## Summary

This PR adds Adj-RIB-In based route tracking to the BGP implementation so routes learned from peers are retained separately from the selected Loc-RIB route. When a peer withdraws a prefix or a BGP session fails, the router now removes only the affected learned paths, reruns best-path selection for those prefixes, and either installs an alternate route or advertises a withdrawal.

## Details

- Add an Adj-RIB-In table to `BgpRouter` for all peer-learned routes.
- Rework UPDATE processing to:
  - handle multiple IPv4 NLRI entries,
  - handle IPv6 MP_REACH_NLRI and MP_UNREACH_NLRI,
  - track affected prefixes,
  - rerun best-path selection only for changed prefixes.
- Add route source metadata to BGP route entries, including source session and peer address.
- Add explicit BGP withdrawal sending for IPv4 and IPv6.
- Withdraw routes learned from a session when established sessions fail or timers expire.
- Guard UPDATE, KEEPALIVE, and WITHDRAW sends when the TCP socket is no longer connected.
- Stop BGP session timers when the FSM transitions back to Idle.
- Restart BGP after lifecycle startup through the timer path so interfaces can come back up first.
- Add a lifecycle stage for network interface configuration and move IPv6 interface reconfiguration before IPv6 address assignment.
- Bind outgoing BGP TCP sockets to the configured local BGP address.
- Ignore stale TCP messages for sockets that have already been replaced after restart/failure.

## Examples

Adds two new diamond-topology examples that demonstrate failover, failback, and a second failure:

- `examples/bgpv4/BgpDiamondFailover`
- `examples/bgpv4/BgpDiamondFailover6`

Both examples prefer the `A-B-C` path initially, fail over to `A-D-C` when router `B` goes down, fail back after `B` restarts, and then exercise failover again after a crash.

## Testing

- Updated existing BGP fingerprints affected by the new route-selection behavior.
- Added fingerprint coverage for the new IPv4 and IPv6 diamond failover examples.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->