### PR TITLE
visualizer: vsg: volumetric shader sphere wavefront + wireframe range spheres + #1113 review fixes

### DIFF
--- a/examples/visualizer/vsgsignal3d/VsgSignal3d.ned
+++ b/examples/visualizer/vsgsignal3d/VsgSignal3d.ned
@@ -36,12 +36,12 @@ network VsgSignal3dShowcase
             @display("p=40,180");
         }
         host1: WirelessHost { // ground station
-            @display("p=110,150");
+            @display("p=110,150;i=device/antennatower");
         }
         host2: WirelessHost { // ground station
-            @display("p=190,150");
+            @display("p=190,150;i=device/antennatower");
         }
         host3: WirelessHost { // drone flying through the 3D volume
-            @display("p=150,150");
+            @display("p=150,150;i=misc/drone");
         }
 }

--- a/examples/visualizer/vsgsignal3d/omnetpp.ini
+++ b/examples/visualizer/vsgsignal3d/omnetpp.ini
@@ -24,9 +24,10 @@ description = "VSG signal propagation in 3D (translucent expanding spheres, a dr
 *.host2.app[0].localPort = 1000
 
 # --- ad-hoc wlan ---
-# Very low power so the computed communication/interference range is ~100m, keeping the
-# translucent transmission spheres a sensible size relative to the scene (see vsgsignal).
-*.host*.wlan[*].radio.transmitter.power = 0.001mW
+# Enough power (0.5mW) that frames decode across the ~80m node spacing, so the data-link visualizer
+# draws connection arrows; the interference-range cap below keeps the transmission spheres a sensible
+# size (the sphere is bounded by the interference range).
+*.host*.wlan[*].radio.transmitter.power = 0.5mW
 *.host*.forwarding = true
 *.host*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
 *.host*.wlan[*].agent.typename = ""
@@ -65,6 +66,8 @@ description = "VSG signal propagation in 3D (translucent expanding spheres, a dr
 *.visualizer.mediumVisualizer.displaySignalDepartures = true
 *.visualizer.mediumVisualizer.displaySignalArrivals = true
 *.visualizer.mediumVisualizer.displayCommunicationRanges = true
+# 3D wireframe spheres for the range indicators (flat circles are meaningless for the flying drone).
+*.visualizer.mediumVisualizer.rangeSphere = true
 # Stretch each (light-speed, sub-microsecond) propagation over ~2s of animation so the
 # spheres are watchable rather than a brief flash. Raise this to slow them further.
 *.visualizer.mediumVisualizer.signalPropagationAnimationTime = 2s

--- a/examples/visualizer/vsgsignalwave3d/VsgSignalWave3d.ned
+++ b/examples/visualizer/vsgsignalwave3d/VsgSignalWave3d.ned
@@ -1,0 +1,53 @@
+//
+// Copyright (C) 2025 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+package inet.examples.visualizer.vsgsignalwave3d;
+
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.visualizer.vsg.integrated.IntegratedVsgVisualizer;
+
+//
+// Showcase for the VOLUMETRIC shader signal wavefront in true 3D
+// (mediumVisualizer.signalShape = "sphere" + signalWaveShader = true). A swarm of
+// four drones flies through the air (3D LinearMobility with a climb/descent
+// elevation) around a ground control station, all exchanging UDP traffic. Each
+// transmission expands as a translucent, rippling GLOWING SPHERE centred at the
+// emitter's 3D position -- the ripple opacity is computed per pixel by a fragment
+// shader across concentric shells, so the waves flow outward while the node is
+// sending and then fade. Several colour-coded spheres pulse in the air at once.
+// Run under Qtenv, switch to the 3D view, orbit the camera, and press Run.
+//
+network VsgSignalWave3dShowcase
+{
+    @display("bgb=300,300");
+    submodules:
+        visualizer: IntegratedVsgVisualizer {
+            @display("p=30,30");
+        }
+        configurator: Ipv4NetworkConfigurator {
+            @display("p=30,90");
+        }
+        radioMedium: Ieee80211ScalarRadioMedium {
+            @display("p=30,150");
+        }
+        gcs: WirelessHost { // ground control station
+            @display("p=150,150;i=device/antennatower");
+        }
+        drone1: WirelessHost {
+            @display("p=80,80;i=misc/drone");
+        }
+        drone2: WirelessHost {
+            @display("p=220,80;i=misc/drone");
+        }
+        drone3: WirelessHost {
+            @display("p=220,220;i=misc/drone");
+        }
+        drone4: WirelessHost {
+            @display("p=80,220;i=misc/drone");
+        }
+}

--- a/examples/visualizer/vsgsignalwave3d/omnetpp.ini
+++ b/examples/visualizer/vsgsignalwave3d/omnetpp.ini
@@ -1,0 +1,124 @@
+[General]
+network = VsgSignalWave3dShowcase
+sim-time-limit = 100s
+description = "VSG volumetric shader wavefront in 3D: a drone swarm, each transmission an expanding rippling glowing sphere in the air"
+
+**.arp.typename = "GlobalArp"
+
+# --- traffic: the four drones send telemetry to the ground control station, and the GCS sends
+#     commands back to drone1, so all five radios transmit and several colour-coded spheres pulse ---
+*.gcs.numApps = 2
+*.gcs.app[0].typename = "UdpSink"
+*.gcs.app[0].localPort = 1000
+*.gcs.app[1].typename = "UdpBasicApp"
+*.gcs.app[1].destAddresses = "drone1"
+*.gcs.app[1].destPort = 2000
+*.gcs.app[1].messageLength = 2500byte
+*.gcs.app[1].sendInterval = 1.9s
+*.gcs.app[1].startTime = uniform(0s, 1s)
+
+*.drone1.numApps = 2
+*.drone1.app[0].typename = "UdpSink"
+*.drone1.app[0].localPort = 2000
+*.drone1.app[1].typename = "UdpBasicApp"
+*.drone1.app[1].destAddresses = "gcs"
+*.drone1.app[1].destPort = 1000
+*.drone1.app[1].messageLength = 2500byte
+*.drone1.app[1].sendInterval = 2s
+*.drone1.app[1].startTime = uniform(0s, 1s)
+
+*.drone2.numApps = 1
+*.drone2.app[0].typename = "UdpBasicApp"
+*.drone2.app[0].destAddresses = "gcs"
+*.drone2.app[0].destPort = 1000
+*.drone2.app[0].messageLength = 2500byte
+*.drone2.app[0].sendInterval = 2.2s
+*.drone2.app[0].startTime = uniform(0s, 1s)
+
+*.drone3.numApps = 1
+*.drone3.app[0].typename = "UdpBasicApp"
+*.drone3.app[0].destAddresses = "gcs"
+*.drone3.app[0].destPort = 1000
+*.drone3.app[0].messageLength = 2500byte
+*.drone3.app[0].sendInterval = 2.4s
+*.drone3.app[0].startTime = uniform(0s, 1s)
+
+*.drone4.numApps = 1
+*.drone4.app[0].typename = "UdpBasicApp"
+*.drone4.app[0].destAddresses = "gcs"
+*.drone4.app[0].destPort = 1000
+*.drone4.app[0].messageLength = 2500byte
+*.drone4.app[0].sendInterval = 2.6s
+*.drone4.app[0].startTime = uniform(0s, 1s)
+
+# --- ad-hoc wlan: enough power (1mW @ 54Mbps) to decode across the ~120m air gaps (so arrows draw);
+#     the sphere size is set by the fade below, NOT by this power ---
+*.*.wlan[*].radio.transmitter.power = 1mW
+*.*.wlan[*].bitrate = 54Mbps
+*.*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
+*.*.wlan[*].agent.typename = ""
+*.radioMedium.maxCommunicationRange = 200m
+*.radioMedium.maxInterferenceRange = 200m
+
+# --- the four drones fly through a 3D box (non-zero movement elevation -> they climb and descend) ---
+*.drone*.mobility.typename = "LinearMobility"
+*.drone*.mobility.speed = 7mps
+*.drone*.mobility.constraintAreaMinX = 40m
+*.drone*.mobility.constraintAreaMinY = 40m
+*.drone*.mobility.constraintAreaMinZ = 30m
+*.drone*.mobility.constraintAreaMaxX = 260m
+*.drone*.mobility.constraintAreaMaxY = 260m
+*.drone*.mobility.constraintAreaMaxZ = 130m
+*.drone1.mobility.initialX = 80m
+*.drone1.mobility.initialY = 80m
+*.drone1.mobility.initialZ = 60m
+*.drone1.mobility.initialMovementHeading = 45deg
+*.drone1.mobility.initialMovementElevation = 15deg
+*.drone2.mobility.initialX = 220m
+*.drone2.mobility.initialY = 80m
+*.drone2.mobility.initialZ = 90m
+*.drone2.mobility.initialMovementHeading = 135deg
+*.drone2.mobility.initialMovementElevation = -20deg
+*.drone3.mobility.initialX = 220m
+*.drone3.mobility.initialY = 220m
+*.drone3.mobility.initialZ = 50m
+*.drone3.mobility.initialMovementHeading = 225deg
+*.drone3.mobility.initialMovementElevation = 25deg
+*.drone4.mobility.initialX = 80m
+*.drone4.mobility.initialY = 220m
+*.drone4.mobility.initialZ = 100m
+*.drone4.mobility.initialMovementHeading = 315deg
+*.drone4.mobility.initialMovementElevation = -15deg
+
+# --- 3D scene box ---
+*.visualizer.sceneVisualizer.axisLength = 40m
+*.visualizer.sceneVisualizer.sceneMinX = 0m
+*.visualizer.sceneVisualizer.sceneMinY = 0m
+*.visualizer.sceneVisualizer.sceneMaxX = 300m
+*.visualizer.sceneVisualizer.sceneMaxY = 300m
+*.visualizer.sceneVisualizer.sceneMinZ = 0m
+*.visualizer.sceneVisualizer.sceneMaxZ = 150m
+
+# --- medium visualizer: the VOLUMETRIC shader sphere wavefront ---
+*.visualizer.mediumVisualizer.displaySignals = true
+*.visualizer.mediumVisualizer.signalShape = "sphere"
+*.visualizer.mediumVisualizer.signalWaveShader = true
+# Sphere size is governed by the fade (not power): signalFadingDistance=18m -> a ~175m sphere.
+*.visualizer.mediumVisualizer.signalFadingDistance = 18m
+*.visualizer.mediumVisualizer.signalWaveLength = 30m
+*.visualizer.mediumVisualizer.displaySignalDepartures = true
+*.visualizer.mediumVisualizer.displaySignalArrivals = true
+*.visualizer.mediumVisualizer.displayCommunicationRanges = true
+# Draw the range indicators as 3D wireframe spheres (a radio's range is a sphere; flat circles are
+# meaningless once the drones leave the ground plane).
+*.visualizer.mediumVisualizer.rangeSphere = true
+# Proven animation speeds: wavefront travels 500 m/s (a ~175m sphere expands in ~0.35s) and the
+# transmit window is slowed ~4 orders of magnitude so a sphere STAYS LIT ~2s while sending.
+*.visualizer.mediumVisualizer.signalPropagationAnimationSpeed = 500/3e8
+*.visualizer.mediumVisualizer.signalTransmissionAnimationSpeed = 50000/3e8
+
+*.visualizer.dataLinkVisualizer.displayLinks = true
+*.visualizer.dataLinkVisualizer.fadeOutTime = 2s
+
+*.visualizer.mobilityVisualizer.displayMovementTrails = true
+*.visualizer.mobilityVisualizer.animationSpeed = 1

--- a/src/inet/visualizer/vsg/README.md
+++ b/src/inet/visualizer/vsg/README.md
@@ -1,0 +1,445 @@
+# INET VSG (VulkanSceneGraph) 3D Visualizer
+
+The VSG visualizer is INET's 3D network-simulation visualizer built on
+[VulkanSceneGraph](https://vsg-dev.github.io/vsg-dev.io/) (VSG) — a modern,
+OSG-free replacement for INET's older OpenSceneGraph-based visualizer
+(`inet/visualizer/osg`). It renders the whole simulated topology (nodes,
+connections, radio signals, mobility trails, routes, statistics, ...) into an
+**off-screen** framebuffer, which OMNeT++'s Qtenv hands to its 3D canvas
+widget for display. There is no on-screen Vulkan window of its own; VSG is
+purely a rendering backend behind Qtenv's existing 3D view. The module layout
+deliberately mirrors the OSG visualizer package-for-package, so anyone
+familiar with `inet.visualizer.osg` will recognize the structure immediately.
+
+This visualizer lives on the `topic/inet-vsg` development branch and is
+enabled via the `VisualizationVsg` INET feature (mutually exclusive with
+`VisualizationOsg` — OMNeT++ is built with either OSG or VSG support, not
+both).
+
+## Architecture
+
+### Module map
+
+The `inet/visualizer/vsg/` tree mirrors `inet/visualizer/osg/` (and the 2D
+canvas visualizer) one folder per protocol layer / concern:
+
+| Folder | Contents |
+|---|---|
+| `base/` | Shared base classes: `SceneVsgVisualizerBase`, `LinkVsgVisualizerBase`, `PathVsgVisualizerBase` |
+| `common/` | `GateScheduleVsgVisualizer`, `InfoVsgVisualizer`, `PacketDropVsgVisualizer`, `QueueVsgVisualizer`, `StatisticVsgVisualizer` |
+| `scene/` | `SceneVsgVisualizer` (floor/axes/viewpoint), `NetworkNodeVsgVisualizer`/`NetworkNodeVsgVisualization` (per-node markers, icons, labels), `NetworkConnectionVsgVisualizer` |
+| `physicallayer/` | `MediumVsgVisualizer` (signals/ranges — see below), `RadioVsgVisualizer`, `PhysicalLinkVsgVisualizer`, `TracingObstacleLossVsgVisualizer` |
+| `linklayer/` | `DataLinkVsgVisualizer`, `Ieee80211VsgVisualizer`, `InterfaceTableVsgVisualizer`, `LinkBreakVsgVisualizer` |
+| `networklayer/` | `NetworkRouteVsgVisualizer`, `RoutingTableVsgVisualizer` |
+| `transportlayer/` | `TransportConnectionVsgVisualizer`, `TransportRouteVsgVisualizer` |
+| `mobility/` | `MobilityVsgVisualizer` (position updates, movement trails) |
+| `power/` | `EnergyStorageVsgVisualizer` |
+| `flow/` | `PacketFlowVsgVisualizer` |
+| `environment/` | `PhysicalEnvironmentVsgVisualizer` (obstacles/terrain shapes) |
+| `integrated/` | `IntegratedVsgVisualizer` / `IntegratedMultiVsgVisualizer` — the "one module wires up everything" convenience wrappers, analogous to `IntegratedVisualizer`/`IntegratedCanvasVisualizer` |
+| `util/` | `VsgUtils.{h,cc}` (geometry/shader toolkit) and `VsgScene.{h,cc}` (scene-root plumbing) — shared by every visualizer above |
+
+Every concrete visualizer follows the same INET convention: a `.ned` file
+declaring the module and its parameters (`like I<Foo>Visualizer`), a `.h`/`.cc`
+pair implementing it, typically extending a shared `<Foo>VisualizerBase` from
+`inet/visualizer/base/` (the layer/concern-specific logic — event
+subscriptions, parameter parsing, filtering — is shared with the 2D canvas and
+OSG visualizers; only the actual node-building code is VSG-specific).
+
+### Off-screen rendering and Qtenv integration
+
+The VSG scene graph is rooted at a `inet::vsg::TopLevelScene` (a
+`vsg::Group` subclass, see `util/VsgScene.h`), which in turn holds a
+`SimulationScene` group that all the concrete visualizers add their nodes
+into. `TopLevelScene::getSimulationScene(cModule *module)` is the standard
+entry point every visualizer calls: it fetches (or lazily creates) the scene
+root that OMNeT++'s `cOsgCanvas` wraps in an opaque `omnetpp::cScene3DNode`.
+Under `WITH_VSG`, `cOsgCanvas` is the same OMNeT++ 3D-canvas API the OSG
+visualizer uses — VSG just supplies a different backend for it
+(`qtenv/vsg/vsgscenehandle.h`). This is why the module names/parameters keep
+the historical "Osg" nomenclature in a few OMNeT++-side APIs (`getOsgCanvas()`
+etc.) even though the rendering underneath is pure VSG.
+
+When no `SceneVsgVisualizer` exists yet, `getSimulationScene()` creates the
+scene with sensible defaults (`clearColor = #FFFFFF`, `zNear = 0.1`,
+`zFar = 100000`, `CAM_TERRAIN` manipulator) so any single visualizer module
+can be dropped into a network and "just work" without requiring the full
+`IntegratedVsgVisualizer`.
+
+VSG's off-screen viewer performs the single-`View` compile and supplies
+lighting; `util/VsgUtils.cc` only builds the scene graph nodes (geometry +
+graphics pipelines) that get attached under that root.
+
+## The `util/` toolkit
+
+`util/VsgUtils.{h,cc}` is the shared geometry/shader helper library that
+every concrete visualizer builds its nodes with — the VSG counterpart of
+`OsgUtils.h`. Because VSG (unlike OSG's fixed-function-friendly
+`Geometry`+`StateSet` split) requires an explicit graphics pipeline for
+*everything*, each helper returns a ready-to-render node: a `vsg::StateGroup`
+that bundles its own pipeline, descriptor bindings, and draw commands.
+
+Key entry points:
+
+- **`createGeometry(vertices, normals, topology, color, opacity, lit, lineWidth, cullBackFace, depthTest)`**
+  — the foundational helper. Builds a `GraphicsPipelineConfigurator` over the
+  shared flat-shaded (`getFlatShaderSet()`) or Phong (`getPhongShaderSet()`)
+  shader set, sets topology/rasterization/blend/depth state, binds a
+  per-instance `vsg_Color`, and emits the `BindVertexBuffers`+`Draw` commands.
+  Nearly every other helper (`createLine`, `createCircle`, `createAnnulus`,
+  `createQuad`, `createPolygon`, `createArrowhead`, `createWireframeSphere`,
+  ...) is built on top of it.
+- **`createCircle` / `createAnnulus`** — flat 2D shapes (range indicators,
+  filled discs), with `createCircle` honoring `cFigure::LineStyle` via real
+  dash geometry (`dashifyVertices` walks the path by arc length and emits only
+  the "dash" intervals — Vulkan core has no line-stipple equivalent).
+- **`createWireframeSphere(center, radius, color, width, latRings, lonRings, segments)`**
+  — a "loose mesh" wireframe sphere (latitude rings + meridian great circles,
+  drawn as `VK_PRIMITIVE_TOPOLOGY_LINE_LIST`), used for 3D range indicators
+  where a radio's range is truly a sphere and a flat circle would be
+  misleading (e.g. a flying drone).
+- **`createSphere` / `createBox`** (and `createTexturedQuad`) — thin wrappers
+  around the VSG `Builder` (`getBuilder()->createSphere/createBox/createQuad`),
+  which bakes its own pipeline internally.
+- **`createWaveRing(center, innerRadius, outerRadius, color, waveLength, waveAmplitude, waveOffset, fadingFactor, fadingDistance, waveFadingFactor, segments)`**
+  — the **baked** signal wavefront: a radially-subdivided annulus whose
+  *per-vertex* alpha reproduces the OSG signal shader's formula (a distance
+  fade `pow(fadingFactor, -d/fadingDistance)` times a cosine ripple across the
+  radius). Rebuilt from scratch every display refresh with the current
+  radii/offset — geometry, not a shader.
+- **`createWaveRingShader(...)`** — the **shader** counterpart: a minimal
+  `[inner, outer]` annulus band whose *per-pixel* opacity is computed by a
+  cached GLSL fragment shader, so the ripple flows smoothly with no
+  tessellation strobing and no per-frame pipeline rebuild (only the tiny
+  vertex band + a small uniform buffer are rebuilt each frame). **Contract:**
+  `center.xy` must be `(0,0)` — position the ring via an enclosing
+  `MatrixTransform` — because the shader derives the radial distance as
+  `length(vertex.xy)`; only `center.z` (a ground-lift) is honored.
+- **`createSphereWaveShader(innerRadius, outerRadius, color, waveLength, waveAmplitude, waveOffset, fadingFactor, fadingDistance, shells, latSegments, lonSegments)`**
+  — the 3D/volumetric counterpart: fills the `[inner, outer]` shell with `N`
+  concentric translucent UV-sphere shells, each shell's opacity computed by
+  the same per-pixel fade × ripple formula (now driven by the true 3D radius
+  `length(localPos)`), so it reads as an expanding, rippling glowing ball. A
+  per-shell alpha scale (`~2/shells`) keeps the stack translucent instead of
+  blending to opaque as the eye ray crosses many shells.
+- **Cached, intentionally-leaked singletons**: `getOptions()`,
+  `getFlatShaderSet()`/`getPhongShaderSet()`, `getBuilder()`,
+  `getWaveRingPipeline()`, `getSphereWavePipeline()` are all lazily created
+  `static ref_ptr<T>&` heap objects that are **never destroyed**. This is
+  deliberate: destroying a VSG object during C++ static-destructor/process-exit
+  teardown crashes, because VSG's global allocator may already be torn down
+  by then (`vsg::deallocate` → null deref). Leaking these avoids the crash;
+  the OS reclaims the memory at process exit.
+- **`fixBuilderBlendAlpha(node)`** — patches the alpha-channel blend factors
+  of pipelines baked by the VSG `Builder` (see the compositing fix below).
+- **`AutoScaleTransform`** — a `vsg::Transform` subclass that recomputes its
+  matrix from the live modelview during the record traversal, reproducing
+  `osg::AutoTransform`'s screen-relative behavior (VSG 1.1 has no equivalent
+  node, and the shader-side `StandardLayout::billboard` doesn't work
+  off-screen). In `billboard` mode, children face the camera and hold a
+  ~constant on-screen size (used for node icons, name labels, and
+  annotations, which are stacked via `screenOffset` so they never overlap
+  regardless of zoom); in non-billboard mode orientation is preserved (used
+  for arrowheads).
+- **`createTexturedQuad` / `createTexturedBillboard`** — icon rendering (see
+  Node rendering below), and `createImage`/`createImageFromResource` — a
+  path-keyed, leaked image cache so repeated icon loads (e.g. fade-out
+  rebuilds) don't re-read from disk every frame.
+
+### The translucent-over-opaque compositing fix
+
+This was the first major VSG-visualizer bug fixed (merged as PR #1112,
+`fix/vsg-translucent-compositing-v2`): any translucent geometry (signal
+discs, range fills, fading packet-drop markers, ...) rendered as an opaque
+**black blob** instead of blending into the scene.
+
+**Root cause**: VSG's standard `ColorBlendState::configureAttachments(true)`
+sets up the expected RGB blend (`srcColor·srcAlpha + dstColor·(1−srcAlpha)`)
+but sets the **alpha channel** blend to `srcAlpha·srcAlpha + dstAlpha·0`
+— i.e. output alpha ≈ `srcAlpha²`, which is close to 0 for any translucent
+draw. The off-screen Qtenv backend hands its framebuffer to Qt as a `QImage`
+with a real per-pixel alpha channel; a near-0 output alpha means Qt composites
+its own (dark) widget background *over* the correctly-blended RGB, so the
+translucent shape renders as a solid black/dark shape.
+
+**Fix**: wherever alpha blending is enabled, explicitly override the
+alpha-channel blend factors to keep the *output* alpha opaque:
+`srcAlphaBlendFactor = ONE`, `dstAlphaBlendFactor = ONE_MINUS_SRC_ALPHA`,
+`alphaBlendOp = ADD` — i.e. `outA = srcA·1 + dstA·(1−srcA)`, which stays 1
+whenever the destination alpha is already 1 (an opaque background). This is
+applied in four places:
+
+- `createGeometry` (the generic pipeline path, whenever `opacity < 1.0`),
+- `createWaveRing` (the baked wavefront),
+- the two shader pipelines (`getWaveRingPipeline`, `getSphereWavePipeline`) —
+  set directly on the `ColorBlendState` at pipeline-creation time,
+- `fixBuilderBlendAlpha()` — for nodes baked by the VSG `Builder`
+  (`createSphere`/`createBox`/`createTexturedQuad`), which bakes its
+  `VkPipeline` internally during `createSphere()`/etc., so the fix has to
+  clone the `ColorBlendState` (Builder may share/cache the same
+  `ColorBlendState` `ref_ptr` across pipelines — don't mutate in place),
+  patch the alpha factors on the clone, and rebuild+swap the
+  `BindGraphicsPipeline` in the returned scene graph via a `vsg::Visitor`
+  that finds every `BindGraphicsPipeline` in the subgraph.
+
+## Signal / medium visualization (`physicallayer/MediumVsgVisualizer`)
+
+`MediumVsgVisualizer` is the VSG port of `MediumOsgVisualizer` — it displays
+radio signals as they propagate through the medium, plus per-radio departure/
+arrival markers and communication/interference range indicators.
+
+### Ring vs. sphere
+
+The `signalShape` parameter (`"ring"` | `"sphere"` | `"both"`, default
+`"ring"`) selects the signal representation:
+
+- **`ring`** (`createRingSignalNode` / `refreshRingTransmissionNode`) — a flat
+  2D annulus, positioned at the transmission's start point via a
+  `MatrixTransform`, tilted per `signalPlane` (`"xy"` default/ground plane,
+  `"xz"`/`"yz"` vertical planes; `"camera"` behaves like `"xy"` since a live
+  camera-facing billboard for a world-sized growing ring has no off-screen
+  equivalent).
+- **`sphere`** (`createSphereSignalNode` / `refreshSphereTransmissionNode`) —
+  a true 3D volumetric wavefront centered at the transmitter's 3D position;
+  meaningful for nodes off the ground plane (drones).
+- **`both`** — draws one ring node and one sphere node per transmission.
+
+### Baked vs. shader
+
+Independently of the shape, `signalWaveShader` (default `false`) switches
+between two rendering strategies:
+
+| | **Baked (default)** | **Shader (`signalWaveShader = true`)** |
+|---|---|---|
+| Ring | `inet::vsg::createWaveRing` — per-vertex alpha, whole annulus geometry rebuilt every display refresh | `inet::vsg::createWaveRingShader` — cached GLSL pipeline, per-pixel fade × ripple, only a thin band + tiny uniform rebuilt per frame |
+| Sphere | `inet::vsg::createSphere` ×2 (start/end wavefront), single alpha per sphere, rebuilt every refresh | `inet::vsg::createSphereWaveShader` — cached GLSL pipeline, concentric shells with per-pixel fade × ripple |
+| Ripple flow | Fixed `waveOffset = 0` when expanding (a moving offset would strobe against the coarse radial tessellation); `waveFadingFactor` damps the ripple toward a flat disc as animation speed rises | Ripple flows continuously; `waveFadingFactor` is pinned to `1.0` (never strobes, since the offset advances in **animation time**, not simulation time) |
+| Compile cost | None (plain geometry) | GLSL compiled to SPIR-V **at runtime** via `VSG_SUPPORTS_ShaderCompiler` (glslang); the pipeline is built once and cached (`getWaveRingPipeline`/`getSphereWavePipeline`) |
+
+If the shader path is requested but the VSG build lacks the GLSL compiler (or
+compilation fails), `getWaveRingPipeline()`/`getSphereWavePipeline()` throw a
+clear `cRuntimeError`:
+`"signalWaveShader needs a VSG built with the GLSL compiler (glslang), ... set signalWaveShader=false to use the baked wavefront"`.
+
+Both paths share the same **fade cap**: the drawn radius is bounded not just
+by the transmitter's interference range but also by the radius at which the
+exponential distance fade drops below a floor (`alphaFloor = 0.02`,
+i.e. `signalFadingDistance · ln(1/0.02) / ln(signalFadingFactor)`). This
+decouples the disc/sphere's *on-screen size* from the *transmit power*: a
+power high enough for real communication (so the data-link visualizer draws
+connection arrows) has an interference range many times larger than the
+communication range, and without this cap the wavefront would balloon past
+the whole scene. The cap is purely a visualization choice governed by
+`signalFadingDistance`/`signalFadingFactor`.
+
+The ring path also lifts the disc a hair above the ground plane
+(`z = clamp(maxRadius * 0.02, 0.5, 3.0)`) so its coplanar triangles don't
+z-fight the floor.
+
+### The ripple ↔ animation-time relationship
+
+In the shader path, the ripple offset is driven by **animation time**
+(`getSimulation()->getEnvir()->getAnimationTime()`) at a fixed visual rate
+(`ripplesPerAnimSecond = 1.2`, wrapped to one wavelength), **not** by the
+light-speed leading-edge radius. Anchoring the ripple to `startRadius` made
+it race past too fast to see during the long "holding while sending" window;
+driving it from animation time makes the waves flow outward steadily for the
+whole transmission and then fade out as the shape shrinks/empties.
+
+### Signal parameters (`physicallayer/MediumVsgVisualizer.ned`)
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `signalShape` | `"ring"` | `"ring"` \| `"sphere"` \| `"both"` |
+| `signalPlane` | `"xy"` | Plane for 2D signal shapes: `"camera"`, `"xy"`, `"xz"`, `"yz"` |
+| `signalFadingDistance` | `100m` | Distance scale of the exponential opacity/fade-cap decay |
+| `signalFadingFactor` | `1.5` | Exponential decay base, must be `> 1.0` |
+| `signalWaveLength` | `100m` | Distance between ripple wave crests |
+| `signalWaveAmplitude` | `0.5` | Relative opacity amplitude of the ripple, `[0, 1]` |
+| `signalWaveFadingAnimationSpeedFactor` | `1.0` | Baked-path only: tunes how fast the ripple flattens toward a smooth disc as animation speed rises |
+| `signalWaveShader` | `false` | Use the GLSL shader path instead of baked geometry (experimental) |
+| `rangeSphere` | `false` | Draw range indicators as 3D wireframe spheres instead of flat ground circles |
+| `transmissionPlane` / `receptionPlane` | `"camera"` | Plane for the departure/arrival indicator icons |
+| `communicationRangePlane` / `interferenceRangePlane` | `"xy"` | Plane for the range circles |
+
+Inherited from `MediumVisualizerBase.ned` (shared with the OSG/canvas
+visualizers) — the notable animation-speed knobs:
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `signalPropagationAnimationSpeed` | `nan` (auto) | Animation speed while the leading/trailing edge is propagating (sweeping) |
+| `signalPropagationAnimationTime` | `1s` | Used instead, when `signalPropagationAnimationSpeed` is unset |
+| `signalTransmissionAnimationSpeed` | `nan` (auto) | Animation speed while the signal is actively being transmitted (i.e. how long the disc/sphere stays lit while "sending") |
+| `signalTransmissionAnimationTime` | `1s` | Used instead, when `signalTransmissionAnimationSpeed` is unset |
+
+### Animation-speed model in practice
+
+Two independent knobs govern how a transmission *feels*:
+
+- `signalPropagationAnimationSpeed` controls how fast the wavefront's
+  **edge sweeps** outward.
+- `signalTransmissionAnimationSpeed` controls how long the disc/sphere
+  **stays lit** while the node is actively sending (the gap between the
+  leading and trailing edge).
+
+Proven values from the `radiomediumactivity` showcase (also used by
+`vsgsignalwave`/`vsgsignalwave3d`, see below):
+
+```
+signalPropagationAnimationSpeed  = 500/3e8     # ~175 m wavefront expands in ~0.35s
+signalTransmissionAnimationSpeed = 50000/3e8   # keeps a ~0.4ms transmission lit for ~2s
+```
+
+i.e. the transmission-hold speed is ~100× slower than the propagation-sweep
+speed, so a wavefront visibly grows to its full size and then holds/pulses
+for a watchable duration before fading, instead of flashing once and
+vanishing (real propagation is at light speed — sub-microsecond for
+in-scene distances).
+
+## Node / range rendering
+
+- **Node representation** (`scene/NetworkNodeVsgVisualization.cc`): each
+  network node's display-string `i=` icon tag is loaded
+  (`inet::vsg::createImage`/`resolveImageResource`) and rendered as a
+  camera-facing, constant-on-screen-size **textured billboard quad**
+  (`createTexturedQuad` wrapped in a billboard `AutoScaleTransform`), with a
+  colored box (`createBox`) fallback if there is no icon or it fails to
+  load. There is currently **no support for real 3D models** — the code has
+  an explicit `TODO: 3D model from the "osgModel"/"model" parameter`, unlike
+  the OSG visualizer's optional model-file loading. Every node also gets a
+  selectable id (`omnetpp.object` user value) so clicking it in the 3D view
+  selects the corresponding module.
+- **Name label + annotations**: stacked as camera-facing, screen-constant-size
+  billboards sharing one `labelPivot`, offset from each other purely in
+  *screen* space (`screenOffset.y`) via `updateAnnotationPositions()` — so the
+  stack (name, then per-visualizer annotations such as the signal
+  departure/arrival marker) never overlaps regardless of zoom level, mirroring
+  how OSG stacks annotations inside its `autoScaleToScreen` transform.
+- **Range indicators**: `displayCommunicationRanges` / `displayInterferenceRanges`
+  draw a circle (`createCircle`, honoring line color/style/width, including
+  dashed/dotted via real dash geometry) around each radio by default. When
+  `rangeSphere = true`, a 3D wireframe sphere (`createWireframeSphere`) is
+  drawn instead — a radio's range is physically a sphere, so a flat ground
+  circle is misleading once nodes leave the ground plane (e.g. a drone).
+- **Icons in 3D examples**: drones and antenna towers are just ordinary
+  display-string icons — `@display("i=misc/drone")` /
+  `@display("i=device/antennatower")` — rendered through the same textured
+  billboard path as any other node icon; there is nothing sphere/drone-specific
+  in the node-rendering code, only in how the examples position/label nodes.
+
+## Examples (`examples/visualizer/`)
+
+| Example | Demonstrates |
+|---|---|
+| `vsgsmoketest` | Minimal end-to-end smoke test: `SceneVsgVisualizer` + `NetworkNodeVsgVisualizer` + `NetworkConnectionVsgVisualizer` + `MobilityVsgVisualizer` wired up individually (no `IntegratedVsgVisualizer`), on a hand-built `VsgSmokeNode` with no protocol stack. A `Mobility` config variant adds moving nodes + movement trails. |
+| `vsgicons` | Infrastructure WiFi (`AccessPoint` + associating stations) exercising Ieee80211 SSID badges, a TCP connection flow (transport-connection icons), a UDP flood causing packet drops, plus node icons/labels, data links, routes, communication ranges (dashed-line style), and wave-modulated medium signals with a custom `signalColor` palette. |
+| `vsgsignal` | Tuning ground for the 2D ring signal visualization: three ad-hoc hosts close enough to actually communicate (so data-link arrows also draw), with `signalFadingDistance`/`signalWaveLength` tuned so the translucent discs fit the 300×300 scene; one host drifts to show growing transmissions as nodes move. |
+| `vsgsignal3d` | Same idea in 3D: `signalShape = "sphere"`, `rangeSphere = true`; two ground-station hosts plus a "drone" (`i=misc/drone`) flying through the volume above them via 3D `LinearMobility` (non-zero movement elevation), so its transmission spheres are visibly centered in the air. |
+| `vsgsignalwave` | Showcases the GLSL **shader** ring wavefront (`signalWaveShader = true`) with the proven `signalPropagationAnimationSpeed`/`signalTransmissionAnimationSpeed` pair from `radiomediumactivity`; a hub + 4 spokes all transmit so several color-coded, continuously-rippling discs overlap and pulse at once. |
+| `vsgsignalwave3d` | The volumetric 3D counterpart: `signalShape = "sphere"` + `signalWaveShader = true` + `rangeSphere = true`; a ground control station plus a 4-drone swarm flying through a 3D box, each transmission an expanding, rippling glowing sphere in the air. |
+| `vsgwireless` | A comprehensive "everything at once" checkpoint: signals, data links, network routes, interface tables, statistics, and mobility trails, all through `IntegratedVsgVisualizer`, on a simple 3-host ad-hoc network (settings proven by the `radiomediumactivity` showcase). |
+
+All examples import `inet.visualizer.vsg.integrated.IntegratedVsgVisualizer`
+(except `vsgsmoketest`, which wires up individual VSG visualizer modules to
+demonstrate that they work standalone) and are meant to be run under Qtenv,
+switching to the 3D view, and pressing Run.
+
+## Building & running
+
+- Requires a VSG-enabled OMNeT++ build (in this environment: the
+  `omnetpp-dev` checkout, configured/built with VSG support,
+  i.e. `WITH_VSG=yes`).
+- INET side: the `VisualizationVsg` feature (`.oppfeatures`, id
+  `VisualizationVsg`) must be enabled; it compiles with
+  `-DINET_WITH_VISUALIZATIONVSG`, requires the `PhysicalEnvironment` and
+  `VisualizationCommon` features, and is **mutually exclusive** with
+  `VisualizationOsg` — an OMNeT++ build has either OSG or VSG support, never
+  both, so the two visualizer features cannot be enabled simultaneously.
+- Build with `make MODE=release` (from the INET root, after
+  `opp_featuretool` / configure has enabled `VisualizationVsg`).
+- Run an example with `inet -u Qtenv` from its directory (e.g.
+  `examples/visualizer/vsgsignalwave3d`), then switch to the 3D view in the
+  Qtenv toolbar and press Run.
+
+### Gotchas
+
+- **Only one VSG Qtenv window at a time.** Two simultaneously open VSG 3D
+  views (e.g. two separate Qtenv instances) conflict over the shared
+  off-screen VSG device/resources and can render black. Close one before
+  opening another.
+- **A harmless startup log pair** is expected and not an error:
+  ```
+  dlopen liboppqtenv-vsg.dylib ...
+  Loaded 3D viewer backend
+  ```
+  This is OMNeT++ dynamically loading the VSG-based Qtenv 3D-viewer backend
+  plugin; it is the normal way the VSG support library gets pulled in.
+
+## Limitations & TODOs
+
+- **No real 3D node models yet** — nodes render as 2D icon billboards
+  (`NetworkNodeVsgVisualization.cc`), not 3D meshes; a `TODO` marks the
+  planned `osgModel`/`model` display-string support.
+- **Per-frame geometry rebuild cost for the baked wavefront** — the default
+  (non-shader) ring/sphere paths rebuild their annulus/sphere geometry from
+  scratch on every `refreshDisplay()` call (VSG bakes geometry+color at
+  construction time; there's no cheap "just change the alpha" update path),
+  which is why the shader path exists as a lower-overhead, smoother-looking
+  alternative.
+- **Per-instance opacity has no cheap update path** — several visualizers
+  (`PacketDropVsgVisualizer`, sphere signal wavefronts, `LinkBreakVsgVisualizer`)
+  note that a fade-out currently rebuilds the whole geometry child at the new
+  alpha; a push-constant or descriptor-set alpha uniform would be more
+  efficient (`TODO`s at each site).
+- **No VSG node-mask equivalent** — `MediumVsgVisualizer`'s departure/arrival
+  indicators are shown/hidden by adding/clearing child nodes rather than
+  toggling visibility, since VSG has no OSG-style node mask.
+  (`MediumVsgVisualizer.cc`)
+  - Departure/arrival indicators are also still plain colored spheres, not
+    the textured billboard (`signalDepartureImage`/`signalArrivalImage`) the
+    OSG visualizer draws — `TODO`s mark the planned switch to
+    `createTexturedBillboard`.
+- **Label position is baked, not mutable** — the per-transmission ring
+  label's world position is set once at construction; the code notes this
+  needs a mutable-position API on `createLabel`/`VsgUtils` before it can
+  track the moving edge each frame (`MediumVsgVisualizer.cc`).
+- **Line width > 1 needs the `wideLines` device feature**, which is absent
+  on MoltenVK (macOS); requested widths silently clamp to 1px there
+  (`VsgUtils.h`).
+- **Line stipple (dotted/dashed) has no Vulkan-core equivalent** — emulated
+  by generating real dash-segment geometry in world-space units
+  (`dashifyVertices` in `VsgUtils.cc`), rather than a true screen-space
+  stipple.
+- Assorted per-visualizer approximations, each flagged with an inline `TODO`
+  in its `.cc`: `EnergyStorageVsgVisualizer` (unimplemented, same as the OSG
+  original), `GateScheduleVsgVisualizer` (no gantt-style timeline bar yet),
+  `QueueVsgVisualizer` (box + label instead of a proper bar figure),
+  `RadioVsgVisualizer` (no radio-mode/rx-tx state icons yet),
+  `RoutingTableVsgVisualizer` (route-line labels not yet rebuilt on refresh),
+  `SceneVsgVisualizerBase` (textured floor image and exponential edge shading
+  not yet ported), `PhysicalEnvironmentVsgVisualizer` (only bounding-box
+  approximations for non-standard `ShapeBase` subclasses),
+  `MobilityVsgVisualizer` (movement-trail geometry rebuilds the whole
+  pipeline as the trail grows rather than using a dynamic vertex buffer).
+
+## History
+
+- **PR #1112** (`fix/vsg-translucent-compositing-v2`, merged as
+  `671b29a034`) — diagnosed and fixed the translucent-over-opaque
+  compositing bug (the "black blob" issue): overrode the alpha-channel blend
+  factors so the off-screen framebuffer's output alpha stays opaque for Qt's
+  compositor, applied across `createGeometry`, `createWaveRing`, and (via
+  `fixBuilderBlendAlpha`) every VSG-`Builder`-baked node.
+- **PR #1113** (`fix/vsg-signal-ripple`, merged as `dbe6bab83f`) — added the
+  GLSL shader-based signal wavefront (`signalWaveShader`,
+  `createWaveRingShader`) with a continuously flowing, per-pixel ripple
+  driven by animation time, plus the fade-cap/animation-speed tuning
+  (`signalFadingDistance`-bounded disc size decoupled from transmit power)
+  proven out by the `vsgsignal`/`vsgsignalwave` example showcases.
+- **Follow-up (in progress on `fix/vsg-signal-sphere-shader`)** — extended the
+  shader wavefront to true 3D: `createSphereWaveShader` (a volumetric,
+  concentric-shell rippling sphere) as the `signalShape = "sphere"`
+  counterpart to the ring shader, plus `createWireframeSphere` and the
+  `rangeSphere` parameter for physically-meaningful 3D range indicators, and
+  the `vsgsignal3d`/`vsgsignalwave3d` drone-swarm showcases that exercise
+  them.

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.cc
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.cc
@@ -53,6 +53,7 @@ void MediumVsgVisualizer::initialize(int stage)
         signalWaveAmplitude = par("signalWaveAmplitude");
         signalWaveFadingAnimationSpeedFactor = par("signalWaveFadingAnimationSpeedFactor");
         signalWaveShader = par("signalWaveShader");
+        rangeSphere = par("rangeSphere");
         networkNodeVisualizer.reference(this, "networkNodeVisualizerModule", true);
     }
 }
@@ -360,39 +361,59 @@ void MediumVsgVisualizer::refreshSphereTransmissionNode(const ITransmission *tra
     double startRadius = propagation->getPropagationSpeed().get<mps>() * (simTime() - transmission->getStartTime()).dbl();
     double endRadius   = std::max(0.0, propagation->getPropagationSpeed().get<mps>() * (simTime() - transmission->getEndTime()).dbl());
 
-    // Bound the drawn radius to the transmitter's interference range, exactly as the ring path does: at
-    // light speed both wavefronts reach hundreds of km within a packet's duration, and an unclamped
-    // translucent sphere would balloon out and blanket the whole scene. Clamping makes the sphere grow
-    // to the range limit and then hold there until the transmission is removed.
+    // Bound the drawn radius to the transmitter's interference range AND to the fade-visible extent
+    // (the same two caps the ring path uses): at light speed both wavefronts reach hundreds of km within
+    // a packet's duration, and an unclamped translucent sphere would blanket the scene. The fade cap
+    // makes the sphere size a function of signalFadingDistance rather than the transmit power, so a power
+    // high enough for real communication (data-link arrows) doesn't inflate the sphere.
     double maxRadius = 1e18;
     if (auto transmitterRadio = transmission->getTransmitterRadio())
         maxRadius = radioMedium->getMediumLimitCache()->getMaxInterferenceRange(transmitterRadio).get();
+    if (signalFadingDistance > 0 && signalFadingFactor > 1.0) {
+        const double alphaFloor = 0.02;
+        maxRadius = std::min(maxRadius, signalFadingDistance * std::log(1.0 / alphaFloor) / std::log(signalFadingFactor));
+    }
     startRadius = std::min(startRadius, maxRadius);
     endRadius   = std::min(endRadius, maxRadius);
 
     cFigure::Color color = signalColorSet.getColor(transmission->getId());
 
-    // node is the Group holding [0] startSphereTransform, [1] endSphereTransform.
+    // node is the Group holding [0] startSphereTransform, [1] endSphereTransform, both at the emission point.
     auto group = static_cast<::vsg::Group *>(node);
-
-    // --- start wavefront ---
     auto startTransform = static_cast<::vsg::MatrixTransform *>(group->children[0].get());
     auto startHolder    = static_cast<::vsg::Group *>(startTransform->children[0].get());
+    auto endTransform   = static_cast<::vsg::MatrixTransform *>(group->children[1].get());
+    auto endHolder      = static_cast<::vsg::Group *>(endTransform->children[0].get());
     startHolder->children.clear();
+    endHolder->children.clear();
+
+    if (signalWaveShader) {
+        // SHADER PATH: one VOLUMETRIC rippling shell region [endRadius, startRadius] (concentric
+        // translucent shells with per-pixel fade x ripple), drawn into the start holder; the end holder
+        // stays empty. The ripple flows in animation time (same as the ring), so it doesn't strobe or
+        // race at light speed. A finished transmission expands, hollows out from the centre, and fades.
+        const double ripplesPerAnimSecond = 1.2;
+        double animationTime = getSimulation()->getEnvir()->getAnimationTime();
+        double rippleOffset = (signalWaveLength > 0)
+            ? std::fmod(animationTime * ripplesPerAnimSecond, 1.0) * signalWaveLength
+            : 0.0;
+        double outer = startRadius;
+        double inner = std::min(endRadius, outer);
+        if (outer > 0 && outer > inner)
+            startHolder->addChild(inet::vsg::createSphereWaveShader(inner, outer, color,
+                    signalWaveLength, signalWaveAmplitude, rippleOffset, signalFadingFactor, signalFadingDistance));
+        return;
+    }
+
+    // BAKED PATH (default): two solid translucent wavefront spheres (leading + trailing edge), each with
+    // a single distance-faded alpha (floored so far spheres stay faintly visible).
     if (startRadius > 0) {
         double startAlpha = (signalFadingDistance > 0 && signalFadingFactor > 1.0)
             ? std::min(1.0, pow(signalFadingFactor, -startRadius / signalFadingDistance))
             : 0.99;
         startAlpha = std::max(0.1, startAlpha);
-        // TODO: the OSG version mutates osg::Material alpha in-place; VSG requires geometry
-        //       rebuild.  This matches the approach in PacketDropVsgVisualizer::setAlpha.
         startHolder->addChild(inet::vsg::createSphere(Coord::ZERO, startRadius, color, startAlpha));
     }
-
-    // --- end wavefront ---
-    auto endTransform = static_cast<::vsg::MatrixTransform *>(group->children[1].get());
-    auto endHolder    = static_cast<::vsg::Group *>(endTransform->children[0].get());
-    endHolder->children.clear();
     if (endRadius > 0) {
         double endAlpha = (signalFadingDistance > 0 && signalFadingFactor > 1.0)
             ? std::min(1.0, pow(signalFadingFactor, -endRadius / signalFadingDistance))
@@ -445,20 +466,23 @@ void MediumVsgVisualizer::handleRadioAdded(const IRadio *radio)
             annotationGroup->addChild(::vsg::Group::create()); // placeholder child 1
         }
 
+        // A radio's range is a sphere, so in rangeSphere mode draw a 3D wireframe sphere (meaningful for
+        // nodes off the ground plane, e.g. drones); otherwise the conventional flat xy-plane circle
+        // (which honors the line style via real dash geometry; width clamps to 1px without wideLines).
         if (displayInterferenceRanges) {
             auto maxInterferenceRange = radioMedium->getMediumLimitCache()->getMaxInterferenceRange(radio);
-            // createCircle draws an xy-plane circle and now honors the line style (solid/dotted/dashed
-            // via real dash geometry). Line width still clamps to 1px where wideLines is unsupported.
-            auto circle = inet::vsg::createCircle(Coord::ZERO, maxInterferenceRange.get(),
-                interferenceRangeLineColor, interferenceRangeLineStyle, interferenceRangeLineWidth);
-            networkNodeVisualization->addChild(circle);
+            auto node = rangeSphere
+                ? inet::vsg::createWireframeSphere(Coord::ZERO, maxInterferenceRange.get(), interferenceRangeLineColor, interferenceRangeLineWidth)
+                : inet::vsg::createCircle(Coord::ZERO, maxInterferenceRange.get(), interferenceRangeLineColor, interferenceRangeLineStyle, interferenceRangeLineWidth);
+            networkNodeVisualization->addChild(node);
         }
 
         if (displayCommunicationRanges) {
             auto maxCommunicationRange = radioMedium->getMediumLimitCache()->getMaxCommunicationRange(radio);
-            auto circle = inet::vsg::createCircle(Coord::ZERO, maxCommunicationRange.get(),
-                communicationRangeLineColor, communicationRangeLineStyle, communicationRangeLineWidth);
-            networkNodeVisualization->addChild(circle);
+            auto node = rangeSphere
+                ? inet::vsg::createWireframeSphere(Coord::ZERO, maxCommunicationRange.get(), communicationRangeLineColor, communicationRangeLineWidth)
+                : inet::vsg::createCircle(Coord::ZERO, maxCommunicationRange.get(), communicationRangeLineColor, communicationRangeLineStyle, communicationRangeLineWidth);
+            networkNodeVisualization->addChild(node);
         }
 
         // Attach the departure/arrival indicator group as an annotation on the network node.

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.h
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.h
@@ -40,6 +40,7 @@ class INET_API MediumVsgVisualizer : public MediumVisualizerBase
     double signalWaveAmplitude = NaN;
     double signalWaveFadingAnimationSpeedFactor = NaN;
     bool signalWaveShader = false; // experimental: draw the ring with the GLSL wave shader (smooth flowing ripple) instead of baked per-vertex alpha
+    bool rangeSphere = false;      // draw communication/interference range indicators as 3D wireframe spheres instead of flat circles
     //@}
 
     /** @name Internal state */

--- a/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.ned
+++ b/src/inet/visualizer/vsg/physicallayer/MediumVsgVisualizer.ned
@@ -36,7 +36,8 @@ simple MediumVsgVisualizer extends MediumVisualizerBase like IMediumVisualizer
         double signalWaveLength @unit(m) = default(100m); // Distance between signal waves, value must be in the range (0, +inf)
         double signalWaveAmplitude = default(0.5); // Relative opacity amplitude of signal waves, value must be in the range [0, 1]
         double signalWaveFadingAnimationSpeedFactor = default(1.0); // Value must be in the range [0, 1]
-        bool signalWaveShader = default(false); // Experimental: render the ring wavefront with a GLSL fragment shader (per-pixel, smoothly flowing ripple) instead of baked per-vertex alpha
+        bool signalWaveShader = default(false); // Experimental: render the wavefront with a GLSL fragment shader (per-pixel, smoothly flowing ripple) instead of baked geometry -- a rippling disc for signalShape "ring", a volumetric rippling sphere for "sphere"
+        bool rangeSphere = default(false); // Draw communication/interference range indicators as 3D wireframe spheres instead of flat ground circles (meaningful for nodes off the ground plane, e.g. drones)
 
         string transmissionPlane @enum("camera","xy","xz","yz") = default("camera"); // Plane for transmission indicator
         string receptionPlane @enum("camera","xy","xz","yz") = default("camera"); // Plane for reception indicator

--- a/src/inet/visualizer/vsg/util/VsgUtils.cc
+++ b/src/inet/visualizer/vsg/util/VsgUtils.cc
@@ -340,8 +340,9 @@ static ref_ptr<GraphicsPipeline> getWaveRingPipeline()
     // off-screen viewer's own compile path would run the shader compiler on source-only stages.
     ShaderStages shaderStages{vertexShader, fragmentShader};
     auto shaderCompiler = ShaderCompiler::create();
-    if (shaderCompiler->supported())
-        shaderCompiler->compile(shaderStages);
+    if (!shaderCompiler->supported() || !shaderCompiler->compile(shaderStages))
+        throw cRuntimeError("signalWaveShader needs a VSG built with the GLSL compiler (glslang), and the "
+                            "wave shaders must compile; set signalWaveShader=false to use the baked wavefront");
 
     // set 0, binding 0: the wave-parameter uniform buffer (fragment stage).
     auto descriptorSetLayout = DescriptorSetLayout::create(DescriptorSetLayoutBindings{
@@ -437,6 +438,207 @@ ref_ptr<Node> createWaveRingShader(const Coord& center, double innerRadius, doub
     commands->addChild(Draw::create(vertices->size(), 1, 0, 0));
     stateGroup->addChild(commands);
     return stateGroup;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Shader-based VOLUMETRIC sphere wavefront: the 3D counterpart of createWaveRingShader. The signal
+// shell [inner, outer] is filled with N concentric translucent sphere shells; a GLSL fragment shader
+// sets each shell's per-pixel opacity from its 3D radius (distance fade x moving cosine ripple), so
+// the ripples read as an expanding, rippling glowing ball. Geometry is built at the LOCAL ORIGIN (the
+// enclosing MatrixTransform places it at the emission point), so d = length(localPos) IS the true
+// radial distance — no origin-vs-centre offset to worry about. One cached pipeline; per frame only the
+// shell vertices + a small uniform are rebuilt. A per-shell alpha scale keeps the stack translucent.
+// ---------------------------------------------------------------------------------------------
+
+static const char *sphereWaveVertexShader = R"(#version 450
+layout(push_constant) uniform PushConstants { mat4 projection; mat4 modelView; } pc;
+layout(location = 0) in vec3 vsg_Vertex;
+layout(location = 0) out vec3 vLocal;
+void main() {
+    vLocal = vsg_Vertex;
+    gl_Position = (pc.projection * pc.modelView) * vec4(vsg_Vertex, 1.0);
+}
+)";
+
+static const char *sphereWaveFragmentShader = R"(#version 450
+layout(location = 0) in vec3 vLocal;
+layout(set = 0, binding = 0) uniform WaveParams {
+    vec4 colorOffset;  // rgb = colour, w = waveOffset
+    vec4 fadeWave;     // x = fadingFactor, y = fadingDistance, z = waveLength, w = amplitude
+    vec4 bounds;       // x = innerRadius, y = outerRadius, z = per-shell alpha scale
+} wp;
+layout(location = 0) out vec4 fragColor;
+void main() {
+    float d = length(vLocal);   // 3D radial distance = this shell's radius
+    float a = wp.fadeWave.w * 0.5;
+    float phi = (wp.fadeWave.z > 0.0) ? (d - wp.colorOffset.w) / wp.fadeWave.z * 6.283185307179586 : 0.0;
+    float fade = (wp.fadeWave.y > 0.0 && wp.fadeWave.x > 1.0) ? pow(wp.fadeWave.x, -d / wp.fadeWave.y) : 1.0;
+    fade = max(fade, 0.22);
+    fade *= 1.0 - smoothstep(wp.bounds.y * 0.8, wp.bounds.y, d);
+    // Scale down per shell: the eye looks through many stacked shells, so a full-strength alpha would
+    // blend to near-opaque. bounds.z keeps the accumulated glow translucent.
+    float alpha = clamp(fade * (1.0 - a + cos(phi) * a) * wp.bounds.z, 0.0, 1.0);
+    fragColor = vec4(wp.colorOffset.rgb, alpha);
+}
+)";
+
+// The sphere-wavefront graphics pipeline, cached (intentionally leaked, like getWaveRingPipeline).
+static ref_ptr<GraphicsPipeline> getSphereWavePipeline()
+{
+    static ref_ptr<GraphicsPipeline>& pipeline = *(new ref_ptr<GraphicsPipeline>());
+    if (pipeline) return pipeline;
+
+    auto vertexShader = ShaderStage::create(VK_SHADER_STAGE_VERTEX_BIT, "main", sphereWaveVertexShader);
+    auto fragmentShader = ShaderStage::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", sphereWaveFragmentShader);
+    ShaderStages shaderStages{vertexShader, fragmentShader};
+    auto shaderCompiler = ShaderCompiler::create();
+    if (!shaderCompiler->supported() || !shaderCompiler->compile(shaderStages))
+        throw cRuntimeError("signalWaveShader needs a VSG built with the GLSL compiler (glslang), and the "
+                            "wave shaders must compile; set signalWaveShader=false to use the baked wavefront");
+
+    auto descriptorSetLayout = DescriptorSetLayout::create(DescriptorSetLayoutBindings{
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}});
+    auto pipelineLayout = PipelineLayout::create(DescriptorSetLayouts{descriptorSetLayout},
+        PushConstantRanges{{VK_SHADER_STAGE_VERTEX_BIT, 0, 128}});
+
+    VertexInputState::Bindings vertexBindings{{0, sizeof(::vsg::vec3), VK_VERTEX_INPUT_RATE_VERTEX}};
+    VertexInputState::Attributes vertexAttributes{{0, 0, VK_FORMAT_R32G32B32_SFLOAT, 0}};
+
+    auto inputAssembly = InputAssemblyState::create();
+    inputAssembly->topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    auto rasterization = RasterizationState::create();
+    rasterization->cullMode = VK_CULL_MODE_NONE;
+    auto depthStencil = DepthStencilState::create();
+    depthStencil->depthTestEnable = VK_TRUE;
+    depthStencil->depthWriteEnable = VK_FALSE; // translucent overlay: test but don't write
+
+    auto colorBlend = ColorBlendState::create();
+    VkPipelineColorBlendAttachmentState blendAttachment{};
+    blendAttachment.blendEnable = VK_TRUE;
+    blendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    blendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    blendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+    blendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    blendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    blendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+    blendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    colorBlend->attachments = ColorBlendState::ColorBlendAttachments{blendAttachment};
+
+    GraphicsPipelineStates pipelineStates{
+        VertexInputState::create(vertexBindings, vertexAttributes),
+        inputAssembly, rasterization, MultisampleState::create(), depthStencil, colorBlend};
+
+    pipeline = GraphicsPipeline::create(pipelineLayout, shaderStages, pipelineStates);
+    return pipeline;
+}
+
+// Append one UV-sphere shell (radius R, centred at the local origin) as a triangle list into `out`,
+// starting at vertex index k; returns the new index. latSegments x lonSegments quads, 6 verts each.
+static size_t appendSphereShell(vec3Array& out, size_t k, double radius, int latSegments, int lonSegments)
+{
+    float R = (float)radius;
+    auto P = [&](double th, double ph) {
+        return ::vsg::vec3(R * (float)(std::sin(th) * std::cos(ph)),
+                           R * (float)(std::sin(th) * std::sin(ph)),
+                           R * (float)std::cos(th));
+    };
+    for (int i = 0; i < latSegments; i++) {
+        double th0 = M_PI * i / latSegments, th1 = M_PI * (i + 1) / latSegments;
+        for (int j = 0; j < lonSegments; j++) {
+            double ph0 = 2.0 * M_PI * j / lonSegments, ph1 = 2.0 * M_PI * (j + 1) / lonSegments;
+            ::vsg::vec3 p00 = P(th0, ph0), p01 = P(th0, ph1), p10 = P(th1, ph0), p11 = P(th1, ph1);
+            out.set(k++, p00); out.set(k++, p10); out.set(k++, p11);
+            out.set(k++, p00); out.set(k++, p11); out.set(k++, p01);
+        }
+    }
+    return k;
+}
+
+ref_ptr<Node> createSphereWaveShader(double innerRadius, double outerRadius, const cFigure::Color& color,
+        double waveLength, double waveAmplitude, double waveOffset, double fadingFactor, double fadingDistance,
+        int shells, int latSegments, int lonSegments)
+{
+    double inner = std::max(0.0, innerRadius);
+    double outer = outerRadius;
+    // Same fade cutoff as the ring: cap the outer radius to where the wave becomes invisible, so a
+    // light-speed wavefront doesn't tessellate the whole scene.
+    const double alphaFloor = 0.02;
+    if (fadingDistance > 0 && fadingFactor > 1.0)
+        outer = std::min(outer, fadingDistance * std::log(1.0 / alphaFloor) / std::log(fadingFactor));
+    if (outer <= inner || shells < 1 || latSegments < 2 || lonSegments < 3)
+        return Group::create();
+
+    size_t vertsPerShell = (size_t)latSegments * lonSegments * 6;
+    auto vertices = vec3Array::create(vertsPerShell * shells);
+    size_t k = 0;
+    for (int s = 0; s < shells; s++) {
+        double r = (shells == 1) ? outer : inner + (outer - inner) * s / (shells - 1);
+        k = appendSphereShell(*vertices, k, r, latSegments, lonSegments);
+    }
+
+    // Per-shell alpha scale: a viewer ray crosses ~half the shells, so ~2/shells keeps the stack from
+    // blending to near-opaque while still reading as a solid volume.
+    double shellAlphaScale = std::min(1.0, 2.0 / std::max(1, shells));
+
+    auto params = vec4Array::create(3);
+    params->properties.dataVariance = DataVariance::STATIC_DATA;
+    params->set(0, ::vsg::vec4((float)color.red / 255.0f, (float)color.green / 255.0f, (float)color.blue / 255.0f, (float)waveOffset));
+    params->set(1, ::vsg::vec4((float)fadingFactor, (float)fadingDistance, (float)waveLength, (float)waveAmplitude));
+    params->set(2, ::vsg::vec4((float)inner, (float)outer, (float)shellAlphaScale, 0.0f));
+
+    auto pipeline = getSphereWavePipeline();
+    auto uniform = DescriptorBuffer::create(params, 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+    auto descriptorSet = DescriptorSet::create(pipeline->layout->setLayouts[0], Descriptors{uniform});
+    auto bindDescriptorSet = BindDescriptorSet::create(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->layout, descriptorSet);
+
+    auto stateGroup = StateGroup::create();
+    stateGroup->add(BindGraphicsPipeline::create(pipeline));
+    stateGroup->add(bindDescriptorSet);
+    auto commands = Commands::create();
+    DataList vertexArrays{vertices};
+    commands->addChild(BindVertexBuffers::create(0, vertexArrays));
+    commands->addChild(Draw::create(vertices->size(), 1, 0, 0));
+    stateGroup->addChild(commands);
+    return stateGroup;
+}
+
+// A "loose mesh" wireframe sphere: latRings latitude circles + lonRings meridian great circles, drawn
+// as a LINE_LIST in the given colour/width. Used for 3D range indicators (a radio's communication /
+// interference range is a sphere, so a flat circle is meaningless once nodes leave the ground plane).
+ref_ptr<Node> createWireframeSphere(const Coord& center, double radius, const cFigure::Color& color,
+        double width, int latRings, int lonRings, int segments)
+{
+    if (radius <= 0 || segments < 3 || latRings < 2 || lonRings < 1)
+        return Group::create();
+    float cx = (float)center.x, cy = (float)center.y, cz = (float)center.z, R = (float)radius;
+    std::vector<::vsg::vec3> pts;
+    // latitude circles (horizontal, poles excluded)
+    for (int i = 1; i < latRings; i++) {
+        double th = M_PI * i / latRings;
+        float z = R * (float)std::cos(th), r = R * (float)std::sin(th);
+        for (int j = 0; j < segments; j++) {
+            double a0 = 2.0 * M_PI * j / segments, a1 = 2.0 * M_PI * (j + 1) / segments;
+            pts.push_back(::vsg::vec3(cx + r * (float)std::cos(a0), cy + r * (float)std::sin(a0), cz + z));
+            pts.push_back(::vsg::vec3(cx + r * (float)std::cos(a1), cy + r * (float)std::sin(a1), cz + z));
+        }
+    }
+    // meridian great circles (vertical, through the poles)
+    for (int k = 0; k < lonRings; k++) {
+        double phi = M_PI * k / lonRings;
+        float cph = (float)std::cos(phi), sph = (float)std::sin(phi);
+        auto Meridian = [&](double t) {
+            float st = (float)std::sin(t), ct = (float)std::cos(t);
+            return ::vsg::vec3(cx + R * st * cph, cy + R * st * sph, cz + R * ct);
+        };
+        for (int j = 0; j < segments; j++) {
+            pts.push_back(Meridian(2.0 * M_PI * j / segments));
+            pts.push_back(Meridian(2.0 * M_PI * (j + 1) / segments));
+        }
+    }
+    auto vertices = vec3Array::create(pts.size());
+    for (size_t i = 0; i < pts.size(); i++)
+        vertices->set(i, pts[i]);
+    return createGeometry(vertices, {}, VK_PRIMITIVE_TOPOLOGY_LINE_LIST, color, 1.0, /*lit*/ false, width);
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/inet/visualizer/vsg/util/VsgUtils.h
+++ b/src/inet/visualizer/vsg/util/VsgUtils.h
@@ -73,6 +73,9 @@ ref_ptr<Node> createPolyline(const std::vector<Coord>& coords, cFigure::Arrowhea
         const cFigure::Color& color, const cFigure::LineStyle& style = cFigure::LINE_SOLID, double width = 1.0, double opacity = 1.0);
 ref_ptr<Node> createCircle(const Coord& center, double radius, const cFigure::Color& color,
         const cFigure::LineStyle& style = cFigure::LINE_SOLID, double width = 1.0, int polygonSize = 64);
+// A "loose mesh" wireframe sphere (latitude + meridian line rings) for 3D range indicators.
+ref_ptr<Node> createWireframeSphere(const Coord& center, double radius, const cFigure::Color& color,
+        double width = 1.0, int latRings = 5, int lonRings = 6, int segments = 24);
 ref_ptr<Node> createAnnulus(const Coord& center, double outerRadius, double innerRadius,
         const cFigure::Color& color, double opacity = 1.0, int polygonSize = 64);
 // Radially-subdivided ring with wave-modulated, distance-faded per-vertex opacity (the propagating
@@ -84,10 +87,21 @@ ref_ptr<Node> createWaveRing(const Coord& center, double innerRadius, double out
         double fadingFactor, double fadingDistance, double waveFadingFactor = 1.0, int segments = 100);
 // Shader-based wave ring (OSG-equivalent): a minimal annulus band whose per-pixel opacity is computed
 // by a cached GLSL fragment shader, so the ripple flows outward smoothly (animate waveOffset) at high
-// FPS with no per-frame pipeline rebuild. Drop-in alternative to createWaveRing; see the .cc.
+// FPS with no per-frame pipeline rebuild.
+// CONTRACT: center.xy MUST be 0 (position the ring via an enclosing MatrixTransform) -- the shader
+// derives the radial distance as length(vertex.xy), so a non-zero center.xy would offset the fade/
+// ripple. Only center.z (a ground-lift) is honoured. (This is the one way it is NOT a drop-in for
+// createWaveRing, whose alpha is computed from the true per-vertex radius.)
 ref_ptr<Node> createWaveRingShader(const Coord& center, double innerRadius, double outerRadius,
         const cFigure::Color& color, double waveLength, double waveAmplitude, double waveOffset,
         double fadingFactor, double fadingDistance, double waveFadingFactor = 1.0, int segments = 100);
+// Shader-based VOLUMETRIC sphere wavefront (the 3D counterpart of createWaveRingShader): the shell
+// [inner, outer] is filled with `shells` concentric UV spheres whose per-pixel opacity is the same
+// distance-fade x moving ripple, so it reads as an expanding, rippling glowing ball. Built at the local
+// origin (position it with an enclosing MatrixTransform); one cached pipeline, rebuilt vertices per frame.
+ref_ptr<Node> createSphereWaveShader(double innerRadius, double outerRadius, const cFigure::Color& color,
+        double waveLength, double waveAmplitude, double waveOffset, double fadingFactor, double fadingDistance,
+        int shells = 18, int latSegments = 12, int lonSegments = 18);
 ref_ptr<Node> createQuad(const Coord& min, const Coord& max, const cFigure::Color& color, double opacity = 1.0);
 ref_ptr<Node> createPolygon(const std::vector<Coord>& points, const cFigure::Color& color, double opacity = 1.0, const Coord& translation = Coord::ZERO);
 ref_ptr<Node> createArrowhead(const Coord& start, const Coord& end, const cFigure::Color& color, double width = 10.0, double height = 20.0, double opacity = 1.0);


### PR DESCRIPTION
## Summary

Follow-up to #1113 (the GLSL shader ring wavefront). Adds the **3D volumetric** counterpart, makes range indicators meaningful in 3D, and addresses all four review comments from #1113.

## Volumetric shader sphere wavefront
`signalShape="sphere"` + `signalWaveShader` now renders each transmission as an **expanding, rippling glowing sphere** (the 3D version of the ring's rippling disc):
- New `createSphereWaveShader` / cached `getSphereWavePipeline` in `VsgUtils`: fills the wavefront shell `[inner, outer]` with concentric UV-sphere shells whose **per-pixel** opacity is the same distance-fade × moving cosine ripple as the ring. Geometry is built at the local origin (positioned by the enclosing transform); a per-shell alpha scale keeps the stack translucent; the ripple flows in animation time.
- `refreshSphereTransmissionNode` gains the `signalWaveShader` branch **and** the fade-based radius cap (so sphere size follows `signalFadingDistance`, not transmit power).
- New example **`vsgsignalwave3d`**: a four-drone swarm exchanging UDP traffic with a ground station — several colour-coded rippling spheres pulse in the air.

## 3D range indicators + icons
- New `createWireframeSphere` (loose latitude/meridian line mesh) and a `rangeSphere` parameter: draws communication/interference ranges as **wireframe spheres** instead of flat ground circles (a radio's range is a sphere — the circle is meaningless once nodes leave the ground plane). Enabled in `vsgsignal3d` and `vsgsignalwave3d`.
- Drone / antenna-tower icons for the 3D examples (`i=misc/drone`, `i=device/antennatower`) instead of laptop billboards.

## Addresses the #1113 review (Devin)
- **🚩 shader-compile has no error handling** → now throws a clear `cRuntimeError` if the VSG lacks glslang or the wave shaders fail to compile, instead of a cryptic Vulkan failure (both the ring and sphere pipelines).
- **🚩 sphere path omits the fade-based radius cap** → added to `refreshSphereTransmissionNode`.
- **🚩 `vsgsignal3d` low power → no arrows** → raised transmit power `0.001mW → 0.5mW` so frames actually decode at the ~80m spacing (0.05mW would *not* have sufficed — those nodes are farther apart than `vsgsignal`'s). Verified: `host2` now receives **35** packets (was **0**), so the data-link arrows appear.
- **🟡 shader uses distance from origin, not centre** → documented the `center.xy`-must-be-0 contract on `createWaveRingShader`; the new sphere shader avoids the pitfall by construction (built at the local origin).

## Docs
Adds `src/inet/visualizer/vsg/README.md` — comprehensive developer/user documentation for the VSG visualizer (architecture, the `util/` toolkit, the compositing fix, ring vs sphere / baked vs shader wavefronts, parameters, examples, build/run, limitations).

## Testing
- Both changed translation units compile cleanly (release).
- All 3D examples pass a Cmdenv smoke test (networks elaborate, nodes communicate → arrows draw; `vsgsignal3d` reception fix verified).
- The sphere shader + wireframe range spheres + drone icons verified visually under Qtenv (off-screen VSG 3D view); no runtime shader/Vulkan errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->