### PR TITLE
visualizer: vsg: signal wavefront viz — shader-based flowing ripple + fixes

### DIFF
--- a/examples/visualizer/vsgsignal/VsgSignal.ned
+++ b/examples/visualizer/vsgsignal/VsgSignal.ned
@@ -13,10 +13,13 @@ import inet.visualizer.vsg.integrated.IntegratedVsgVisualizer;
 
 //
 // A small wireless network for tuning the VSG signal-propagation visualization.
-// Three hosts on a 300x300 ground plane, within each other's communication range
-// (~150m), so the translucent transmission discs are a sensible size relative to
-// the scene. host3 moves to show growing transmissions as nodes move around.
-// Run under Qtenv and switch to the 3D view.
+// Three hosts on a 300x300 ground plane, positioned within each other's ~100m
+// communication range (the transmitter power in omnetpp.ini is set so the range
+// is ~100m, keeping the translucent transmission discs a sensible size relative
+// to the scene). Because the nodes are in range, transmissions are received, so
+// the data-link visualizer also draws connection arrows. host3 moves slowly to
+// show growing transmissions as nodes move around. Run under Qtenv, switch to the
+// 3D view, and press Run.
 //
 network VsgSignalShowcase
 {
@@ -32,12 +35,12 @@ network VsgSignalShowcase
             @display("p=40,180");
         }
         host1: WirelessHost {
-            @display("p=80,200");
+            @display("p=135,165");
         }
         host2: WirelessHost {
-            @display("p=220,200");
+            @display("p=165,165");
         }
         host3: WirelessHost {
-            @display("p=150,100");
+            @display("p=150,135");
         }
 }

--- a/examples/visualizer/vsgsignal/omnetpp.ini
+++ b/examples/visualizer/vsgsignal/omnetpp.ini
@@ -5,46 +5,48 @@ description = "VSG signal propagation tuning (translucent transmission discs, gr
 
 **.arp.typename = "GlobalArp"
 
-# --- traffic: host1 -> host2 and host3 -> host2 ---
+# --- traffic: host1 -> host2 and host3 -> host2 (frequent, staggered, so discs
+#     and data-link arrows appear often instead of only in brief bursts) ---
 *.host1.numApps = 1
 *.host1.app[0].typename = "UdpBasicApp"
 *.host1.app[0].destAddresses = "host2"
 *.host1.app[0].destPort = 1000
 *.host1.app[0].messageLength = 1000byte
-*.host1.app[0].sendInterval = 2s
-*.host1.app[0].startTime = uniform(0s, 0.5s)
+*.host1.app[0].sendInterval = 1s
+*.host1.app[0].startTime = uniform(0s, 1s)   # randomized so transmissions don't coincide
 *.host3.numApps = 1
 *.host3.app[0].typename = "UdpBasicApp"
 *.host3.app[0].destAddresses = "host2"
 *.host3.app[0].destPort = 1000
 *.host3.app[0].messageLength = 1000byte
-*.host3.app[0].sendInterval = 2.3s
+*.host3.app[0].sendInterval = 1.3s
 *.host2.numApps = 1
 *.host2.app[0].typename = "UdpSink"
 *.host2.app[0].localPort = 1000
 
 # --- ad-hoc wlan ---
-# Very low power so the computed communication/interference range is ~100m
-# (free-space: range ~ sqrt(power); 10mW gives ~10km, so scale down by (100/10000)^2 ~ 1e-4).
-*.host*.wlan[*].radio.transmitter.power = 0.001mW
+# The three hosts sit in a tight cluster (~30m apart) and use enough transmit power (0.05mW) that
+# their frames reliably DECODE at that spacing -- that reception is what makes the data-link
+# visualizer draw connection arrows. (The disc size is NOT tied to this power: the medium visualizer
+# caps the disc to signalFadingDistance below, so raising power for a real link does not blow up the
+# disc.)
+*.host*.wlan[*].radio.transmitter.power = 0.05mW
 *.host*.forwarding = true
 *.host*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
 *.host*.wlan[*].agent.typename = ""
 
-# --- cap the range (maxIgnoreNaN takes the max of par and computed, so this is a floor;
-#     the low power above makes the computed range small, and this keeps it sane) ---
-*.radioMedium.maxCommunicationRange = 100m
-*.radioMedium.maxInterferenceRange = 100m
-
-# --- host3 moves slowly, to show transmissions from a moving node ---
+# --- host3 drifts slowly around the cluster, staying within communication range of the
+#     other two (so its transmissions are received and its arrows also appear) ---
 *.host3.mobility.typename = "LinearMobility"
-*.host3.mobility.speed = 5mps
+*.host3.mobility.speed = 3mps
+*.host3.mobility.initialX = 150m
+*.host3.mobility.initialY = 135m
 *.host3.mobility.initialMovementHeading = 30deg
-*.host3.mobility.constraintAreaMinX = 30m
-*.host3.mobility.constraintAreaMinY = 30m
+*.host3.mobility.constraintAreaMinX = 130m
+*.host3.mobility.constraintAreaMinY = 120m
 *.host3.mobility.constraintAreaMinZ = 0m
-*.host3.mobility.constraintAreaMaxX = 270m
-*.host3.mobility.constraintAreaMaxY = 270m
+*.host3.mobility.constraintAreaMaxX = 170m
+*.host3.mobility.constraintAreaMaxY = 165m
 *.host3.mobility.constraintAreaMaxZ = 0m
 
 # --- VSG 3D visualizer settings ---
@@ -60,6 +62,13 @@ description = "VSG signal propagation tuning (translucent transmission discs, gr
 *.visualizer.mediumVisualizer.displaySignalDepartures = true
 *.visualizer.mediumVisualizer.displaySignalArrivals = true
 *.visualizer.mediumVisualizer.displayCommunicationRanges = true
+# Disc size is governed by the fade, not the transmit power: the disc is drawn out to where the
+# distance fade makes it invisible. signalFadingDistance=15m -> a ~145m disc that fits this scene.
+*.visualizer.mediumVisualizer.signalFadingDistance = 15m
+*.visualizer.mediumVisualizer.signalWaveLength = 40m
+# Stretch each (light-speed, sub-microsecond) propagation over ~2s of animation so
+# the discs are watchable rather than a brief flash. Raise this to slow them further.
+*.visualizer.mediumVisualizer.signalPropagationAnimationTime = 2s
 
 *.visualizer.dataLinkVisualizer.displayLinks = true
 *.visualizer.dataLinkVisualizer.fadeOutTime = 2s

--- a/examples/visualizer/vsgsignal3d/VsgSignal3d.ned
+++ b/examples/visualizer/vsgsignal3d/VsgSignal3d.ned
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2025 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+package inet.examples.visualizer.vsgsignal3d;
+
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.visualizer.vsg.integrated.IntegratedVsgVisualizer;
+
+//
+// A wireless network for showing VSG signal propagation as translucent expanding
+// spheres in real 3D space (signalShape = "sphere"). Two ground stations sit on the
+// floor within range of each other, and host3 is a "drone" that flies through the
+// volume above them (3D LinearMobility with a non-zero movement elevation). As each
+// node transmits, a translucent sphere expands outward from its current 3D position,
+// so the drone's transmissions are visibly centred up in the air rather than on the
+// ground. Because the nodes stay within range, the data-link visualizer also draws
+// connection arrows. Run under Qtenv, switch to the 3D view, orbit the camera, and
+// press Run.
+//
+network VsgSignal3dShowcase
+{
+    @display("bgb=300,300");
+    submodules:
+        visualizer: IntegratedVsgVisualizer {
+            @display("p=40,40");
+        }
+        configurator: Ipv4NetworkConfigurator {
+            @display("p=40,110");
+        }
+        radioMedium: Ieee80211ScalarRadioMedium {
+            @display("p=40,180");
+        }
+        host1: WirelessHost { // ground station
+            @display("p=110,150");
+        }
+        host2: WirelessHost { // ground station
+            @display("p=190,150");
+        }
+        host3: WirelessHost { // drone flying through the 3D volume
+            @display("p=150,150");
+        }
+}

--- a/examples/visualizer/vsgsignal3d/omnetpp.ini
+++ b/examples/visualizer/vsgsignal3d/omnetpp.ini
@@ -1,0 +1,76 @@
+[General]
+network = VsgSignal3dShowcase
+sim-time-limit = 100s
+description = "VSG signal propagation in 3D (translucent expanding spheres, a drone flying through the volume)"
+
+**.arp.typename = "GlobalArp"
+
+# --- traffic: host1 -> host2 (ground link) and host3 -> host2 (drone -> ground) ---
+*.host1.numApps = 1
+*.host1.app[0].typename = "UdpBasicApp"
+*.host1.app[0].destAddresses = "host2"
+*.host1.app[0].destPort = 1000
+*.host1.app[0].messageLength = 1000byte
+*.host1.app[0].sendInterval = 1s
+*.host1.app[0].startTime = uniform(0s, 1s)   # randomized so transmissions don't coincide
+*.host3.numApps = 1
+*.host3.app[0].typename = "UdpBasicApp"
+*.host3.app[0].destAddresses = "host2"
+*.host3.app[0].destPort = 1000
+*.host3.app[0].messageLength = 1000byte
+*.host3.app[0].sendInterval = 1.3s
+*.host2.numApps = 1
+*.host2.app[0].typename = "UdpSink"
+*.host2.app[0].localPort = 1000
+
+# --- ad-hoc wlan ---
+# Very low power so the computed communication/interference range is ~100m, keeping the
+# translucent transmission spheres a sensible size relative to the scene (see vsgsignal).
+*.host*.wlan[*].radio.transmitter.power = 0.001mW
+*.host*.forwarding = true
+*.host*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
+*.host*.wlan[*].agent.typename = ""
+*.radioMedium.maxCommunicationRange = 100m
+*.radioMedium.maxInterferenceRange = 100m
+
+# --- host3 is a drone: it flies THROUGH the volume above the two ground stations
+#     (non-zero movement elevation + a 3D constraint box), so its transmission spheres
+#     are centred up in the air. It stays mostly within range of host2. ---
+*.host3.mobility.typename = "LinearMobility"
+*.host3.mobility.speed = 8mps
+*.host3.mobility.initialX = 150m
+*.host3.mobility.initialY = 150m
+*.host3.mobility.initialZ = 70m
+*.host3.mobility.initialMovementHeading = 45deg
+*.host3.mobility.initialMovementElevation = 20deg
+*.host3.mobility.constraintAreaMinX = 90m
+*.host3.mobility.constraintAreaMinY = 90m
+*.host3.mobility.constraintAreaMinZ = 20m
+*.host3.mobility.constraintAreaMaxX = 210m
+*.host3.mobility.constraintAreaMaxY = 210m
+*.host3.mobility.constraintAreaMaxZ = 120m
+
+# --- VSG 3D visualizer settings ---
+*.visualizer.sceneVisualizer.axisLength = 30m
+*.visualizer.sceneVisualizer.sceneMinX = 0m
+*.visualizer.sceneVisualizer.sceneMinY = 0m
+*.visualizer.sceneVisualizer.sceneMaxX = 300m
+*.visualizer.sceneVisualizer.sceneMaxY = 300m
+*.visualizer.sceneVisualizer.sceneMinZ = 0m
+*.visualizer.sceneVisualizer.sceneMaxZ = 150m
+
+*.visualizer.mediumVisualizer.displaySignals = true
+# Draw signals as translucent expanding spheres (3D wavefronts) rather than flat ground rings.
+*.visualizer.mediumVisualizer.signalShape = "sphere"
+*.visualizer.mediumVisualizer.displaySignalDepartures = true
+*.visualizer.mediumVisualizer.displaySignalArrivals = true
+*.visualizer.mediumVisualizer.displayCommunicationRanges = true
+# Stretch each (light-speed, sub-microsecond) propagation over ~2s of animation so the
+# spheres are watchable rather than a brief flash. Raise this to slow them further.
+*.visualizer.mediumVisualizer.signalPropagationAnimationTime = 2s
+
+*.visualizer.dataLinkVisualizer.displayLinks = true
+*.visualizer.dataLinkVisualizer.fadeOutTime = 2s
+
+*.visualizer.mobilityVisualizer.displayMovementTrails = true
+*.visualizer.mobilityVisualizer.animationSpeed = 1

--- a/examples/visualizer/vsgsignalwave/VsgSignalWave.ned
+++ b/examples/visualizer/vsgsignalwave/VsgSignalWave.ned
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2025 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+package inet.examples.visualizer.vsgsignalwave;
+
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.visualizer.vsg.integrated.IntegratedVsgVisualizer;
+
+//
+// Showcase for the GLSL shader-based signal wavefront in the VSG visualizer
+// (mediumVisualizer.signalWaveShader = true). The ripple opacity is computed per
+// pixel by a fragment shader whose waveOffset advances every frame, so the waves
+// flow continuously outward like the OSG signal visualization; the disc stays lit
+// for the whole transmission (signalTransmissionAnimationSpeed), and when a
+// transmission finishes the ring expands, empties from the centre, and fades.
+//
+// Four hosts sit around a central hub (~110m spokes, within communication range),
+// all exchanging UDP traffic, so several translucent colour-coded ripple discs
+// overlap and pulse across the scene. host2 drifts to add some motion. Run under
+// Qtenv, switch to the 3D view, and press Run.
+//
+network VsgSignalWaveShowcase
+{
+    @display("bgb=400,400");
+    submodules:
+        visualizer: IntegratedVsgVisualizer {
+            @display("p=40,40");
+        }
+        configurator: Ipv4NetworkConfigurator {
+            @display("p=40,110");
+        }
+        radioMedium: Ieee80211ScalarRadioMedium {
+            @display("p=40,180");
+        }
+        hub: WirelessHost {
+            @display("p=200,200");
+        }
+        host1: WirelessHost {
+            @display("p=200,90");
+        }
+        host2: WirelessHost {
+            @display("p=310,200");
+        }
+        host3: WirelessHost {
+            @display("p=200,310");
+        }
+        host4: WirelessHost {
+            @display("p=90,200");
+        }
+}

--- a/examples/visualizer/vsgsignalwave/omnetpp.ini
+++ b/examples/visualizer/vsgsignalwave/omnetpp.ini
@@ -1,0 +1,108 @@
+[General]
+network = VsgSignalWaveShowcase
+sim-time-limit = 100s
+description = "VSG shader signal wavefront: per-pixel ripples flowing outward, multiple overlapping colour-coded discs that stay lit while sending"
+
+**.arp.typename = "GlobalArp"
+
+# --- traffic: the four spokes send to the hub, and the hub sends back to host1, so all
+#     five radios transmit and you get several colour-coded ripple discs at once ---
+*.hub.numApps = 2
+*.hub.app[0].typename = "UdpSink"
+*.hub.app[0].localPort = 1000
+*.hub.app[1].typename = "UdpBasicApp"
+*.hub.app[1].destAddresses = "host1"
+*.hub.app[1].destPort = 2000
+*.hub.app[1].messageLength = 2500byte
+*.hub.app[1].sendInterval = 1.7s
+*.hub.app[1].startTime = uniform(0s, 1s)
+
+*.host1.numApps = 2
+*.host1.app[0].typename = "UdpSink"
+*.host1.app[0].localPort = 2000
+*.host1.app[1].typename = "UdpBasicApp"
+*.host1.app[1].destAddresses = "hub"
+*.host1.app[1].destPort = 1000
+*.host1.app[1].messageLength = 2500byte
+*.host1.app[1].sendInterval = 2s
+*.host1.app[1].startTime = uniform(0s, 1s)
+
+*.host2.numApps = 1
+*.host2.app[0].typename = "UdpBasicApp"
+*.host2.app[0].destAddresses = "hub"
+*.host2.app[0].destPort = 1000
+*.host2.app[0].messageLength = 2500byte
+*.host2.app[0].sendInterval = 2.2s
+*.host2.app[0].startTime = uniform(0s, 1s)
+
+*.host3.numApps = 1
+*.host3.app[0].typename = "UdpBasicApp"
+*.host3.app[0].destAddresses = "hub"
+*.host3.app[0].destPort = 1000
+*.host3.app[0].messageLength = 2500byte
+*.host3.app[0].sendInterval = 2.4s
+*.host3.app[0].startTime = uniform(0s, 1s)
+
+*.host4.numApps = 1
+*.host4.app[0].typename = "UdpBasicApp"
+*.host4.app[0].destAddresses = "hub"
+*.host4.app[0].destPort = 1000
+*.host4.app[0].messageLength = 2500byte
+*.host4.app[0].sendInterval = 2.6s
+*.host4.app[0].startTime = uniform(0s, 1s)
+
+# --- ad-hoc wlan: enough power to decode across the ~110m spokes (so arrows draw); the disc
+#     size is set by the fade below, NOT by this power. Fixed 54 Mbps keeps each transmission
+#     ~0.4ms, which -- slowed by signalTransmissionAnimationSpeed -- lights the disc for ~2s. ---
+*.host*.wlan[*].radio.transmitter.power = 1mW
+*.hub.wlan[*].radio.transmitter.power = 1mW
+*.host*.wlan[*].bitrate = 54Mbps
+*.hub.wlan[*].bitrate = 54Mbps
+*.*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
+*.*.wlan[*].agent.typename = ""
+*.radioMedium.maxCommunicationRange = 200m
+*.radioMedium.maxInterferenceRange = 200m
+
+# --- host2 drifts slowly around the east side, staying within range of the hub ---
+*.host2.mobility.typename = "LinearMobility"
+*.host2.mobility.speed = 4mps
+*.host2.mobility.initialX = 310m
+*.host2.mobility.initialY = 200m
+*.host2.mobility.initialMovementHeading = 60deg
+*.host2.mobility.constraintAreaMinX = 250m
+*.host2.mobility.constraintAreaMinY = 130m
+*.host2.mobility.constraintAreaMinZ = 0m
+*.host2.mobility.constraintAreaMaxX = 350m
+*.host2.mobility.constraintAreaMaxY = 270m
+*.host2.mobility.constraintAreaMaxZ = 0m
+
+# --- scene ---
+*.visualizer.sceneVisualizer.axisLength = 40m
+*.visualizer.sceneVisualizer.sceneMinX = 0m
+*.visualizer.sceneVisualizer.sceneMinY = 0m
+*.visualizer.sceneVisualizer.sceneMaxX = 400m
+*.visualizer.sceneVisualizer.sceneMaxY = 400m
+*.visualizer.sceneVisualizer.sceneMinZ = 0m
+*.visualizer.sceneVisualizer.sceneMaxZ = 0m
+
+# --- medium visualizer: the shader wavefront ---
+*.visualizer.mediumVisualizer.displaySignals = true
+*.visualizer.mediumVisualizer.signalWaveShader = true
+# Disc size is governed by the fade (not power): signalFadingDistance=18m -> a ~175m disc that
+# overlaps the neighbours nicely without blanketing the 400m scene.
+*.visualizer.mediumVisualizer.signalFadingDistance = 18m
+*.visualizer.mediumVisualizer.signalWaveLength = 35m
+# Animation speeds proven by the radiomediumactivity showcase: the wavefront travels 500 m/s (so a
+# ~175m disc expands in ~0.35s) and the "while transmitting" window is slowed 4 orders of magnitude
+# so the disc STAYS LIT for the whole ~0.4ms transmission (~2s of animation) instead of flashing.
+*.visualizer.mediumVisualizer.signalPropagationAnimationSpeed = 500/3e8
+*.visualizer.mediumVisualizer.signalTransmissionAnimationSpeed = 50000/3e8
+*.visualizer.mediumVisualizer.displaySignalDepartures = true
+*.visualizer.mediumVisualizer.displaySignalArrivals = true
+*.visualizer.mediumVisualizer.displayCommunicationRanges = true
+
+*.visualizer.dataLinkVisualizer.displayLinks = true
+*.visualizer.dataLinkVisualizer.fadeOutTime = 2s
+
+*.visualizer.mobilityVisualizer.displayMovementTrails = true
+*.visualizer.mobilityVisualizer.animationSpeed = 1

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.cc
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.cc
@@ -283,6 +283,15 @@ void MediumVsgVisualizer::refreshRingTransmissionNode(const ITransmission *trans
     double maxRadius = 1e18;
     if (auto transmitterRadio = transmission->getTransmitterRadio())
         maxRadius = radioMedium->getMediumLimitCache()->getMaxInterferenceRange(transmitterRadio).get();
+    // Also cap the disc to where the distance fade renders it invisible (the same cutoff createWaveRing
+    // uses). This makes the disc's on-screen size a function of the fade parameters — a visualization
+    // choice — rather than the transmit power: otherwise a power high enough for the nodes to actually
+    // communicate (so the data-link visualizer draws arrows) would balloon the interference-range disc
+    // far past the scene, since the interference range is many times the communication range.
+    if (signalFadingDistance > 0 && signalFadingFactor > 1.0) {
+        const double alphaFloor = 0.02;
+        maxRadius = std::min(maxRadius, signalFadingDistance * std::log(1.0 / alphaFloor) / std::log(signalFadingFactor));
+    }
 
     cFigure::Color color = signalColorSet.getColor(transmission->getId());
     // Damp the ripple as the animation speeds up, mirroring the OSG signal shader's waveFadingFactor
@@ -304,15 +313,21 @@ void MediumVsgVisualizer::refreshRingTransmissionNode(const ITransmission *trans
     //    interference range (maxRadius, above), so draw a persistent translucent filled disc
     //    (createAnnulus) covering the entire range at a constant 20% opacity. The wave-ring's distance
     //    fade is wrong here (it fades to ~0 well inside the range), so a uniform fill is used instead.
+    // Lift the disc a hair above the ground plane. On a flat scene the disc and the floor are both at
+    // the transmitter's z, and coplanar surfaces z-fight — the depth buffer can't decide which is in
+    // front, producing a rotating pinwheel of light/dark wedges. A tiny offset (invisible at scene
+    // scale) breaks the tie so the disc sits cleanly on top. (OSG instead disables depth writes; the
+    // lift is the robust equivalent for the baked-geometry path.)
+    Coord discCenter(0.0, 0.0, std::clamp(maxRadius * 0.02, 0.5, 3.0));
     double outer = std::min(startRadius, maxRadius);
     double inner = std::min(endRadius, outer);
     if (endRadius >= maxRadius && maxRadius > 0) {
         // FILLED RANGE: trailing edge past the whole range -> uniform translucent fill.
-        annulusHolder->addChild(inet::vsg::createAnnulus(Coord::ZERO, maxRadius, 0.0, color, 0.2, 100));
+        annulusHolder->addChild(inet::vsg::createAnnulus(discCenter, maxRadius, 0.0, color, 0.2, 100));
     }
     else if (outer > 0 && outer > inner) {
         // EXPANDING: ripple-modulated, distance-faded disc (the growing wavefront).
-        annulusHolder->addChild(inet::vsg::createWaveRing(Coord::ZERO, inner, outer,
+        annulusHolder->addChild(inet::vsg::createWaveRing(discCenter, inner, outer,
                 color, signalWaveLength, signalWaveAmplitude, 0.0,
                 signalFadingFactor, signalFadingDistance, waveFadingFactor));
     }
@@ -331,6 +346,16 @@ void MediumVsgVisualizer::refreshSphereTransmissionNode(const ITransmission *tra
     auto propagation = radioMedium->getPropagation();
     double startRadius = propagation->getPropagationSpeed().get<mps>() * (simTime() - transmission->getStartTime()).dbl();
     double endRadius   = std::max(0.0, propagation->getPropagationSpeed().get<mps>() * (simTime() - transmission->getEndTime()).dbl());
+
+    // Bound the drawn radius to the transmitter's interference range, exactly as the ring path does: at
+    // light speed both wavefronts reach hundreds of km within a packet's duration, and an unclamped
+    // translucent sphere would balloon out and blanket the whole scene. Clamping makes the sphere grow
+    // to the range limit and then hold there until the transmission is removed.
+    double maxRadius = 1e18;
+    if (auto transmitterRadio = transmission->getTransmitterRadio())
+        maxRadius = radioMedium->getMediumLimitCache()->getMaxInterferenceRange(transmitterRadio).get();
+    startRadius = std::min(startRadius, maxRadius);
+    endRadius   = std::min(endRadius, maxRadius);
 
     cFigure::Color color = signalColorSet.getColor(transmission->getId());
 

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.cc
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.cc
@@ -52,6 +52,7 @@ void MediumVsgVisualizer::initialize(int stage)
         signalWaveLength = par("signalWaveLength");
         signalWaveAmplitude = par("signalWaveAmplitude");
         signalWaveFadingAnimationSpeedFactor = par("signalWaveFadingAnimationSpeedFactor");
+        signalWaveShader = par("signalWaveShader");
         networkNodeVisualizer.reference(this, "networkNodeVisualizerModule", true);
     }
 }
@@ -303,33 +304,45 @@ void MediumVsgVisualizer::refreshRingTransmissionNode(const ITransmission *trans
     double waveFadingFactor = (animationSpeed > 0 && signalWaveFadingAnimationSpeedFactor > 0)
         ? std::min(1.0, signalPropagationAnimationSpeed / animationSpeed / signalWaveFadingAnimationSpeedFactor)
         : 1.0;
-    // The signal propagates at light speed, so within microseconds both wavefronts cross maxRadius.
-    // Two visual phases:
-    //  - EXPANDING (leading edge still inside the range): the wavefront is a growing, ripple-modulated
-    //    translucent disc (createWaveRing) from the trailing edge to the leading edge. waveOffset is
-    //    FIXED (0) so the ripple phase stays anchored in space as the disc grows (else the interior
-    //    strobes between opaque/transparent each time the edge crosses a wavelength boundary).
-    //  - FILLED RANGE (trailing edge has passed the range): the signal has fully swept the whole
-    //    interference range (maxRadius, above), so draw a persistent translucent filled disc
-    //    (createAnnulus) covering the entire range at a constant 20% opacity. The wave-ring's distance
-    //    fade is wrong here (it fades to ~0 well inside the range), so a uniform fill is used instead.
-    // Lift the disc a hair above the ground plane. On a flat scene the disc and the floor are both at
-    // the transmitter's z, and coplanar surfaces z-fight — the depth buffer can't decide which is in
-    // front, producing a rotating pinwheel of light/dark wedges. A tiny offset (invisible at scene
-    // scale) breaks the tie so the disc sits cleanly on top. (OSG instead disables depth writes; the
-    // lift is the robust equivalent for the baked-geometry path.)
-    Coord discCenter(0.0, 0.0, std::clamp(maxRadius * 0.02, 0.5, 3.0));
     double outer = std::min(startRadius, maxRadius);
     double inner = std::min(endRadius, outer);
-    if (endRadius >= maxRadius && maxRadius > 0) {
-        // FILLED RANGE: trailing edge past the whole range -> uniform translucent fill.
-        annulusHolder->addChild(inet::vsg::createAnnulus(discCenter, maxRadius, 0.0, color, 0.2, 100));
+    // Lift the disc a hair above the ground plane so its coplanar triangles don't z-fight the floor
+    // (both sit at the transmitter's z); invisible at scene scale. The shader path also disables depth
+    // writes, but keeps the lift so it wins the depth test cleanly over the opaque floor.
+    Coord discCenter(0.0, 0.0, std::clamp(maxRadius * 0.02, 0.5, 3.0));
+
+    if (signalWaveShader) {
+        // SHADER PATH (OSG-equivalent): a single wave ring [inner, outer] whose per-pixel opacity is a
+        // moving ripple. The shader's distance fade makes far parts vanish, so no separate FILLED phase
+        // is needed: a finished transmission simply expands, empties from the centre as the trailing edge
+        // grows, and fades away.
+        //
+        // Drive the ripple from ANIMATION time (not the light-speed leading edge): anchoring waveOffset to
+        // startRadius made the ripple race past too fast to see during the long "holding while sending"
+        // window. With a fixed visual rate the waves flow outward steadily for the whole transmission and
+        // then fade out. Wrapped to one wavelength to stay precise over long runs. waveFadingFactor is
+        // pinned to 1 here — the ripple never strobes (it advances in animation time, not sim time), so
+        // the animation-speed damping that the baked path needs would only dim it for no reason.
+        const double ripplesPerAnimSecond = 1.2;
+        double animationTime = getSimulation()->getEnvir()->getAnimationTime();
+        double rippleOffset = (signalWaveLength > 0)
+            ? std::fmod(animationTime * ripplesPerAnimSecond, 1.0) * signalWaveLength
+            : 0.0;
+        if (outer > 0 && outer > inner)
+            annulusHolder->addChild(inet::vsg::createWaveRingShader(discCenter, inner, outer,
+                    color, signalWaveLength, signalWaveAmplitude, rippleOffset,
+                    signalFadingFactor, signalFadingDistance, /*waveFadingFactor*/ 1.0));
     }
-    else if (outer > 0 && outer > inner) {
-        // EXPANDING: ripple-modulated, distance-faded disc (the growing wavefront).
-        annulusHolder->addChild(inet::vsg::createWaveRing(discCenter, inner, outer,
-                color, signalWaveLength, signalWaveAmplitude, 0.0,
-                signalFadingFactor, signalFadingDistance, waveFadingFactor));
+    else {
+        // BAKED PATH (default): two phases. EXPANDING = growing ripple disc with a FIXED waveOffset=0 (a
+        // moving offset strobes against the coarse radial tessellation). FILLED RANGE (trailing edge past
+        // maxRadius) = uniform fill, since the baked wave's distance fade goes to ~0 well inside the range.
+        if (endRadius >= maxRadius && maxRadius > 0)
+            annulusHolder->addChild(inet::vsg::createAnnulus(discCenter, maxRadius, 0.0, color, 0.2, 100));
+        else if (outer > 0 && outer > inner)
+            annulusHolder->addChild(inet::vsg::createWaveRing(discCenter, inner, outer,
+                    color, signalWaveLength, signalWaveAmplitude, 0.0,
+                    signalFadingFactor, signalFadingDistance, waveFadingFactor));
     }
 
     // Update label position (placed at edge of inner radius in the direction of transmission->getId()).

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.h
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.h
@@ -39,6 +39,7 @@ class INET_API MediumVsgVisualizer : public MediumVisualizerBase
     double signalWaveLength = NaN;
     double signalWaveAmplitude = NaN;
     double signalWaveFadingAnimationSpeedFactor = NaN;
+    bool signalWaveShader = false; // experimental: draw the ring with the GLSL wave shader (smooth flowing ripple) instead of baked per-vertex alpha
     //@}
 
     /** @name Internal state */

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.ned
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.ned
@@ -36,6 +36,7 @@ simple MediumVsgVisualizer extends MediumVisualizerBase like IMediumVisualizer
         double signalWaveLength @unit(m) = default(100m); // Distance between signal waves, value must be in the range (0, +inf)
         double signalWaveAmplitude = default(0.5); // Relative opacity amplitude of signal waves, value must be in the range [0, 1]
         double signalWaveFadingAnimationSpeedFactor = default(1.0); // Value must be in the range [0, 1]
+        bool signalWaveShader = default(false); // Experimental: render the ring wavefront with a GLSL fragment shader (per-pixel, smoothly flowing ripple) instead of baked per-vertex alpha
 
         string transmissionPlane @enum("camera","xy","xz","yz") = default("camera"); // Plane for transmission indicator
         string receptionPlane @enum("camera","xy","xz","yz") = default("camera"); // Plane for reception indicator

--- a/src/inet/visualizer/vsg/util/VsgUtils.cc
+++ b/src/inet/visualizer/vsg/util/VsgUtils.cc
@@ -283,6 +283,163 @@ ref_ptr<Node> createWaveRing(const Coord& center, double innerRadius, double out
 }
 
 // ---------------------------------------------------------------------------------------------
+// Shader-based wave ring: the OSG-equivalent. A minimal annulus band [inner, outer] whose PER-PIXEL
+// opacity is computed by a GLSL fragment shader (distance fade x moving cosine ripple), so the ripple
+// flows outward smoothly (waveOffset animates each frame) with no tessellation strobing. The graphics
+// pipeline (shaders/blend/depth) is created ONCE and cached, so per frame we only rebuild the tiny
+// vertex band + a small uniform buffer and rebind the cached pipeline — no per-frame pipeline recompile.
+// ---------------------------------------------------------------------------------------------
+
+// GLSL is compiled to SPIR-V at runtime (VSG_SUPPORTS_ShaderCompiler). The vertex shader forwards the
+// local xy so the fragment shader can compute the exact radial distance per pixel. The wave parameters
+// arrive in a small uniform block (packed into three vec4s).
+static const char *waveRingVertexShader = R"(#version 450
+layout(push_constant) uniform PushConstants { mat4 projection; mat4 modelView; } pc;
+layout(location = 0) in vec3 vsg_Vertex;
+layout(location = 0) out vec2 vLocal;
+void main() {
+    vLocal = vsg_Vertex.xy;
+    gl_Position = (pc.projection * pc.modelView) * vec4(vsg_Vertex, 1.0);
+}
+)";
+
+static const char *waveRingFragmentShader = R"(#version 450
+layout(location = 0) in vec2 vLocal;
+layout(set = 0, binding = 0) uniform WaveParams {
+    vec4 colorOffset;  // rgb = colour, w = waveOffset
+    vec4 fadeWave;     // x = fadingFactor, y = fadingDistance, z = waveLength, w = amplitude
+    vec4 bounds;       // x = innerRadius, y = outerRadius
+} wp;
+layout(location = 0) out vec4 fragColor;
+void main() {
+    // The geometry band is already [inner, outer], so no radial clipping is needed here (an earlier
+    // shader-side discard on wp.bounds silently blanked everything whenever the uniform read as 0).
+    float d = length(vLocal);
+    float a = wp.fadeWave.w * 0.5;
+    float phi = (wp.fadeWave.z > 0.0) ? (d - wp.colorOffset.w) / wp.fadeWave.z * 6.283185307179586 : 0.0;
+    float fade = (wp.fadeWave.y > 0.0 && wp.fadeWave.x > 1.0) ? pow(wp.fadeWave.x, -d / wp.fadeWave.y) : 1.0;
+    // Don't let the distance fade take the wavefront all the way to invisible: floor it so the outer
+    // ripples stay readable, then ramp smoothly to zero only in the outermost margin so there is no
+    // hard ring at the disc edge.
+    fade = max(fade, 0.22);
+    fade *= 1.0 - smoothstep(wp.bounds.y * 0.8, wp.bounds.y, d);
+    float alpha = clamp(fade * (1.0 - a + cos(phi) * a), 0.0, 1.0);
+    fragColor = vec4(wp.colorOffset.rgb, alpha);
+}
+)";
+
+// The wave-ring graphics pipeline, cached (intentionally leaked, as the other shared vsg singletons).
+static ref_ptr<GraphicsPipeline> getWaveRingPipeline()
+{
+    static ref_ptr<GraphicsPipeline>& pipeline = *(new ref_ptr<GraphicsPipeline>());
+    if (pipeline) return pipeline;
+
+    auto vertexShader = ShaderStage::create(VK_SHADER_STAGE_VERTEX_BIT, "main", waveRingVertexShader);
+    auto fragmentShader = ShaderStage::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", waveRingFragmentShader);
+    // Pre-compile GLSL -> SPIR-V now so the pipeline holds ready SPIR-V, regardless of whether the
+    // off-screen viewer's own compile path would run the shader compiler on source-only stages.
+    ShaderStages shaderStages{vertexShader, fragmentShader};
+    auto shaderCompiler = ShaderCompiler::create();
+    if (shaderCompiler->supported())
+        shaderCompiler->compile(shaderStages);
+
+    // set 0, binding 0: the wave-parameter uniform buffer (fragment stage).
+    auto descriptorSetLayout = DescriptorSetLayout::create(DescriptorSetLayoutBindings{
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}});
+    // 128 bytes of vertex push constants = projection + modelView, pushed automatically by the
+    // RecordTraversal for the enclosing MatrixTransform (the standard vsg convention).
+    auto pipelineLayout = PipelineLayout::create(DescriptorSetLayouts{descriptorSetLayout},
+        PushConstantRanges{{VK_SHADER_STAGE_VERTEX_BIT, 0, 128}});
+
+    // vertex input: one vec3 position per vertex.
+    VertexInputState::Bindings vertexBindings{{0, sizeof(::vsg::vec3), VK_VERTEX_INPUT_RATE_VERTEX}};
+    VertexInputState::Attributes vertexAttributes{{0, 0, VK_FORMAT_R32G32B32_SFLOAT, 0}};
+
+    auto inputAssembly = InputAssemblyState::create();
+    inputAssembly->topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+    auto rasterization = RasterizationState::create();
+    rasterization->cullMode = VK_CULL_MODE_NONE;
+    auto depthStencil = DepthStencilState::create();
+    depthStencil->depthTestEnable = VK_TRUE;
+    depthStencil->depthWriteEnable = VK_FALSE; // translucent overlay: test but don't write (no z-fighting)
+
+    // Standard alpha blend for RGB; keep the OUTPUT alpha opaque (srcA*1 + dstA*(1-srcA)) so the
+    // off-screen framebuffer isn't near-transparent for Qt's composite — same fix as createGeometry.
+    auto colorBlend = ColorBlendState::create();
+    VkPipelineColorBlendAttachmentState blendAttachment{};
+    blendAttachment.blendEnable = VK_TRUE;
+    blendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    blendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    blendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+    blendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    blendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    blendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+    blendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    colorBlend->attachments = ColorBlendState::ColorBlendAttachments{blendAttachment};
+
+    GraphicsPipelineStates pipelineStates{
+        VertexInputState::create(vertexBindings, vertexAttributes),
+        inputAssembly,
+        rasterization,
+        MultisampleState::create(),
+        depthStencil,
+        colorBlend};
+
+    pipeline = GraphicsPipeline::create(pipelineLayout, shaderStages, pipelineStates);
+    return pipeline;
+}
+
+ref_ptr<Node> createWaveRingShader(const Coord& center, double innerRadius, double outerRadius,
+        const cFigure::Color& color, double waveLength, double waveAmplitude, double waveOffset,
+        double fadingFactor, double fadingDistance, double waveFadingFactor, int segments)
+{
+    double inner = std::max(0.0, innerRadius);
+    double outer = outerRadius;
+    // Clamp the outer radius to where the distance fade renders the wave invisible (same cutoff the
+    // baked createWaveRing uses), so a light-speed wavefront doesn't try to tessellate the whole scene.
+    const double alphaFloor = 0.02;
+    if (fadingDistance > 0 && fadingFactor > 1.0)
+        outer = std::min(outer, fadingDistance * std::log(1.0 / alphaFloor) / std::log(fadingFactor));
+    if (outer <= inner || segments < 3)
+        return Group::create();
+
+    // Minimal geometry: a single annulus band [inner, outer] as a triangle strip around the ring. The
+    // fragment shader paints the full radial gradient/ripple per pixel, so no radial subdivision needed.
+    auto vertices = vec3Array::create((segments + 1) * 2);
+    float cx = (float)center.x, cy = (float)center.y, cz = (float)center.z;
+    for (int j = 0; j <= segments; j++) {
+        double t = 2.0 * M_PI * (j % segments) / segments;
+        float ct = (float)std::cos(t), st = (float)std::sin(t);
+        vertices->set(j * 2,     ::vsg::vec3(cx + (float)inner * ct, cy + (float)inner * st, cz));
+        vertices->set(j * 2 + 1, ::vsg::vec3(cx + (float)outer * ct, cy + (float)outer * st, cz));
+    }
+
+    // Wave parameters (three packed vec4s) in a per-frame uniform buffer.
+    auto params = vec4Array::create(3);
+    params->properties.dataVariance = DataVariance::STATIC_DATA; // rebuilt fresh each frame
+    float amplitude = (float)(waveAmplitude * waveFadingFactor);
+    params->set(0, ::vsg::vec4((float)color.red / 255.0f, (float)color.green / 255.0f, (float)color.blue / 255.0f, (float)waveOffset));
+    params->set(1, ::vsg::vec4((float)fadingFactor, (float)fadingDistance, (float)waveLength, amplitude));
+    params->set(2, ::vsg::vec4((float)inner, (float)outer, 0.0f, 0.0f));
+
+    auto pipeline = getWaveRingPipeline();
+    auto uniform = DescriptorBuffer::create(params, 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+    auto descriptorSet = DescriptorSet::create(pipeline->layout->setLayouts[0], Descriptors{uniform});
+    auto bindDescriptorSet = BindDescriptorSet::create(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->layout, descriptorSet);
+
+    auto stateGroup = StateGroup::create();
+    stateGroup->add(BindGraphicsPipeline::create(pipeline));
+    stateGroup->add(bindDescriptorSet);
+
+    auto commands = Commands::create();
+    DataList vertexArrays{vertices};
+    commands->addChild(BindVertexBuffers::create(0, vertexArrays));
+    commands->addChild(Draw::create(vertices->size(), 1, 0, 0));
+    stateGroup->addChild(commands);
+    return stateGroup;
+}
+
+// ---------------------------------------------------------------------------------------------
 // Vertex-array builders
 // ---------------------------------------------------------------------------------------------
 

--- a/src/inet/visualizer/vsg/util/VsgUtils.h
+++ b/src/inet/visualizer/vsg/util/VsgUtils.h
@@ -82,6 +82,12 @@ ref_ptr<Node> createAnnulus(const Coord& center, double outerRadius, double inne
 ref_ptr<Node> createWaveRing(const Coord& center, double innerRadius, double outerRadius,
         const cFigure::Color& color, double waveLength, double waveAmplitude, double waveOffset,
         double fadingFactor, double fadingDistance, double waveFadingFactor = 1.0, int segments = 100);
+// Shader-based wave ring (OSG-equivalent): a minimal annulus band whose per-pixel opacity is computed
+// by a cached GLSL fragment shader, so the ripple flows outward smoothly (animate waveOffset) at high
+// FPS with no per-frame pipeline rebuild. Drop-in alternative to createWaveRing; see the .cc.
+ref_ptr<Node> createWaveRingShader(const Coord& center, double innerRadius, double outerRadius,
+        const cFigure::Color& color, double waveLength, double waveAmplitude, double waveOffset,
+        double fadingFactor, double fadingDistance, double waveFadingFactor = 1.0, int segments = 100);
 ref_ptr<Node> createQuad(const Coord& min, const Coord& max, const cFigure::Color& color, double opacity = 1.0);
 ref_ptr<Node> createPolygon(const std::vector<Coord>& points, const cFigure::Color& color, double opacity = 1.0, const Coord& translation = Coord::ZERO);
 ref_ptr<Node> createArrowhead(const Coord& start, const Coord& end, const cFigure::Color& color, double width = 10.0, double height = 20.0, double opacity = 1.0);


### PR DESCRIPTION
## Summary

Follow-up to #1112 (the translucent-over-opaque compositing fix). Now that translucent geometry composites correctly, this improves the VSG signal-propagation visualization and adds a shader-based flowing wavefront, plus example scenes to exercise it.

## What's in it

**1. Signal-viz baseline** (`1d535bc`)
- `refreshSphereTransmissionNode`: clamp the sphere radius to the interference range (mirrors the ring path) so light-speed spheres don't balloon over the whole scene.
- `refreshRingTransmissionNode`: cap the disc to the fade-visible extent, so disc size is governed by `signalFadingDistance` (a visualization choice) rather than transmit power — otherwise a power high enough for nodes to actually communicate (so data-link arrows draw) would blow the interference-range disc far past the scene. Also lift the disc a hair off the ground to stop coplanar z-fighting with the floor.
- Retune `examples/visualizer/vsgsignal` (cluster the hosts within communication range so arrows draw; tune power/fade so the disc stays scene-sized).
- Add `examples/visualizer/vsgsignal3d`: translucent expanding **spheres** with a drone flying through 3D space.

**2. GLSL shader-based wavefront** (`bc1f70b`)
- Opt-in `mediumVisualizer.signalWaveShader`: a minimal annulus band whose **per-pixel** opacity is computed by a GLSL fragment shader (distance fade × cosine ripple), the OSG-equivalent of the baked per-vertex approach. GLSL is compiled to SPIR-V at runtime.
- The graphics pipeline is **created once and cached** — per frame only the small vertex band + a 3-vec4 uniform buffer are rebuilt, so there's no per-frame pipeline recompile (smooth animation, responsive pause).
- The ripple is driven by **animation time** at a fixed visual rate, so the waves flow outward steadily for the whole transmission (including the "holding while sending" window) and then fade out — instead of racing past at light speed or sitting static.
- Distance fade is floored with a soft outer edge (outer ripples stay readable, no hard ring); depth writes disabled (translucent overlay, no z-fighting).
- Add `examples/visualizer/vsgsignalwave`: a hub + four spokes exchanging UDP traffic, so several colour-coded ripple discs overlap and stay lit while sending.

The shader path is **opt-in** and off by default; `vsgsignal` / `vsgsignal3d` and every other example keep the existing baked path.

## Testing

- Both `.cc` translation units compile cleanly (release).
- All four examples pass a Cmdenv smoke test (network elaborates, hosts communicate → arrows draw).
- The shader path verified visually under Qtenv (off-screen VSG 3D view): flowing ripples, discs lit for the transmission then fading, no z-fighting, no runtime shader/Vulkan errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->