### PR TITLE
visualizer: vsg: LIDAR / PLY point-cloud terrain as the scene ground (sceneModel)

### DIFF
--- a/examples/visualizer/vsglidar/VsgLidar.ned
+++ b/examples/visualizer/vsglidar/VsgLidar.ned
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2025 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+package inet.examples.visualizer.vsglidar;
+
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.visualizer.vsg.integrated.IntegratedVsgVisualizer;
+
+//
+// A drone swarm flying over a real LIDAR landscape. The VSG scene ground is replaced
+// by an actual LIDAR point-cloud scan (mediumVisualizer... sceneVisualizer.sceneModel
+// = a PLY file), coloured by elevation, recentred and auto-fit into the scene bounds.
+// Five drones fly through the airspace above the terrain, exchanging UDP traffic; each
+// transmission is a translucent, rippling glowing sphere expanding over the landscape.
+// The (flat, meaningless-in-3D) range indicators are turned off to keep the view clean,
+// leaving just the terrain + the signal wavefronts. Run under Qtenv, switch to the 3D
+// view, orbit/tilt the camera, and press Run.
+//
+// The sceneModel mechanism works with ANY PLY point cloud; terrain.ply here is a
+// subsampled USGS Sandy LIDAR tile of New York (buildings included).
+//
+network VsgLidarShowcase
+{
+    @display("bgb=800,450");
+    submodules:
+        visualizer: IntegratedVsgVisualizer {
+            @display("p=60,60");
+        }
+        configurator: Ipv4NetworkConfigurator {
+            @display("p=60,140");
+        }
+        radioMedium: Ieee80211ScalarRadioMedium {
+            @display("p=60,220");
+        }
+        drone1: WirelessHost { // swarm leader
+            @display("p=400,225;i=misc/drone");
+        }
+        drone2: WirelessHost {
+            @display("p=150,120;i=misc/drone");
+        }
+        drone3: WirelessHost {
+            @display("p=650,120;i=misc/drone");
+        }
+        drone4: WirelessHost {
+            @display("p=650,330;i=misc/drone");
+        }
+        drone5: WirelessHost {
+            @display("p=150,330;i=misc/drone");
+        }
+}

--- a/examples/visualizer/vsglidar/omnetpp.ini
+++ b/examples/visualizer/vsglidar/omnetpp.ini
@@ -1,0 +1,126 @@
+[General]
+network = VsgLidarShowcase
+sim-time-limit = 100s
+description = "Drone swarm over a real LIDAR landscape: PLY point-cloud terrain as the VSG ground, volumetric shader signal spheres, range indicators off"
+
+**.arp.typename = "GlobalArp"
+
+# --- traffic: drones 2-5 report to the leader (drone1), and the leader relays to drone2, so all five
+#     radios transmit and several colour-coded signal spheres pulse over the landscape ---
+*.drone1.numApps = 2
+*.drone1.app[0].typename = "UdpSink"
+*.drone1.app[0].localPort = 1000
+*.drone1.app[1].typename = "UdpBasicApp"
+*.drone1.app[1].destAddresses = "drone2"
+*.drone1.app[1].destPort = 2000
+*.drone1.app[1].messageLength = 2500byte
+*.drone1.app[1].sendInterval = 1.8s
+*.drone1.app[1].startTime = uniform(0s, 1s)
+
+*.drone2.numApps = 2
+*.drone2.app[0].typename = "UdpSink"
+*.drone2.app[0].localPort = 2000
+*.drone2.app[1].typename = "UdpBasicApp"
+*.drone2.app[1].destAddresses = "drone1"
+*.drone2.app[1].destPort = 1000
+*.drone2.app[1].messageLength = 2500byte
+*.drone2.app[1].sendInterval = 2s
+*.drone2.app[1].startTime = uniform(0s, 1s)
+
+*.drone3.numApps = 1
+*.drone3.app[0].typename = "UdpBasicApp"
+*.drone3.app[0].destAddresses = "drone1"
+*.drone3.app[0].destPort = 1000
+*.drone3.app[0].messageLength = 2500byte
+*.drone3.app[0].sendInterval = 2.3s
+*.drone3.app[0].startTime = uniform(0s, 1s)
+
+*.drone4.numApps = 1
+*.drone4.app[0].typename = "UdpBasicApp"
+*.drone4.app[0].destAddresses = "drone1"
+*.drone4.app[0].destPort = 1000
+*.drone4.app[0].messageLength = 2500byte
+*.drone4.app[0].sendInterval = 2.6s
+*.drone4.app[0].startTime = uniform(0s, 1s)
+
+*.drone5.numApps = 1
+*.drone5.app[0].typename = "UdpBasicApp"
+*.drone5.app[0].destAddresses = "drone1"
+*.drone5.app[0].destPort = 1000
+*.drone5.app[0].messageLength = 2500byte
+*.drone5.app[0].sendInterval = 2.9s
+*.drone5.app[0].startTime = uniform(0s, 1s)
+
+# --- ad-hoc wlan: enough power (10mW) to reach across the ~400m air gaps of the swarm; the sphere size
+#     is set by the fade below, not by this power ---
+*.drone*.wlan[*].radio.transmitter.power = 10mW
+*.drone*.wlan[*].bitrate = 54Mbps
+*.drone*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
+*.drone*.wlan[*].agent.typename = ""
+*.radioMedium.maxCommunicationRange = 500m
+*.radioMedium.maxInterferenceRange = 500m
+
+# --- the five drones fly through the airspace above the terrain (altitude ~280-360m, above the ~256m
+#     tall buildings in the scan); non-zero movement elevation makes them climb and descend ---
+*.drone*.mobility.typename = "LinearMobility"
+*.drone*.mobility.speed = 10mps
+*.drone*.mobility.constraintAreaMinX = 100m
+*.drone*.mobility.constraintAreaMinY = 80m
+*.drone*.mobility.constraintAreaMinZ = 280m
+*.drone*.mobility.constraintAreaMaxX = 700m
+*.drone*.mobility.constraintAreaMaxY = 370m
+*.drone*.mobility.constraintAreaMaxZ = 360m
+*.drone1.mobility.initialX = 400m
+*.drone1.mobility.initialY = 225m
+*.drone1.mobility.initialZ = 320m
+*.drone1.mobility.initialMovementHeading = 20deg
+*.drone1.mobility.initialMovementElevation = 10deg
+*.drone2.mobility.initialX = 150m
+*.drone2.mobility.initialY = 120m
+*.drone2.mobility.initialZ = 290m
+*.drone2.mobility.initialMovementHeading = 60deg
+*.drone2.mobility.initialMovementElevation = 15deg
+*.drone3.mobility.initialX = 650m
+*.drone3.mobility.initialY = 120m
+*.drone3.mobility.initialZ = 340m
+*.drone3.mobility.initialMovementHeading = 150deg
+*.drone3.mobility.initialMovementElevation = -15deg
+*.drone4.mobility.initialX = 650m
+*.drone4.mobility.initialY = 330m
+*.drone4.mobility.initialZ = 300m
+*.drone4.mobility.initialMovementHeading = 220deg
+*.drone4.mobility.initialMovementElevation = 20deg
+*.drone5.mobility.initialX = 150m
+*.drone5.mobility.initialY = 330m
+*.drone5.mobility.initialZ = 310m
+*.drone5.mobility.initialMovementHeading = 315deg
+*.drone5.mobility.initialMovementElevation = -20deg
+
+# --- scene: match the ~800x450m LIDAR footprint so the terrain fits ~1:1; tall Z for the buildings + drones ---
+*.visualizer.sceneVisualizer.axisLength = 80m
+*.visualizer.sceneVisualizer.sceneMinX = 0m
+*.visualizer.sceneVisualizer.sceneMinY = 0m
+*.visualizer.sceneVisualizer.sceneMaxX = 800m
+*.visualizer.sceneVisualizer.sceneMaxY = 450m
+*.visualizer.sceneVisualizer.sceneMinZ = 0m
+*.visualizer.sceneVisualizer.sceneMaxZ = 400m
+# THE point of this example: use a LIDAR PLY point cloud as the ground instead of the flat quad.
+*.visualizer.sceneVisualizer.sceneModel = "terrain.ply"
+
+# --- medium visualizer: volumetric shader signal spheres, range indicators OFF (uncluttered) ---
+*.visualizer.mediumVisualizer.displaySignals = true
+*.visualizer.mediumVisualizer.signalShape = "sphere"
+*.visualizer.mediumVisualizer.signalWaveShader = true
+*.visualizer.mediumVisualizer.rangeSphere = false
+*.visualizer.mediumVisualizer.displayCommunicationRanges = false
+*.visualizer.mediumVisualizer.displayInterferenceRanges = false
+*.visualizer.mediumVisualizer.signalFadingDistance = 25m
+*.visualizer.mediumVisualizer.signalWaveLength = 35m
+*.visualizer.mediumVisualizer.signalPropagationAnimationSpeed = 500/3e8
+*.visualizer.mediumVisualizer.signalTransmissionAnimationSpeed = 50000/3e8
+
+*.visualizer.dataLinkVisualizer.displayLinks = true
+*.visualizer.dataLinkVisualizer.fadeOutTime = 2s
+
+*.visualizer.mobilityVisualizer.displayMovementTrails = true
+*.visualizer.mobilityVisualizer.animationSpeed = 1

--- a/src/inet/visualizer/vsg/README.md
+++ b/src/inet/visualizer/vsg/README.md
@@ -327,6 +327,45 @@ in-scene distances).
   billboard path as any other node icon; there is nothing sphere/drone-specific
   in the node-rendering code, only in how the examples position/label nodes.
 
+## Scene terrain from a point cloud (`sceneModel`)
+
+By default the scene ground is a flat colored quad (`SceneVsgVisualizerBase::createSceneFloor` →
+`createQuad`, color `sceneColor`, at `z ≈ 0`). Setting the scene parameter **`sceneModel`** to a PLY
+file path replaces that quad with a real 3D terrain loaded from the file — e.g. a LIDAR scan — so
+nodes fly over actual landscape instead of a flat plane:
+
+```ini
+*.visualizer.sceneVisualizer.sceneModel = "terrain.ply"
+```
+
+The path is resolved **relative to the working directory** (the example folder when you run
+`inet -u Qtenv omnetpp.ini` there); an absolute path also works. If the file can't be opened the
+simulation stops with a clear `cRuntimeError` instead of silently drawing nothing.
+
+**How it works** (`inet::vsg::createTerrainFromPLY`, `util/VsgUtils.cc`) — the PLY is parsed directly
+(no mesh importer), which keeps it general and lets us handle raw LIDAR:
+
+- **Any PLY point cloud** — ascii or `binary_little_endian`, any property layout. It reads the
+  `element vertex` block, locates `x`/`y`/`z` by name (and `red`/`green`/`blue` if present), and skips
+  the other properties by their declared byte sizes. Faces are ignored — it renders points, not a mesh.
+- **Coordinate fit** — LIDAR tiles use huge projected coordinates (e.g. UTM easting/northing in the
+  millions). The cloud is **recentered** to its own centroid and **aspect-preserving-scaled to fit the
+  configured scene bounds** (`sceneMinX..sceneMaxZ`), base sitting at `sceneMinZ`. So any PLY, at any
+  real-world scale, drops into the scene box — set the scene bounds to roughly the tile's footprint
+  aspect for a natural ~1:1 look.
+- **Color** — the file's `red/green/blue` if present, otherwise points are colored by **elevation**
+  (a teal → green → tan → brown → white height ramp), which reads as a heightmap.
+- **Rendering** — a colored `POINT_LIST` through a small cached custom pipeline
+  (`getPointCloudPipeline`) that sets `gl_PointSize` so the points read as a surface rather than 1px
+  specks (point size clamps to 1 on GPUs without the `largePoints` feature). Loaded once at scene init.
+
+This is separate from per-*node* 3D models (still a TODO — nodes are icon billboards); `sceneModel` is
+specifically the scene ground/terrain, and works with **any** `.ply` point cloud, not a specific file.
+
+**Example — `vsglidar`** (see below): a 5-drone swarm flying over a subsampled USGS Hurricane-Sandy
+LIDAR tile of New York (`terrain.ply`, buildings included). To reuse it, drop any other `.ply` point
+cloud into an example folder and point `sceneModel` at it.
+
 ## Examples (`examples/visualizer/`)
 
 | Example | Demonstrates |
@@ -338,6 +377,7 @@ in-scene distances).
 | `vsgsignalwave` | Showcases the GLSL **shader** ring wavefront (`signalWaveShader = true`) with the proven `signalPropagationAnimationSpeed`/`signalTransmissionAnimationSpeed` pair from `radiomediumactivity`; a hub + 4 spokes all transmit so several color-coded, continuously-rippling discs overlap and pulse at once. |
 | `vsgsignalwave3d` | The volumetric 3D counterpart: `signalShape = "sphere"` + `signalWaveShader = true` + `rangeSphere = true`; a ground control station plus a 4-drone swarm flying through a 3D box, each transmission an expanding, rippling glowing sphere in the air. |
 | `vsgwireless` | A comprehensive "everything at once" checkpoint: signals, data links, network routes, interface tables, statistics, and mobility trails, all through `IntegratedVsgVisualizer`, on a simple 3-host ad-hoc network (settings proven by the `radiomediumactivity` showcase). |
+| `vsglidar` | A **LIDAR point-cloud terrain** as the scene ground (`sceneVisualizer.sceneModel = "terrain.ply"`, a subsampled USGS Sandy scan of New York, elevation-colored): a 5-drone swarm flies over the landscape exchanging UDP, each transmission a volumetric shader sphere; range indicators off to keep the view clean. Shows the general `sceneModel` mechanism (works with any `.ply`). |
 
 All examples import `inet.visualizer.vsg.integrated.IntegratedVsgVisualizer`
 (except `vsgsmoketest`, which wires up individual VSG visualizer modules to
@@ -410,6 +450,14 @@ switching to the 3D view, and pressing Run.
   by generating real dash-segment geometry in world-space units
   (`dashifyVertices` in `VsgUtils.cc`), rather than a true screen-space
   stipple.
+- **`sceneModel` terrain is points-only** — a PLY loaded via `sceneModel`
+  renders as a `POINT_LIST` (`createTerrainFromPLY`), not a meshed/triangulated
+  surface; point size relies on `gl_PointSize`, which clamps to 1px on GPUs
+  without the `largePoints` feature (a fallback to world-space point quads would
+  be more robust for sparse clouds). Only PLY is parsed — ascii /
+  `binary_little_endian`, `x`/`y`/`z` + optional `red`/`green`/`blue`; other
+  formats and `binary_big_endian` aren't handled, and the whole cloud is read
+  into memory once at scene init.
 - Assorted per-visualizer approximations, each flagged with an inline `TODO`
   in its `.cc`: `EnergyStorageVsgVisualizer` (unimplemented, same as the OSG
   original), `GateScheduleVsgVisualizer` (no gantt-style timeline bar yet),
@@ -436,10 +484,14 @@ switching to the 3D view, and pressing Run.
   driven by animation time, plus the fade-cap/animation-speed tuning
   (`signalFadingDistance`-bounded disc size decoupled from transmit power)
   proven out by the `vsgsignal`/`vsgsignalwave` example showcases.
-- **Follow-up (in progress on `fix/vsg-signal-sphere-shader`)** — extended the
-  shader wavefront to true 3D: `createSphereWaveShader` (a volumetric,
-  concentric-shell rippling sphere) as the `signalShape = "sphere"`
+- **PR #1114** (`fix/vsg-signal-sphere-shader`, merged as `07bcfdb61c`) —
+  extended the shader wavefront to true 3D: `createSphereWaveShader` (a
+  volumetric, concentric-shell rippling sphere) as the `signalShape = "sphere"`
   counterpart to the ring shader, plus `createWireframeSphere` and the
   `rangeSphere` parameter for physically-meaningful 3D range indicators, and
-  the `vsgsignal3d`/`vsgsignalwave3d` drone-swarm showcases that exercise
-  them.
+  the `vsgsignal3d`/`vsgsignalwave3d` drone-swarm showcases that exercise them.
+  Also added this README and addressed the #1113 review feedback.
+- **Follow-up** — `sceneModel`: load an external PLY point cloud (e.g. a LIDAR
+  scan) as the scene ground (`createTerrainFromPLY`), recentered, auto-fit to
+  the scene bounds, and elevation-colored; the `vsglidar` drone-swarm-over-terrain
+  showcase demonstrates it.

--- a/src/inet/visualizer/vsg/base/SceneVsgVisualizerBase.cc
+++ b/src/inet/visualizer/vsg/base/SceneVsgVisualizerBase.cc
@@ -69,12 +69,21 @@ void SceneVsgVisualizerBase::initializeAxis(double axisLength)
 void SceneVsgVisualizerBase::initializeSceneFloor()
 {
     Box sceneBounds = getSceneBounds();
-    if (sceneBounds.getMin() != sceneBounds.getMax()) {
+    if (sceneBounds.getMin() == sceneBounds.getMax())
+        return;
+    auto scene = inet::vsg::TopLevelScene::getSimulationScene(visualizationTargetModule);
+    const char *sceneModel = par("sceneModel");
+    if (sceneModel != nullptr && *sceneModel != '\0') {
+        // Load an external terrain model (a PLY point cloud, e.g. a LIDAR scan) as the ground, in place
+        // of the flat quad. The path is resolved relative to the working directory (the example dir).
+        auto terrain = inet::vsg::createTerrainFromPLY(sceneModel, sceneBounds.getMin(), sceneBounds.getMax());
+        scene->addChild(terrain);
+    }
+    else {
         auto color = cFigure::Color(par("sceneColor"));
         double opacity = par("sceneOpacity");
         // TODO: textured floor (sceneImage) and exponential edge shading (sceneShading) not yet ported.
         auto sceneFloor = createSceneFloor(sceneBounds.getMin(), sceneBounds.getMax(), color, opacity);
-        auto scene = inet::vsg::TopLevelScene::getSimulationScene(visualizationTargetModule);
         scene->addChild(sceneFloor);
     }
 }

--- a/src/inet/visualizer/vsg/base/SceneVsgVisualizerBase.ned
+++ b/src/inet/visualizer/vsg/base/SceneVsgVisualizerBase.ned
@@ -31,6 +31,7 @@ simple SceneVsgVisualizerBase extends SceneVisualizerBase
         string sceneImage = default(""); // Scene texture (repeated), no image by default
         double sceneImageSize @unit(m) = default(1m); // Scene texture size
         bool sceneShading = default(true); // Exponential shading for scene color, enabled by default
+        string sceneModel = default(""); // Path to an external terrain model (a PLY point cloud, e.g. a LIDAR scan) to use as the ground instead of the flat quad; recentred and aspect-fit into the scene bounds. Resolved relative to the working directory. Empty = flat floor.
 
         @class(SceneVsgVisualizerBase);
 }

--- a/src/inet/visualizer/vsg/util/VsgUtils.cc
+++ b/src/inet/visualizer/vsg/util/VsgUtils.cc
@@ -10,7 +10,10 @@
 #include <vsgXchange/all.h>
 
 #include <cmath>
+#include <cstring>
+#include <fstream>
 #include <map>
+#include <sstream>
 
 namespace inet {
 
@@ -639,6 +642,216 @@ ref_ptr<Node> createWireframeSphere(const Coord& center, double radius, const cF
     for (size_t i = 0; i < pts.size(); i++)
         vertices->set(i, pts[i]);
     return createGeometry(vertices, {}, VK_PRIMITIVE_TOPOLOGY_LINE_LIST, color, 1.0, /*lit*/ false, width);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Point-cloud terrain from a PLY file (e.g. a LIDAR scan used as the scene ground). We parse the PLY
+// ourselves (ascii or binary_little_endian) rather than lean on a mesh importer: LIDAR clouds have no
+// faces and often no colours, and we need to recentre huge projected coordinates, fit to the scene box,
+// and colour by elevation. Rendered as a coloured POINT_LIST with a tiny cached pipeline.
+// ---------------------------------------------------------------------------------------------
+
+static const char *pointCloudVertexShader = R"(#version 450
+layout(push_constant) uniform PushConstants { mat4 projection; mat4 modelView; } pc;
+layout(location = 0) in vec3 vsg_Vertex;
+layout(location = 1) in vec4 vsg_Color;
+layout(location = 0) out vec4 vColor;
+void main() {
+    vColor = vsg_Color;
+    gl_Position = (pc.projection * pc.modelView) * vec4(vsg_Vertex, 1.0);
+    gl_PointSize = 3.0;   // fat enough to read as a surface (clamps to 1 without the largePoints feature)
+}
+)";
+
+static const char *pointCloudFragmentShader = R"(#version 450
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec4 fragColor;
+void main() { fragColor = vColor; }
+)";
+
+// Cached opaque point-cloud pipeline (per-vertex position + colour, POINT_LIST, depth test + write).
+static ref_ptr<GraphicsPipeline> getPointCloudPipeline()
+{
+    static ref_ptr<GraphicsPipeline>& pipeline = *(new ref_ptr<GraphicsPipeline>());
+    if (pipeline) return pipeline;
+
+    auto vertexShader = ShaderStage::create(VK_SHADER_STAGE_VERTEX_BIT, "main", pointCloudVertexShader);
+    auto fragmentShader = ShaderStage::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", pointCloudFragmentShader);
+    ShaderStages shaderStages{vertexShader, fragmentShader};
+    auto shaderCompiler = ShaderCompiler::create();
+    if (!shaderCompiler->supported() || !shaderCompiler->compile(shaderStages))
+        throw cRuntimeError("sceneModel point-cloud rendering needs a VSG built with the GLSL compiler (glslang)");
+
+    auto pipelineLayout = PipelineLayout::create(DescriptorSetLayouts{},
+        PushConstantRanges{{VK_SHADER_STAGE_VERTEX_BIT, 0, 128}});
+    VertexInputState::Bindings vertexBindings{
+        {0, sizeof(::vsg::vec3), VK_VERTEX_INPUT_RATE_VERTEX},
+        {1, sizeof(::vsg::vec4), VK_VERTEX_INPUT_RATE_VERTEX}};
+    VertexInputState::Attributes vertexAttributes{
+        {0, 0, VK_FORMAT_R32G32B32_SFLOAT, 0},
+        {1, 1, VK_FORMAT_R32G32B32A32_SFLOAT, 0}};
+    auto inputAssembly = InputAssemblyState::create();
+    inputAssembly->topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+    auto rasterization = RasterizationState::create();
+    rasterization->cullMode = VK_CULL_MODE_NONE;
+    auto depthStencil = DepthStencilState::create();   // defaults: depth test + write on (opaque)
+    auto colorBlend = ColorBlendState::create();
+    VkPipelineColorBlendAttachmentState att{};
+    att.blendEnable = VK_FALSE;                          // opaque terrain
+    att.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    colorBlend->attachments = ColorBlendState::ColorBlendAttachments{att};
+
+    GraphicsPipelineStates pipelineStates{
+        VertexInputState::create(vertexBindings, vertexAttributes),
+        inputAssembly, rasterization, MultisampleState::create(), depthStencil, colorBlend};
+    pipeline = GraphicsPipeline::create(pipelineLayout, shaderStages, pipelineStates);
+    return pipeline;
+}
+
+static int plyTypeSize(const std::string& t) {
+    if (t == "double" || t == "float64") return 8;
+    if (t == "float" || t == "float32" || t == "int" || t == "int32" || t == "uint" || t == "uint32") return 4;
+    if (t == "short" || t == "int16" || t == "ushort" || t == "uint16") return 2;
+    if (t == "char" || t == "int8" || t == "uchar" || t == "uint8") return 1;
+    return 0;
+}
+static double plyRead(const char* p, const std::string& t) {
+    if (t == "double" || t == "float64") { double v; std::memcpy(&v, p, 8); return v; }
+    if (t == "float" || t == "float32")  { float v; std::memcpy(&v, p, 4); return (double)v; }
+    if (t == "int" || t == "int32")      { int32_t v; std::memcpy(&v, p, 4); return (double)v; }
+    if (t == "uint" || t == "uint32")    { uint32_t v; std::memcpy(&v, p, 4); return (double)v; }
+    if (t == "short" || t == "int16")    { int16_t v; std::memcpy(&v, p, 2); return (double)v; }
+    if (t == "ushort" || t == "uint16")  { uint16_t v; std::memcpy(&v, p, 2); return (double)v; }
+    if (t == "char" || t == "int8")      { int8_t v; std::memcpy(&v, p, 1); return (double)v; }
+    if (t == "uchar" || t == "uint8")    { uint8_t v; std::memcpy(&v, p, 1); return (double)v; }
+    return 0.0;
+}
+// Terrain elevation ramp for a normalised height t in [0,1]: teal (low) -> green -> tan -> brown -> white.
+static ::vsg::vec4 elevationColor(double t) {
+    t = std::max(0.0, std::min(1.0, t));
+    static const double stops[5] = {0.0, 0.30, 0.60, 0.85, 1.0};
+    static const float rgb[5][3] = {
+        {0.16f, 0.36f, 0.36f}, {0.24f, 0.55f, 0.28f}, {0.72f, 0.68f, 0.40f}, {0.55f, 0.42f, 0.32f}, {0.95f, 0.95f, 0.97f}};
+    int i = 0; while (i < 4 && t > stops[i + 1]) i++;
+    double f = (stops[i + 1] > stops[i]) ? (t - stops[i]) / (stops[i + 1] - stops[i]) : 0.0;
+    return ::vsg::vec4((float)(rgb[i][0] + (rgb[i + 1][0] - rgb[i][0]) * f),
+                       (float)(rgb[i][1] + (rgb[i + 1][1] - rgb[i][1]) * f),
+                       (float)(rgb[i][2] + (rgb[i + 1][2] - rgb[i][2]) * f), 1.0f);
+}
+
+ref_ptr<Node> createTerrainFromPLY(const std::string& path, const Coord& sceneMin, const Coord& sceneMax)
+{
+    std::ifstream in(path, std::ios::binary);
+    if (!in)
+        throw cRuntimeError("sceneModel: cannot open PLY file '%s' (resolved relative to the working directory)", path.c_str());
+
+    // --- header ---
+    std::string line;
+    std::getline(in, line);
+    if (line.rfind("ply", 0) != 0) return Group::create();
+    std::string format;
+    int vertexCount = 0;
+    std::vector<std::pair<std::string, std::string>> props; // (type, name) of the vertex element, in order
+    std::string curElement;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        std::istringstream ss(line);
+        std::string tok; ss >> tok;
+        if (tok == "format") ss >> format;
+        else if (tok == "element") { ss >> curElement; if (curElement == "vertex") ss >> vertexCount; }
+        else if (tok == "property" && curElement == "vertex") {
+            std::string type; ss >> type;
+            if (type == "list") continue; // e.g. face vertex-index lists — not a vertex scalar
+            std::string name; ss >> name;
+            props.emplace_back(type, name);
+        }
+        else if (tok == "end_header") break;
+    }
+    bool ascii = (format.rfind("ascii", 0) == 0);
+    bool binaryLE = (format.rfind("binary_little_endian", 0) == 0);
+    if (vertexCount <= 0 || props.empty() || (!ascii && !binaryLE))
+        return Group::create();
+
+    // locate x/y/z (+ optional r/g/b) by property name; compute byte offsets and column indices
+    int stride = 0, offX = -1, offY = -1, offZ = -1, offR = -1, offG = -1, offB = -1;
+    int idxX = -1, idxY = -1, idxZ = -1, idxR = -1, idxG = -1, idxB = -1;
+    std::string tX, tY, tZ, tR;
+    for (size_t i = 0; i < props.size(); i++) {
+        const std::string& ty = props[i].first;
+        const std::string& n = props[i].second;
+        if (n == "x") { offX = stride; tX = ty; idxX = (int)i; }
+        else if (n == "y") { offY = stride; tY = ty; idxY = (int)i; }
+        else if (n == "z") { offZ = stride; tZ = ty; idxZ = (int)i; }
+        else if (n == "red" || n == "r") { offR = stride; tR = ty; idxR = (int)i; }
+        else if (n == "green" || n == "g") { offG = stride; idxG = (int)i; }
+        else if (n == "blue" || n == "b") { offB = stride; idxB = (int)i; }
+        stride += plyTypeSize(ty);
+    }
+    if (offX < 0 || offY < 0 || offZ < 0) return Group::create();
+    bool hasRGB = (offR >= 0 && offG >= 0 && offB >= 0);
+    double rgbScale = (tR == "uchar" || tR == "uint8") ? 1.0 / 255.0 : 1.0;
+
+    // --- read the vertices ---
+    std::vector<double> xs(vertexCount), ys(vertexCount), zs(vertexCount);
+    std::vector<::vsg::vec4> rgbs(hasRGB ? vertexCount : 0);
+    if (binaryLE) {
+        std::vector<char> buf(stride);
+        for (int i = 0; i < vertexCount; i++) {
+            in.read(buf.data(), stride);
+            if (!in) return Group::create();
+            xs[i] = plyRead(buf.data() + offX, tX); ys[i] = plyRead(buf.data() + offY, tY); zs[i] = plyRead(buf.data() + offZ, tZ);
+            if (hasRGB)
+                rgbs[i] = ::vsg::vec4((float)(plyRead(buf.data() + offR, tR) * rgbScale),
+                                      (float)(plyRead(buf.data() + offG, tR) * rgbScale),
+                                      (float)(plyRead(buf.data() + offB, tR) * rgbScale), 1.0f);
+        }
+    }
+    else { // ascii
+        for (int i = 0; i < vertexCount; i++) {
+            if (!std::getline(in, line)) return Group::create();
+            std::istringstream ss(line);
+            std::vector<double> v; double d; while (ss >> d) v.push_back(d);
+            if ((int)v.size() < (int)props.size()) return Group::create();
+            xs[i] = v[idxX]; ys[i] = v[idxY]; zs[i] = v[idxZ];
+            if (hasRGB) rgbs[i] = ::vsg::vec4((float)(v[idxR] * rgbScale), (float)(v[idxG] * rgbScale), (float)(v[idxB] * rgbScale), 1.0f);
+        }
+    }
+
+    // --- recentre, fit into the scene box (aspect-preserving), colour by elevation if no RGB ---
+    double minX = xs[0], maxX = xs[0], minY = ys[0], maxY = ys[0], minZ = zs[0], maxZ = zs[0];
+    for (int i = 1; i < vertexCount; i++) {
+        minX = std::min(minX, xs[i]); maxX = std::max(maxX, xs[i]);
+        minY = std::min(minY, ys[i]); maxY = std::max(maxY, ys[i]);
+        minZ = std::min(minZ, zs[i]); maxZ = std::max(maxZ, zs[i]);
+    }
+    double cx = (minX + maxX) / 2, cy = (minY + maxY) / 2, dz = (maxZ - minZ);
+    double plyW = maxX - minX, plyH = maxY - minY;
+    double sceneW = sceneMax.x - sceneMin.x, sceneH = sceneMax.y - sceneMin.y;
+    double scale = 1.0;
+    if (plyW > 0 && plyH > 0 && std::isfinite(sceneW) && std::isfinite(sceneH) && sceneW > 0 && sceneH > 0)
+        scale = std::min(sceneW / plyW, sceneH / plyH);
+    double centerX = (std::isfinite(sceneMin.x) && std::isfinite(sceneMax.x)) ? (sceneMin.x + sceneMax.x) / 2 : 0.0;
+    double centerY = (std::isfinite(sceneMin.y) && std::isfinite(sceneMax.y)) ? (sceneMin.y + sceneMax.y) / 2 : 0.0;
+    double baseZ = std::isfinite(sceneMin.z) ? sceneMin.z : 0.0;
+
+    auto vertices = vec3Array::create(vertexCount);
+    auto colors = vec4Array::create(vertexCount);
+    for (int i = 0; i < vertexCount; i++) {
+        vertices->set(i, ::vsg::vec3((float)((xs[i] - cx) * scale + centerX),
+                                     (float)((ys[i] - cy) * scale + centerY),
+                                     (float)((zs[i] - minZ) * scale + baseZ)));
+        colors->set(i, hasRGB ? rgbs[i] : elevationColor(dz > 0 ? (zs[i] - minZ) / dz : 0.0));
+    }
+
+    // --- build the node (fit baked into the vertices, so no transform needed) ---
+    auto stateGroup = StateGroup::create();
+    stateGroup->add(BindGraphicsPipeline::create(getPointCloudPipeline()));
+    auto commands = Commands::create();
+    DataList arrays{vertices, colors};
+    commands->addChild(BindVertexBuffers::create(0, arrays));
+    commands->addChild(Draw::create(vertices->size(), 1, 0, 0));
+    stateGroup->addChild(commands);
+    return stateGroup;
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/inet/visualizer/vsg/util/VsgUtils.cc
+++ b/src/inet/visualizer/vsg/util/VsgUtils.cc
@@ -748,7 +748,9 @@ ref_ptr<Node> createTerrainFromPLY(const std::string& path, const Coord& sceneMi
     // --- header ---
     std::string line;
     std::getline(in, line);
-    if (line.rfind("ply", 0) != 0) return Group::create();
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (line.rfind("ply", 0) != 0)
+        throw cRuntimeError("sceneModel: '%s' is not a PLY file (missing 'ply' magic)", path.c_str());
     std::string format;
     int vertexCount = 0;
     std::vector<std::pair<std::string, std::string>> props; // (type, name) of the vertex element, in order
@@ -769,13 +771,15 @@ ref_ptr<Node> createTerrainFromPLY(const std::string& path, const Coord& sceneMi
     }
     bool ascii = (format.rfind("ascii", 0) == 0);
     bool binaryLE = (format.rfind("binary_little_endian", 0) == 0);
-    if (vertexCount <= 0 || props.empty() || (!ascii && !binaryLE))
-        return Group::create();
+    if (!ascii && !binaryLE)
+        throw cRuntimeError("sceneModel: '%s' has unsupported PLY format '%s' (only ascii and binary_little_endian are supported)", path.c_str(), format.c_str());
+    if (vertexCount <= 0 || props.empty())
+        throw cRuntimeError("sceneModel: '%s' has no readable vertex element", path.c_str());
 
     // locate x/y/z (+ optional r/g/b) by property name; compute byte offsets and column indices
     int stride = 0, offX = -1, offY = -1, offZ = -1, offR = -1, offG = -1, offB = -1;
     int idxX = -1, idxY = -1, idxZ = -1, idxR = -1, idxG = -1, idxB = -1;
-    std::string tX, tY, tZ, tR;
+    std::string tX, tY, tZ, tR, tG, tB;
     for (size_t i = 0; i < props.size(); i++) {
         const std::string& ty = props[i].first;
         const std::string& n = props[i].second;
@@ -783,13 +787,16 @@ ref_ptr<Node> createTerrainFromPLY(const std::string& path, const Coord& sceneMi
         else if (n == "y") { offY = stride; tY = ty; idxY = (int)i; }
         else if (n == "z") { offZ = stride; tZ = ty; idxZ = (int)i; }
         else if (n == "red" || n == "r") { offR = stride; tR = ty; idxR = (int)i; }
-        else if (n == "green" || n == "g") { offG = stride; idxG = (int)i; }
-        else if (n == "blue" || n == "b") { offB = stride; idxB = (int)i; }
+        else if (n == "green" || n == "g") { offG = stride; tG = ty; idxG = (int)i; }
+        else if (n == "blue" || n == "b") { offB = stride; tB = ty; idxB = (int)i; }
         stride += plyTypeSize(ty);
     }
-    if (offX < 0 || offY < 0 || offZ < 0) return Group::create();
+    if (offX < 0 || offY < 0 || offZ < 0)
+        throw cRuntimeError("sceneModel: '%s' has no x/y/z vertex properties", path.c_str());
     bool hasRGB = (offR >= 0 && offG >= 0 && offB >= 0);
-    double rgbScale = (tR == "uchar" || tR == "uint8") ? 1.0 / 255.0 : 1.0;
+    // 8-bit channels are 0..255, float channels 0..1 — normalise each channel by ITS OWN type.
+    auto colScale = [](const std::string& t) { return (t == "uchar" || t == "uint8") ? 1.0 / 255.0 : 1.0; };
+    double scaleR = colScale(tR), scaleG = colScale(tG), scaleB = colScale(tB);
 
     // --- read the vertices ---
     std::vector<double> xs(vertexCount), ys(vertexCount), zs(vertexCount);
@@ -798,22 +805,25 @@ ref_ptr<Node> createTerrainFromPLY(const std::string& path, const Coord& sceneMi
         std::vector<char> buf(stride);
         for (int i = 0; i < vertexCount; i++) {
             in.read(buf.data(), stride);
-            if (!in) return Group::create();
+            if (!in)
+                throw cRuntimeError("sceneModel: '%s' is truncated (expected %d vertices)", path.c_str(), vertexCount);
             xs[i] = plyRead(buf.data() + offX, tX); ys[i] = plyRead(buf.data() + offY, tY); zs[i] = plyRead(buf.data() + offZ, tZ);
             if (hasRGB)
-                rgbs[i] = ::vsg::vec4((float)(plyRead(buf.data() + offR, tR) * rgbScale),
-                                      (float)(plyRead(buf.data() + offG, tR) * rgbScale),
-                                      (float)(plyRead(buf.data() + offB, tR) * rgbScale), 1.0f);
+                rgbs[i] = ::vsg::vec4((float)(plyRead(buf.data() + offR, tR) * scaleR),
+                                      (float)(plyRead(buf.data() + offG, tG) * scaleG),
+                                      (float)(plyRead(buf.data() + offB, tB) * scaleB), 1.0f);
         }
     }
     else { // ascii
         for (int i = 0; i < vertexCount; i++) {
-            if (!std::getline(in, line)) return Group::create();
+            if (!std::getline(in, line))
+                throw cRuntimeError("sceneModel: '%s' is truncated (expected %d vertices)", path.c_str(), vertexCount);
             std::istringstream ss(line);
             std::vector<double> v; double d; while (ss >> d) v.push_back(d);
-            if ((int)v.size() < (int)props.size()) return Group::create();
+            if ((int)v.size() < (int)props.size())
+                throw cRuntimeError("sceneModel: '%s' has a short vertex line (%d values, expected %d)", path.c_str(), (int)v.size(), (int)props.size());
             xs[i] = v[idxX]; ys[i] = v[idxY]; zs[i] = v[idxZ];
-            if (hasRGB) rgbs[i] = ::vsg::vec4((float)(v[idxR] * rgbScale), (float)(v[idxG] * rgbScale), (float)(v[idxB] * rgbScale), 1.0f);
+            if (hasRGB) rgbs[i] = ::vsg::vec4((float)(v[idxR] * scaleR), (float)(v[idxG] * scaleG), (float)(v[idxB] * scaleB), 1.0f);
         }
     }
 

--- a/src/inet/visualizer/vsg/util/VsgUtils.h
+++ b/src/inet/visualizer/vsg/util/VsgUtils.h
@@ -102,6 +102,10 @@ ref_ptr<Node> createWaveRingShader(const Coord& center, double innerRadius, doub
 ref_ptr<Node> createSphereWaveShader(double innerRadius, double outerRadius, const cFigure::Color& color,
         double waveLength, double waveAmplitude, double waveOffset, double fadingFactor, double fadingDistance,
         int shells = 18, int latSegments = 12, int lonSegments = 18);
+// Load a PLY point cloud (ascii or binary_little_endian; any property layout with x/y/z, optional r/g/b)
+// and return it as a coloured POINT_LIST node, recentred and aspect-fit into [sceneMin, sceneMax] and
+// coloured by elevation when the file has no colours. For a LIDAR/terrain "ground". Empty group on failure.
+ref_ptr<Node> createTerrainFromPLY(const std::string& path, const Coord& sceneMin, const Coord& sceneMax);
 ref_ptr<Node> createQuad(const Coord& min, const Coord& max, const cFigure::Color& color, double opacity = 1.0);
 ref_ptr<Node> createPolygon(const std::vector<Coord>& points, const cFigure::Color& color, double opacity = 1.0, const Coord& translation = Coord::ZERO);
 ref_ptr<Node> createArrowhead(const Coord& start, const Coord& end, const cFigure::Color& color, double width = 10.0, double height = 20.0, double opacity = 1.0);


### PR DESCRIPTION
## Summary

Adds a general mechanism to use an **external PLY point cloud (e.g. a LIDAR scan) as the VSG scene ground**, via a new `sceneModel` scene parameter — so simulations can run over real terrain instead of the flat green quad. Follow-up to the VSG signal-visualization work (#1112 → #1113 → #1114).

## What's in it

**`sceneModel` scene parameter** (`SceneVsgVisualizerBase`, mirroring the existing `sceneImage` convention). When set to a PLY path, the scene loads that point cloud as the ground instead of the flat quad; a clear `cRuntimeError` is thrown if the file can't be opened.

**`createTerrainFromPLY`** (`util/VsgUtils`) — parses the PLY directly (no mesh importer), which keeps it general:
- **Any PLY point cloud** — ascii or `binary_little_endian`, any property layout; locates `x`/`y`/`z` (+ optional `red`/`green`/`blue`) by name and skips the rest by declared byte size.
- **Coordinate fit** — recenters the (often huge, projected UTM) coordinates and **aspect-preserving-fits** the cloud into the configured scene bounds, base at `sceneMinZ`. Any PLY at any real-world scale drops into the scene box.
- **Color** — the file's RGB if present, else an **elevation** ramp (teal → green → tan → brown → white), which reads as a heightmap.
- **Rendering** — colored `POINT_LIST` through a small cached custom pipeline (`getPointCloudPipeline`) that sets `gl_PointSize`.

**New example `vsglidar`** — a 5-drone swarm flying over a subsampled USGS Hurricane-Sandy LIDAR tile of New York (`terrain.ply`, buildings included, ~6.5 MiB), exchanging UDP with volumetric shader signal spheres; range indicators off to keep the view clean. Demonstrates the mechanism (works with any `.ply`).

**Docs** — a new "Scene terrain from a point cloud (`sceneModel`)" section in the VSG visualizer README, plus the examples table, limitations, and history updated.

## Testing
- Both changed translation units compile cleanly (release).
- `vsglidar` passes a Cmdenv smoke test (network elaborates, the drone swarm communicates — leader receives 34 packets).
- Loaded and rendered under Qtenv (off-screen VSG 3D view) with no runtime shader/Vulkan/parse errors; the terrain loads at scene init (a bad path throws immediately).

## Notes
- The `terrain.ply` (6.5 MiB) is committed as the example's data — in line with existing INET example/showcase binaries (there's a 7.4 MiB `.mkv`, a 2.6 MiB `.osm`, several 2.5 MiB MP3s).
- Terrain is rendered as points, not a meshed surface; point size relies on `gl_PointSize` (clamps to 1px without the `largePoints` device feature). Both noted in the README limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->