### PR TITLE
visualizer/osg: fix build against omnetpp topic/VSG (osg::Node fwd-decl removed from cenvir.h)

### DIFF
--- a/src/inet/visualizer/osg/common/PacketDropOsgVisualizer.h
+++ b/src/inet/visualizer/osg/common/PacketDropOsgVisualizer.h
@@ -8,6 +8,7 @@
 #ifndef __INET_PACKETDROPOSGVISUALIZER_H
 #define __INET_PACKETDROPOSGVISUALIZER_H
 
+#include <osg/Node>
 #include <osg/ref_ptr>
 
 #include "inet/visualizer/base/PacketDropVisualizerBase.h"

--- a/src/inet/visualizer/osg/linklayer/LinkBreakOsgVisualizer.h
+++ b/src/inet/visualizer/osg/linklayer/LinkBreakOsgVisualizer.h
@@ -8,6 +8,7 @@
 #ifndef __INET_LINKBREAKOSGVISUALIZER_H
 #define __INET_LINKBREAKOSGVISUALIZER_H
 
+#include <osg/Node>
 #include <osg/ref_ptr>
 
 #include "inet/visualizer/base/LinkBreakVisualizerBase.h"

--- a/src/inet/visualizer/osg/networklayer/RoutingTableOsgVisualizer.h
+++ b/src/inet/visualizer/osg/networklayer/RoutingTableOsgVisualizer.h
@@ -8,6 +8,7 @@
 #ifndef __INET_ROUTINGTABLEOSGVISUALIZER_H
 #define __INET_ROUTINGTABLEOSGVISUALIZER_H
 
+#include <osg/Node>
 #include <osg/ref_ptr>
 
 #include "inet/visualizer/base/RoutingTableVisualizerBase.h"


### PR DESCRIPTION
## Problem

After updating omnetpp-dev `topic/VSG` to include commit `fc5a453385` ("remove the dead refOsgNode/unrefOsgNode ref-counting chain"), every INET 3D example died at startup with

```
Bus error: 10  ... in inet::SharedDataManager::getInstance()
```

and a clean rebuild of INET failed to compile.

## Root cause

omnetpp commit `fc5a453385` removed two things from `include/omnetpp/cenvir.h`:

1. the `namespace osg { class Node; }` forward declaration, and
2. the two `refOsgNode`/`unrefOsgNode` pure virtuals of `cEnvir`.

(1) breaks compilation: `PacketDropOsgVisualizer.h`, `LinkBreakOsgVisualizer.h` and `RoutingTableOsgVisualizer.h` use `osg::Node` but include only `<osg/ref_ptr>`; they got the declaration transitively from `<omnetpp.h>`.

(2) breaks ABI: the `cEnvir` vtable layout changed, so a stale `libINET.dylib` built against the old headers crashes at load time — the first virtual call through `cEnvir` (`getEnvir()->addLifecycleListener(...)` in `SharedDataManager::getInstance()`, run via `EXECUTE_ON_STARTUP`) lands on the wrong vtable slot, hence the SIGBUS. A full rebuild is required either way; this PR is what makes that rebuild succeed.

## Fix

Add the missing `#include <osg/Node>` to the three headers, matching the sibling OSG visualizer headers (e.g. `StatisticOsgVisualizer.h`).

## Testing

Against omnetpp-dev `topic/VSG` @ `581f7d0f84` (macOS, clang, MODE=release):

- full INET rebuild succeeds (previously 7 compile errors in the three files);
- all 6 `examples/visualizer` 3D examples (vsgsmoketest, vsgicons, vsgsignal, vsgsignalwave3d, vsgwireless, vsglidar) now load `oppqtenv-vsg` and open their Qtenv window (previously all SIGBUSed at startup);
- headless physics regression in `examples/visualizer/vsglidar` passes: `TerrainTwoRay` and `TerrainOcclusion` run to `--sim-time-limit=60s` with plausible `packetReceived:count` values (occlusion reduces reception as expected).

Note: an unrelated runtime segfault remains when *running* dynamic-scene examples (crash in `vsg::RecordTraversal::apply(Commands)`); it bisects to omnetpp `topic/VSG` commit `1851edcddb` (compile-skip via address-sum scene signature) and needs an omnetpp-side fix — reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->