### PR TITLE
visualizer: adopt backend-neutral cScene3DNode (OSG+VSG coexistence)

### DIFF
--- a/.oppfeatures
+++ b/.oppfeatures
@@ -1759,10 +1759,12 @@
         name = "Visualization VSG (3D)"
         description = "Provides network-level 3D visualization features for physical layer,
                        data link layer and network layer communications, and more.
-                       This is the VulkanSceneGraph-based replacement for the OpenSceneGraph
+                       This is the VulkanSceneGraph-based counterpart to the OpenSceneGraph
                        (VisualizationOsg) 3D visualizer; it requires OMNeT++ built with VSG
-                       support (WITH_VSG=yes). VisualizationOsg and VisualizationVsg are
-                       mutually exclusive (OMNeT++ is built with either OSG or VSG, not both)."
+                       support (WITH_VSG=yes). Since OMNeT++'s cScene3DNode became
+                       backend-neutral, VisualizationOsg and VisualizationVsg may be enabled
+                       together (in an OMNeT++ built with both WITH_OSG and WITH_VSG); each
+                       scene renders on the backend its visualizer creates."
         initiallyEnabled = "false"
         requires = "PhysicalEnvironment VisualizationCommon"
         recommended = ""

--- a/src/inet/common/geometry/common/GeographicCoordinateSystem.cc
+++ b/src/inet/common/geometry/common/GeographicCoordinateSystem.cc
@@ -10,6 +10,7 @@
 #if defined(WITH_OSGEARTH) && defined(INET_WITH_VISUALIZATIONOSG)
 #include <osg/PositionAttitudeTransform>
 #include <osgEarth/GeoTransform>
+#include "qtenv/osg/osgscenehandle.h"   // omnetpp::getOsgRoot()
 #endif
 
 namespace inet {
@@ -49,7 +50,7 @@ Define_Module(OsgGeographicCoordinateSystem);
 void OsgGeographicCoordinateSystem::initialize(int stage)
 {
     if (stage == INITSTAGE_LOCAL) {
-        auto mapScene = getParentModule()->getOsgCanvas()->getScene();
+        auto mapScene = omnetpp::getOsgRoot(getParentModule()->getOsgCanvas()->getScene());
         mapNode = osgEarth::MapNode::findMapNode(mapScene);
         if (mapNode == nullptr)
             throw cRuntimeError("Count not find map node in the scene");

--- a/src/inet/visualizer/osg/base/SceneOsgVisualizerBase.cc
+++ b/src/inet/visualizer/osg/base/SceneOsgVisualizerBase.cc
@@ -12,6 +12,8 @@
 #include <osg/ShapeDrawable>
 #include <osgDB/ReadFile>
 
+#include "qtenv/osg/osgscenehandle.h"   // omnetpp::createScene3DNode(osg::Node*)
+
 #include "inet/common/ModuleAccess.h"
 #include "inet/visualizer/osg/scene/NetworkNodeOsgVisualizer.h"
 #include "inet/visualizer/osg/util/OsgScene.h"
@@ -28,7 +30,7 @@ void SceneOsgVisualizerBase::initializeScene()
         throw cRuntimeError("OSG canvas scene at '%s' has been already initialized", visualizationTargetModule->getFullPath().c_str());
     else {
         auto topLevelScene = new inet::osg::TopLevelScene();
-        osgCanvas->setScene(topLevelScene);
+        osgCanvas->setScene(omnetpp::createScene3DNode(topLevelScene));
         const char *clearColor = par("clearColor");
         if (*clearColor != '\0')
             osgCanvas->setClearColor(cFigure::Color(clearColor));

--- a/src/inet/visualizer/osg/common/PacketDropOsgVisualizer.h
+++ b/src/inet/visualizer/osg/common/PacketDropOsgVisualizer.h
@@ -8,6 +8,7 @@
 #ifndef __INET_PACKETDROPOSGVISUALIZER_H
 #define __INET_PACKETDROPOSGVISUALIZER_H
 
+#include <osg/Node>
 #include <osg/ref_ptr>
 
 #include "inet/visualizer/base/PacketDropVisualizerBase.h"

--- a/src/inet/visualizer/osg/linklayer/LinkBreakOsgVisualizer.h
+++ b/src/inet/visualizer/osg/linklayer/LinkBreakOsgVisualizer.h
@@ -8,6 +8,7 @@
 #ifndef __INET_LINKBREAKOSGVISUALIZER_H
 #define __INET_LINKBREAKOSGVISUALIZER_H
 
+#include <osg/Node>
 #include <osg/ref_ptr>
 
 #include "inet/visualizer/base/LinkBreakVisualizerBase.h"

--- a/src/inet/visualizer/osg/networklayer/RoutingTableOsgVisualizer.h
+++ b/src/inet/visualizer/osg/networklayer/RoutingTableOsgVisualizer.h
@@ -8,6 +8,7 @@
 #ifndef __INET_ROUTINGTABLEOSGVISUALIZER_H
 #define __INET_ROUTINGTABLEOSGVISUALIZER_H
 
+#include <osg/Node>
 #include <osg/ref_ptr>
 
 #include "inet/visualizer/base/RoutingTableVisualizerBase.h"

--- a/src/inet/visualizer/osg/scene/SceneOsgEarthVisualizer.cc
+++ b/src/inet/visualizer/osg/scene/SceneOsgEarthVisualizer.cc
@@ -19,6 +19,7 @@
 #include <osgDB/ReadFile>
 #include <osgEarth/Capabilities>
 #include <osgEarth/Viewpoint>
+#include "qtenv/osg/osgscenehandle.h"   // omnetpp::getOsgRoot()
 #endif // ifdef WITH_OSGEARTH
 
 namespace inet {
@@ -62,7 +63,7 @@ void SceneOsgEarthVisualizer::initializeScene()
         throw cRuntimeError("Could not read earth map file '%s'", mapFileString.c_str());
     auto osgCanvas = visualizationTargetModule->getOsgCanvas();
     osgCanvas->setViewerStyle(cOsgCanvas::STYLE_EARTH);
-    auto topLevelScene = check_and_cast<inet::osg::TopLevelScene *>(osgCanvas->getScene());
+    auto topLevelScene = check_and_cast<inet::osg::TopLevelScene *>(omnetpp::getOsgRoot(osgCanvas->getScene()));
     topLevelScene->addChild(mapScene);
     mapNode = MapNode::findMapNode(mapScene);
     if (mapNode == nullptr)

--- a/src/inet/visualizer/osg/scene/SceneOsgVisualizer.cc
+++ b/src/inet/visualizer/osg/scene/SceneOsgVisualizer.cc
@@ -10,6 +10,8 @@
 #include <osg/Group>
 #include <osgDB/ReadFile>
 
+#include "qtenv/osg/osgscenehandle.h"   // omnetpp::getOsgRoot()
+
 #include "inet/common/ModuleAccess.h"
 #include "inet/visualizer/osg/util/OsgScene.h"
 #include "inet/visualizer/osg/util/OsgUtils.h"
@@ -39,7 +41,7 @@ void SceneOsgVisualizer::initialize(int stage)
 void SceneOsgVisualizer::initializeScene()
 {
     SceneOsgVisualizerBase::initializeScene();
-    auto topLevelScene = check_and_cast<inet::osg::TopLevelScene *>(visualizationTargetModule->getOsgCanvas()->getScene());
+    auto topLevelScene = check_and_cast<inet::osg::TopLevelScene *>(omnetpp::getOsgRoot(visualizationTargetModule->getOsgCanvas()->getScene()));
     topLevelScene->addChild(new inet::osg::SimulationScene());
 }
 

--- a/src/inet/visualizer/osg/util/OsgScene.cc
+++ b/src/inet/visualizer/osg/util/OsgScene.cc
@@ -7,6 +7,8 @@
 
 #include "inet/visualizer/osg/util/OsgScene.h"
 
+#include "qtenv/osg/osgscenehandle.h"   // omnetpp::createScene3DNode(osg::Node*), getOsgRoot()
+
 namespace inet {
 
 namespace osg {
@@ -35,7 +37,7 @@ SimulationScene *TopLevelScene::getSimulationScene()
 SimulationScene *TopLevelScene::getSimulationScene(cModule *module)
 {
     auto osgCanvas = module->getOsgCanvas();
-    auto topLevelScene = dynamic_cast<TopLevelScene *>(osgCanvas->getScene());
+    auto topLevelScene = dynamic_cast<TopLevelScene *>(omnetpp::getOsgRoot(osgCanvas->getScene()));
     if (topLevelScene != nullptr)
         return topLevelScene->getSimulationScene();
     else {
@@ -43,7 +45,7 @@ SimulationScene *TopLevelScene::getSimulationScene(cModule *module)
         topLevelScene = new TopLevelScene();
         topLevelScene->addChild(simulationScene);
         // NOTE: these are the default values when there's no SceneOsgVisualizer
-        osgCanvas->setScene(topLevelScene);
+        osgCanvas->setScene(omnetpp::createScene3DNode(topLevelScene));
         osgCanvas->setClearColor(cFigure::Color("#FFFFFF"));
         osgCanvas->setZNear(0.1);
         osgCanvas->setZFar(100000);

--- a/src/inet/visualizer/vsg/README.md
+++ b/src/inet/visualizer/vsg/README.md
@@ -387,16 +387,23 @@ switching to the 3D view, and pressing Run.
 ## Building & running
 
 - Requires a VSG-enabled OMNeT++ build (in this environment: the
-  `omnetpp-dev` checkout, configured/built with VSG support,
-  i.e. `WITH_VSG=yes`).
-- INET side: the `VisualizationVsg` feature (`.oppfeatures`, id
-  `VisualizationVsg`) must be enabled; it compiles with
-  `-DINET_WITH_VISUALIZATIONVSG`, requires the `PhysicalEnvironment` and
-  `VisualizationCommon` features, and is **mutually exclusive** with
-  `VisualizationOsg` — an OMNeT++ build has either OSG or VSG support, never
-  both, so the two visualizer features cannot be enabled simultaneously.
+  `omnetpp-dev` checkout, configured with `WITH_VSG=yes`).
+- **OSG and VSG can now coexist in one build.** Since OMNeT++'s `cScene3DNode`
+  became a backend-neutral handle (omnetpp-dev `topic/VSG`, the
+  "backend-neutral `cScene3DNode`" change), a single OMNeT++ build can contain
+  **both** 3D backends and choose one **per simulation**. To get this,
+  configure OMNeT++ with **both** `WITH_OSG=yes` *and* `WITH_VSG=yes`: the
+  Qtenv loader then builds and loads both `liboppqtenv-osg` and
+  `liboppqtenv-vsg` and selects the matching one per `cOsgCanvas` (via
+  `cScene3DNode::getBackendType()`). Building with only one backend still works.
+- INET side: enable the `VisualizationVsg` feature (`.oppfeatures`; compiles
+  with `-DINET_WITH_VISUALIZATIONVSG`; requires `PhysicalEnvironment` and
+  `VisualizationCommon`). `VisualizationOsg` **may be enabled at the same
+  time** — a scene renders on whichever backend its visualizer creates. (An
+  earlier revision of this doc said the two were mutually exclusive; that was
+  true only before the backend-neutral `cScene3DNode` change.)
 - Build with `make MODE=release` (from the INET root, after
-  `opp_featuretool` / configure has enabled `VisualizationVsg`).
+  `opp_featuretool` / configure has enabled the desired feature(s)).
 - Run an example with `inet -u Qtenv` from its directory (e.g.
   `examples/visualizer/vsgsignalwave3d`), then switch to the 3D view in the
   Qtenv toolbar and press Run.

--- a/src/inet/visualizer/vsg/scene/SceneVsgVisualizer.cc
+++ b/src/inet/visualizer/vsg/scene/SceneVsgVisualizer.cc
@@ -39,7 +39,7 @@ void SceneVsgVisualizer::initializeScene()
 {
     SceneVsgVisualizerBase::initializeScene();
     auto sceneNode = visualizationTargetModule->getOsgCanvas()->getScene();
-    auto topLevelScene = sceneNode != nullptr ? dynamic_cast<inet::vsg::TopLevelScene *>(sceneNode->getRoot().get()) : nullptr;
+    auto topLevelScene = dynamic_cast<inet::vsg::TopLevelScene *>(omnetpp::getVsgRoot(sceneNode).get());
     if (topLevelScene == nullptr)
         throw cRuntimeError("Cannot find the VSG top level scene");
     topLevelScene->addChild(inet::vsg::SimulationScene::create());

--- a/src/inet/visualizer/vsg/util/VsgScene.cc
+++ b/src/inet/visualizer/vsg/util/VsgScene.cc
@@ -31,7 +31,7 @@ SimulationScene *TopLevelScene::getSimulationScene(cModule *module)
     // Under WITH_VSG the cOsgCanvas scene is an opaque omnetpp::cScene3DNode that
     // wraps the VSG scene-root group; recover our TopLevelScene from its root.
     auto sceneNode = osgCanvas->getScene();
-    ::vsg::ref_ptr<Group> root = sceneNode != nullptr ? sceneNode->getRoot() : ::vsg::ref_ptr<Group>();
+    ::vsg::ref_ptr<Group> root = omnetpp::getVsgRoot(sceneNode);   // null / wrong-backend safe
     auto topLevelScene = root ? dynamic_cast<TopLevelScene *>(root.get()) : nullptr;
     if (topLevelScene != nullptr)
         return topLevelScene->getSimulationScene();

--- a/src/makefrag
+++ b/src/makefrag
@@ -60,6 +60,11 @@ endif
 WITH_VISUALIZATIONOSG := $(shell (cd .. && $(FEATURETOOL) -q isenabled VisualizationOsg && echo enabled) )
 ifeq ($(WITH_VISUALIZATIONOSG), enabled)
   ifeq ($(WITH_OSG), yes)
+    # -I$(OMNETPP_ROOT)/src gives access to the plugin's qtenv/osg/osgscenehandle.h
+    # (createScene3DNode / getOsgRoot / cScene3DNode), needed by the OSG scene
+    # visualizers now that cScene3DNode is backend-neutral. Mirrors the
+    # VisualizationVsg block below; required for OSG-only builds (VSG disabled).
+    CFLAGS += -I$(OMNETPP_ROOT)/src
     OMNETPP_LIBS += -losg -losgText -losgDB -losgGA -losgViewer -losgUtil -lOpenThreads # TODO: use $(OSG_LIBS) from Makefile.inc? Does that include -losgText? Why not?
     ifeq ($(WITH_OSGEARTH), yes)
       OMNETPP_LIBS += -losgEarth -losgEarthUtil # TODO: use $(OSGEARTH_LIBS) from Makefile.inc? -lgeos_c might also be needed. Is that included? Should it be?


### PR DESCRIPTION
## What

Companion to omnetpp/omnetpp-dev `topic/VSG` (backend-neutral `cScene3DNode`, PR omnetpp/omnetpp-dev#5). Updates INET's OSG and VSG visualizers to the renderer-neutral scene-handle API so INET builds and runs against an OMNeT++ that contains **both** 3-D backends, with the renderer chosen per simulation.

## How

- Wrap OSG scene roots with `omnetpp::createScene3DNode()` when calling `cOsgCanvas::setScene()`.
- Recover the typed root via `getOsgRoot()` / `getVsgRoot()` instead of casting `cScene3DNode` directly to a scene-graph type.
- Updated both visualizer trees:
  - OSG: `SceneOsgVisualizer`, `SceneOsgEarthVisualizer`, `SceneOsgVisualizerBase`, `OsgScene`, `GeographicCoordinateSystem`
  - VSG: `SceneVsgVisualizer`, `VsgScene`

## Verified

Built against an OMNeT++ with both backends. From the same build: INET OSG showcase (`showcases/visualizer/osg/networknode`, `oppqtenv-osg`) and VSG showcases (`vsgsignal`, `vsgsignal3d`, `vsglidar`, `vsgsignalwave`, `oppqtenv-vsg`) each render on the correct backend.

Requires the omnetpp-dev `topic/VSG` change (PR omnetpp/omnetpp-dev#5) to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->