### PR TITLE
ieee80211: make rate control adapt per receiver, add per-receiver configured rates

### DIFF
--- a/WHATSNEW
+++ b/WHATSNEW
@@ -1,6 +1,62 @@
 Recent changes in the INET Framework
 ====================================
 
+INET-4.7.x (in development)
+---------------------------
+
+Notable backward incompatible changes are the following:
+
+1. IEEE 802.11 rate control per receiver
+
+   IEEE 802.11 rate control now selects and adapts the transmission rate
+   separately for each peer a station transmits to. The rate controls previously
+   kept a single set of adaptive state per module, so the feedback of all peers
+   was blended into one rate.
+
+   To make this possible, the getRate() method of the IRateControl C++ interface,
+   implemented by AarfRateControl and OnoeRateControl, now takes the MAC address
+   of the receiver. This change requires the modification of rate control models
+   implemented outside INET, which no longer compile until their getRate() is
+   given the new argument. Simulation models that only configure a rate control
+   are unaffected.
+
+   Rate selection no longer consults the rate control for group-addressed frames,
+   which are never acknowledged and so could never have their rate corrected by
+   feedback. They now take a mandatory rate, as they already did when no rate
+   control was configured.
+
+   These changes may change the statistical results of simulations that use an
+   adaptive rate control, either where a station transmits to several peers or
+   where it sends group-addressed traffic.
+
+Notable backward compatible changes are the following:
+
+1. IEEE 802.11 per-station rate statistics
+
+   The datarateChanged signal of the rate controls is now emitted with the name of
+   the receiving station as a named details object, and a new dataratePerStation
+   statistic demultiplexes it into one data rate vector per peer. The
+   datarateSelected signal of Dcf and Hcf is tagged the same way, which also covers
+   fixed and configured rates. The declaration of the aggregate datarateChanged
+   statistic is unchanged and it still ignores the details, but the values it
+   records move: the rate control no longer reports a rate when the mode set
+   changes, and reports one per station when that station is first seen instead.
+
+2. IEEE 802.11 per-receiver configured data frame rates
+
+   RateSelection and QosRateSelection gained a dataFrameBitratePerReceiver
+   parameter, a map from peer interface module path to bitrate, which fixes the
+   rate of originated unicast data frames separately for each peer. It is empty by
+   default, so it changes nothing unless it is configured. The dataFrameBitrate
+   parameter, which fixes one rate for the whole interface, is unchanged.
+
+3. Naming the host owning a MAC address
+
+   A new L3AddressResolver::getHostNameWithMacAddress() method names the host that
+   owns a MAC address, by the host's path relative to the network, and falls back
+   to the MAC address string when no host owns the address.
+
+
 INET-4.7 (July 2026) — feature release
 --------------------------------------
 

--- a/src/inet/linklayer/ieee80211/mac/contract/IRateControl.h
+++ b/src/inet/linklayer/ieee80211/mac/contract/IRateControl.h
@@ -9,6 +9,7 @@
 #define __INET_IRATECONTROL_H
 
 #include "inet/common/packet/Packet.h"
+#include "inet/linklayer/common/MacAddress.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211ControlInfo_m.h"
@@ -25,7 +26,8 @@ class INET_API IRateControl
   public:
     virtual ~IRateControl() {}
 
-    virtual const physicallayer::IIeee80211Mode *getRate() = 0;
+    // Returns the rate to use for a unicast frame addressed to the given receiver.
+    virtual const physicallayer::IIeee80211Mode *getRate(const MacAddress& receiverAddress) = 0;
     virtual void frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp) = 0;
     virtual void frameReceived(Packet *frame) = 0;
 };

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
@@ -102,7 +102,7 @@ void Dcf::transmitControlResponseFrame(Packet *responsePacket, const Ptr<const I
     else
         throw cRuntimeError("Unknown received frame type");
     RateSelection::setFrameMode(responsePacket, responseHeader, responseMode);
-    emit(IRateSelection::datarateSelectedSignal, responseMode->getDataMode()->getNetBitrate().get<bps>(), responsePacket);
+    RateSelection::emitDatarateSelected(this, responseHeader, responseMode);
     EV_DEBUG << "Datarate for " << responsePacket->getName() << " is set to " << responseMode->getDataMode()->getNetBitrate() << ".\n";
     tx->transmitFrame(responsePacket, responseHeader, modeSet->getSifsTime(), this);
     delete responsePacket;
@@ -166,7 +166,7 @@ void Dcf::transmitFrame(Packet *packet, simtime_t ifs)
     const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
     auto mode = rateSelection->computeMode(packet, header);
     RateSelection::setFrameMode(packet, header, mode);
-    emit(IRateSelection::datarateSelectedSignal, mode->getDataMode()->getNetBitrate().get<bps>(), packet);
+    RateSelection::emitDatarateSelected(this, header, mode);
     EV_DEBUG << "Datarate for " << packet->getName() << " is set to " << mode->getDataMode()->getNetBitrate() << ".\n";
     auto pendingPacket = channelAccess->getInProgressFrames()->getPendingFrameFor(packet);
     auto duration = originatorProtectionMechanism->computeDurationField(packet, header, pendingPacket, pendingPacket == nullptr ? nullptr : pendingPacket->peekAtFront<Ieee80211DataOrMgmtHeader>());

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -13,6 +13,7 @@
 #include "inet/linklayer/ieee80211/mac/blockack/OriginatorBlockAckProcedure.h"
 #include "inet/linklayer/ieee80211/mac/blockack/RecipientBlockAckAgreementHandler.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/HcfFs.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
 #include "inet/linklayer/ieee80211/mac/recipient/RecipientAckProcedure.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
@@ -668,7 +669,7 @@ void Hcf::transmitFrame(Packet *packet, simtime_t ifs)
         }
         auto mode = rateSelection->computeMode(packet, header, txop);
         setFrameMode(packet, header, mode);
-        emit(IRateSelection::datarateSelectedSignal, mode->getDataMode()->getNetBitrate().get<bps>(), packet);
+        RateSelection::emitDatarateSelected(this, header, mode);
         EV_DEBUG << "Datarate for " << packet->getName() << " is set to " << mode->getDataMode()->getNetBitrate() << ".\n";
         if (txop->getProtectionMechanism() == TxopProcedure::ProtectionMechanism::SINGLE_PROTECTION) {
             auto pendingPacket = channelOwner->getInProgressFrames()->getPendingFrameFor(packet);
@@ -703,7 +704,7 @@ void Hcf::transmitControlResponseFrame(Packet *responsePacket, const Ptr<const I
     else
         throw cRuntimeError("Unknown received frame type");
     setFrameMode(responsePacket, responseHeader, responseMode);
-    emit(IRateSelection::datarateSelectedSignal, responseMode->getDataMode()->getNetBitrate().get<bps>(), responsePacket);
+    RateSelection::emitDatarateSelected(this, responseHeader, responseMode);
     EV_DEBUG << "Datarate for " << responsePacket->getName() << " is set to " << responseMode->getDataMode()->getNetBitrate() << ".\n";
     tx->transmitFrame(responsePacket, responseHeader, modeSet->getSifsTime(), this);
     delete responsePacket;

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.cc
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.cc
@@ -19,18 +19,14 @@ void AarfRateControl::initialize(int stage)
     RateControlBase::initialize(stage);
     if (stage == INITSTAGE_LOCAL) {
         factor = par("increaseThresholdFactor");
-        increaseThreshold = par("increaseThreshold");
         maxIncreaseThreshold = par("maxIncreaseThreshold");
         decreaseThreshold = par("decreaseThreshold");
         interval = par("interval");
+        WATCH_EXPR("numStations", (int)stations.size());
         WATCH(factor);
-        WATCH(increaseThreshold);
         WATCH(maxIncreaseThreshold);
         WATCH(decreaseThreshold);
         WATCH(interval);
-        WATCH(timer);
-        WATCH(probing);
-        WATCH(numberOfConsSuccTransmissions);
     }
     else if (stage == INITSTAGE_LINK_LAYER) {
     }
@@ -41,66 +37,80 @@ void AarfRateControl::handleMessage(cMessage *msg)
     throw cRuntimeError("This module doesn't handle self messages");
 }
 
+AarfRateControl::State& AarfRateControl::getState(const MacAddress& receiverAddress)
+{
+    auto it = stations.find(receiverAddress);
+    if (it == stations.end()) {
+        State state;
+        state.address = receiverAddress;
+        state.mode = getInitialMode();
+        state.increaseThreshold = par("increaseThreshold");
+        state.timer = simTime(); // the interval starts when the station is first seen, not at t=0
+        it = stations.insert({receiverAddress, state}).first;
+        emitDatarateChangedSignal(state.address, state.mode);
+    }
+    return it->second;
+}
+
 void AarfRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp)
 {
-    MacAddress receiverAddress = getReceiverAddress(frame);
-    increaseRateIfTimerIsExpired(receiverAddress);
+    State& state = getState(getReceiverAddress(frame));
+    increaseRateIfTimerIsExpired(state);
 
-    if (!isSuccessful && probing) { // probing packet failed
-        numberOfConsSuccTransmissions = 0;
-        currentMode = decreaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal(receiverAddress, currentMode);
-        EV_DETAIL << "Decreased rate to " << *currentMode << endl;
-        multiplyIncreaseThreshold(factor);
-        resetTimer();
+    if (!isSuccessful && state.probing) { // probing packet failed
+        state.numberOfConsSuccTransmissions = 0;
+        state.mode = decreaseRateIfPossible(state.mode);
+        emitDatarateChangedSignal(state.address, state.mode);
+        EV_DETAIL << "Decreased rate to " << *state.mode << endl;
+        multiplyIncreaseThreshold(state, factor);
+        resetTimer(state);
     }
     else if (!isSuccessful && retryCount >= decreaseThreshold - 1) { // decreaseThreshold consecutive failed transmissions
-        numberOfConsSuccTransmissions = 0;
-        currentMode = decreaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal(receiverAddress, currentMode);
-        EV_DETAIL << "Decreased rate to " << *currentMode << endl;
-        resetIncreaseThreshdold();
-        resetTimer();
+        state.numberOfConsSuccTransmissions = 0;
+        state.mode = decreaseRateIfPossible(state.mode);
+        emitDatarateChangedSignal(state.address, state.mode);
+        EV_DETAIL << "Decreased rate to " << *state.mode << endl;
+        resetIncreaseThreshdold(state);
+        resetTimer(state);
     }
     else if (isSuccessful && retryCount == 0)
-        numberOfConsSuccTransmissions++;
+        state.numberOfConsSuccTransmissions++;
 
-    if (numberOfConsSuccTransmissions == increaseThreshold) {
-        numberOfConsSuccTransmissions = 0;
-        currentMode = increaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal(receiverAddress, currentMode);
-        EV_DETAIL << "Increased rate to " << *currentMode << endl;
-        resetTimer();
-        probing = true;
+    if (state.numberOfConsSuccTransmissions == state.increaseThreshold) {
+        state.numberOfConsSuccTransmissions = 0;
+        state.mode = increaseRateIfPossible(state.mode);
+        emitDatarateChangedSignal(state.address, state.mode);
+        EV_DETAIL << "Increased rate to " << *state.mode << endl;
+        resetTimer(state);
+        state.probing = true;
     }
     else
-        probing = false;
-
+        state.probing = false;
 }
 
-void AarfRateControl::multiplyIncreaseThreshold(double factor)
+void AarfRateControl::multiplyIncreaseThreshold(State& state, double factor)
 {
-    if (increaseThreshold * factor <= maxIncreaseThreshold)
-        increaseThreshold *= factor;
+    if (state.increaseThreshold * factor <= maxIncreaseThreshold)
+        state.increaseThreshold *= factor;
 }
 
-void AarfRateControl::resetIncreaseThreshdold()
+void AarfRateControl::resetIncreaseThreshdold(State& state)
 {
-    increaseThreshold = par("increaseThreshold");
+    state.increaseThreshold = par("increaseThreshold");
 }
 
-void AarfRateControl::resetTimer()
+void AarfRateControl::resetTimer(State& state)
 {
-    timer = simTime();
+    state.timer = simTime();
 }
 
-void AarfRateControl::increaseRateIfTimerIsExpired(const MacAddress& receiverAddress)
+void AarfRateControl::increaseRateIfTimerIsExpired(State& state)
 {
-    if (simTime() - timer >= interval) {
-        currentMode = increaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal(receiverAddress, currentMode);
-        EV_DETAIL << "Increased rate to " << *currentMode << endl;
-        resetTimer();
+    if (simTime() - state.timer >= interval) {
+        state.mode = increaseRateIfPossible(state.mode);
+        emitDatarateChangedSignal(state.address, state.mode);
+        EV_DETAIL << "Increased rate to " << *state.mode << endl;
+        resetTimer(state);
     }
 }
 
@@ -111,9 +121,10 @@ void AarfRateControl::frameReceived(Packet *frame)
 const IIeee80211Mode *AarfRateControl::getRate(const MacAddress& receiverAddress)
 {
     Enter_Method("getRate");
-    increaseRateIfTimerIsExpired(receiverAddress);
-    EV_INFO << "The current mode is " << currentMode << " the net bitrate is " << currentMode->getDataMode()->getNetBitrate() << std::endl;
-    return currentMode;
+    State& state = getState(receiverAddress);
+    increaseRateIfTimerIsExpired(state);
+    EV_INFO << "The current mode is " << state.mode << " the net bitrate is " << state.mode->getDataMode()->getNetBitrate() << std::endl;
+    return state.mode;
 }
 
 } /* namespace ieee80211 */

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.cc
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.cc
@@ -43,12 +43,13 @@ void AarfRateControl::handleMessage(cMessage *msg)
 
 void AarfRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp)
 {
-    increaseRateIfTimerIsExpired();
+    MacAddress receiverAddress = getReceiverAddress(frame);
+    increaseRateIfTimerIsExpired(receiverAddress);
 
     if (!isSuccessful && probing) { // probing packet failed
         numberOfConsSuccTransmissions = 0;
         currentMode = decreaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal();
+        emitDatarateChangedSignal(receiverAddress, currentMode);
         EV_DETAIL << "Decreased rate to " << *currentMode << endl;
         multiplyIncreaseThreshold(factor);
         resetTimer();
@@ -56,7 +57,7 @@ void AarfRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuc
     else if (!isSuccessful && retryCount >= decreaseThreshold - 1) { // decreaseThreshold consecutive failed transmissions
         numberOfConsSuccTransmissions = 0;
         currentMode = decreaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal();
+        emitDatarateChangedSignal(receiverAddress, currentMode);
         EV_DETAIL << "Decreased rate to " << *currentMode << endl;
         resetIncreaseThreshdold();
         resetTimer();
@@ -67,7 +68,7 @@ void AarfRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuc
     if (numberOfConsSuccTransmissions == increaseThreshold) {
         numberOfConsSuccTransmissions = 0;
         currentMode = increaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal();
+        emitDatarateChangedSignal(receiverAddress, currentMode);
         EV_DETAIL << "Increased rate to " << *currentMode << endl;
         resetTimer();
         probing = true;
@@ -93,11 +94,11 @@ void AarfRateControl::resetTimer()
     timer = simTime();
 }
 
-void AarfRateControl::increaseRateIfTimerIsExpired()
+void AarfRateControl::increaseRateIfTimerIsExpired(const MacAddress& receiverAddress)
 {
     if (simTime() - timer >= interval) {
         currentMode = increaseRateIfPossible(currentMode);
-        emitDatarateChangedSignal();
+        emitDatarateChangedSignal(receiverAddress, currentMode);
         EV_DETAIL << "Increased rate to " << *currentMode << endl;
         resetTimer();
     }
@@ -107,10 +108,10 @@ void AarfRateControl::frameReceived(Packet *frame)
 {
 }
 
-const IIeee80211Mode *AarfRateControl::getRate()
+const IIeee80211Mode *AarfRateControl::getRate(const MacAddress& receiverAddress)
 {
     Enter_Method("getRate");
-    increaseRateIfTimerIsExpired();
+    increaseRateIfTimerIsExpired(receiverAddress);
     EV_INFO << "The current mode is " << currentMode << " the net bitrate is " << currentMode->getDataMode()->getNetBitrate() << std::endl;
     return currentMode;
 }

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.h
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.h
@@ -19,25 +19,35 @@ namespace ieee80211 {
 class INET_API AarfRateControl : public RateControlBase
 {
   protected:
-    simtime_t timer = SIMTIME_ZERO;
+    // Per-receiver adaptive state (formerly single-instance module members).
+    struct State {
+        MacAddress address; // the receiver this state belongs to (for per-station rate attribution)
+        const physicallayer::IIeee80211Mode *mode = nullptr;
+        simtime_t timer = SIMTIME_ZERO;
+        bool probing = false;
+        int increaseThreshold = -1;
+        int numberOfConsSuccTransmissions = 0;
+    };
+    std::map<MacAddress, State> stations;
+
+    // configuration, shared across stations
     simtime_t interval = SIMTIME_ZERO;
-    bool probing = false;
-    int increaseThreshold = -1;
     int maxIncreaseThreshold = -1;
     int decreaseThreshold = -1;
     double factor = -1;
-
-    int numberOfConsSuccTransmissions = 0;
 
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
     virtual void handleMessage(cMessage *msg) override;
 
-    virtual void multiplyIncreaseThreshold(double factor);
-    virtual void resetIncreaseThreshdold();
-    virtual void resetTimer();
-    virtual void increaseRateIfTimerIsExpired(const MacAddress& receiverAddress);
+    virtual State& getState(const MacAddress& receiverAddress);
+    virtual void resetRateControl() override { stations.clear(); }
+
+    virtual void multiplyIncreaseThreshold(State& state, double factor);
+    virtual void resetIncreaseThreshdold(State& state);
+    virtual void resetTimer(State& state);
+    virtual void increaseRateIfTimerIsExpired(State& state);
 
   public:
     virtual const physicallayer::IIeee80211Mode *getRate(const MacAddress& receiverAddress) override;

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.h
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.h
@@ -37,10 +37,10 @@ class INET_API AarfRateControl : public RateControlBase
     virtual void multiplyIncreaseThreshold(double factor);
     virtual void resetIncreaseThreshdold();
     virtual void resetTimer();
-    virtual void increaseRateIfTimerIsExpired();
+    virtual void increaseRateIfTimerIsExpired(const MacAddress& receiverAddress);
 
   public:
-    virtual const physicallayer::IIeee80211Mode *getRate() override;
+    virtual const physicallayer::IIeee80211Mode *getRate(const MacAddress& receiverAddress) override;
     virtual void frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp) override;
     virtual void frameReceived(Packet *frame) override;
 };

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.ned
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.ned
@@ -26,7 +26,7 @@ simple AarfRateControl extends SimpleModule like IRateControl
                                             // needed to increase the rate
         double increaseThresholdFactor = default(2); // When the transmission of the probing packet fails, increaseThreshold is multiplied by increaseThresholdFactor.
         int maxIncreaseThreshold = default(50); // Upper bound for increaseThreshold.
-        displayStringTextFormat = default("{currentMode}");
+        displayStringTextFormat = default("{numStations} stations");
         @display("i=block/cogwheel");
         @signal[datarateChanged];
         @statistic[datarateChanged](title="datarate"; record=vector; interpolationmode=sample-hold); // aggregate rate over all stations (interleaved)

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.ned
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.ned
@@ -29,6 +29,7 @@ simple AarfRateControl extends SimpleModule like IRateControl
         displayStringTextFormat = default("{currentMode}");
         @display("i=block/cogwheel");
         @signal[datarateChanged];
-        @statistic[datarateChanged](title="datarate"; record=vector; interpolationmode=sample-hold);
+        @statistic[datarateChanged](title="datarate"; record=vector; interpolationmode=sample-hold); // aggregate rate over all stations (interleaved)
+        @statistic[dataratePerStation](title="data rate per station"; source=demux(datarateChanged); unit=bps; record=vector; interpolationmode=sample-hold); // one vector per receiver, demultiplexed by station
 }
 

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.cc
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.cc
@@ -42,7 +42,7 @@ void OnoeRateControl::handleMessage(cMessage *msg)
 
 void OnoeRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp)
 {
-    computeModeIfTimerIsExpired();
+    computeModeIfTimerIsExpired(getReceiverAddress(frame));
     if (isSuccessful)
         numOfSuccTransmissions++;
     else if (isGivenUp)
@@ -51,10 +51,10 @@ void OnoeRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuc
         numOfRetries++;
 }
 
-void OnoeRateControl::computeModeIfTimerIsExpired()
+void OnoeRateControl::computeModeIfTimerIsExpired(const MacAddress& receiverAddress)
 {
     if (simTime() - timer >= interval) {
-        computeMode();
+        computeMode(receiverAddress);
         timer = simTime();
     }
 }
@@ -63,7 +63,7 @@ void OnoeRateControl::frameReceived(Packet *frame)
 {
 }
 
-void OnoeRateControl::computeMode()
+void OnoeRateControl::computeMode(const MacAddress& receiverAddress)
 {
     int numOfFrameTransmitted = numOfSuccTransmissions + numOfGivenUpTransmissions + numOfRetries;
     avgRetriesPerFrame = double(numOfRetries) / (numOfSuccTransmissions + numOfGivenUpTransmissions);
@@ -71,7 +71,7 @@ void OnoeRateControl::computeMode()
     if (numOfSuccTransmissions > 0) {
         if (numOfFrameTransmitted >= 10 && avgRetriesPerFrame > 1) {
             currentMode = decreaseRateIfPossible(currentMode);
-            emitDatarateChangedSignal();
+            emitDatarateChangedSignal(receiverAddress, currentMode);
             EV_DETAIL << "Decreased rate to " << *currentMode << endl;
             credit = 0;
         }
@@ -82,7 +82,7 @@ void OnoeRateControl::computeMode()
 
         if (credit >= 10) {
             currentMode = increaseRateIfPossible(currentMode);
-            emitDatarateChangedSignal();
+            emitDatarateChangedSignal(receiverAddress, currentMode);
             EV_DETAIL << "Increased rate to " << *currentMode << endl;
             credit = 0;
         }
@@ -91,10 +91,10 @@ void OnoeRateControl::computeMode()
     }
 }
 
-const IIeee80211Mode *OnoeRateControl::getRate()
+const IIeee80211Mode *OnoeRateControl::getRate(const MacAddress& receiverAddress)
 {
     Enter_Method("getRate");
-    computeModeIfTimerIsExpired();
+    computeModeIfTimerIsExpired(receiverAddress);
     EV_INFO << "The current mode is " << currentMode << " the net bitrate is " << currentMode->getDataMode()->getNetBitrate() << std::endl;
     return currentMode;
 }

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.cc
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.cc
@@ -19,20 +19,29 @@ void OnoeRateControl::initialize(int stage)
     RateControlBase::initialize(stage);
     if (stage == INITSTAGE_LOCAL) {
         interval = par("interval");
-        WATCH(timer);
-        WATCH(numOfRetries);
-        WATCH(credit);
-        WATCH(numOfSuccTransmissions);
-        WATCH(numOfGivenUpTransmissions);
-        WATCH(avgRetriesPerFrame);
+        WATCH_EXPR("numStations", (int)stations.size());
     }
 }
 
-void OnoeRateControl::resetStatisticalVariables()
+OnoeRateControl::State& OnoeRateControl::getState(const MacAddress& receiverAddress)
 {
-    numOfRetries = 0;
-    numOfSuccTransmissions = 0;
-    numOfGivenUpTransmissions = 0;
+    auto it = stations.find(receiverAddress);
+    if (it == stations.end()) {
+        State state;
+        state.address = receiverAddress;
+        state.mode = getInitialMode();
+        state.timer = simTime(); // the interval starts when the station is first seen, not at t=0
+        it = stations.insert({receiverAddress, state}).first;
+        emitDatarateChangedSignal(state.address, state.mode);
+    }
+    return it->second;
+}
+
+void OnoeRateControl::resetStatisticalVariables(State& state)
+{
+    state.numOfRetries = 0;
+    state.numOfSuccTransmissions = 0;
+    state.numOfGivenUpTransmissions = 0;
 }
 
 void OnoeRateControl::handleMessage(cMessage *msg)
@@ -42,20 +51,21 @@ void OnoeRateControl::handleMessage(cMessage *msg)
 
 void OnoeRateControl::frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp)
 {
-    computeModeIfTimerIsExpired(getReceiverAddress(frame));
+    State& state = getState(getReceiverAddress(frame));
+    computeModeIfTimerIsExpired(state);
     if (isSuccessful)
-        numOfSuccTransmissions++;
+        state.numOfSuccTransmissions++;
     else if (isGivenUp)
-        numOfGivenUpTransmissions++;
+        state.numOfGivenUpTransmissions++;
     if (retryCount > 0)
-        numOfRetries++;
+        state.numOfRetries++;
 }
 
-void OnoeRateControl::computeModeIfTimerIsExpired(const MacAddress& receiverAddress)
+void OnoeRateControl::computeModeIfTimerIsExpired(State& state)
 {
-    if (simTime() - timer >= interval) {
-        computeMode(receiverAddress);
-        timer = simTime();
+    if (simTime() - state.timer >= interval) {
+        computeMode(state);
+        state.timer = simTime();
     }
 }
 
@@ -63,40 +73,41 @@ void OnoeRateControl::frameReceived(Packet *frame)
 {
 }
 
-void OnoeRateControl::computeMode(const MacAddress& receiverAddress)
+void OnoeRateControl::computeMode(State& state)
 {
-    int numOfFrameTransmitted = numOfSuccTransmissions + numOfGivenUpTransmissions + numOfRetries;
-    avgRetriesPerFrame = double(numOfRetries) / (numOfSuccTransmissions + numOfGivenUpTransmissions);
+    int numOfFrameTransmitted = state.numOfSuccTransmissions + state.numOfGivenUpTransmissions + state.numOfRetries;
+    state.avgRetriesPerFrame = double(state.numOfRetries) / (state.numOfSuccTransmissions + state.numOfGivenUpTransmissions);
 
-    if (numOfSuccTransmissions > 0) {
-        if (numOfFrameTransmitted >= 10 && avgRetriesPerFrame > 1) {
-            currentMode = decreaseRateIfPossible(currentMode);
-            emitDatarateChangedSignal(receiverAddress, currentMode);
-            EV_DETAIL << "Decreased rate to " << *currentMode << endl;
-            credit = 0;
+    if (state.numOfSuccTransmissions > 0) {
+        if (numOfFrameTransmitted >= 10 && state.avgRetriesPerFrame > 1) {
+            state.mode = decreaseRateIfPossible(state.mode);
+            emitDatarateChangedSignal(state.address, state.mode);
+            EV_DETAIL << "Decreased rate to " << *state.mode << endl;
+            state.credit = 0;
         }
-        else if (avgRetriesPerFrame >= 0.1)
-            credit--;
+        else if (state.avgRetriesPerFrame >= 0.1)
+            state.credit--;
         else
-            credit++;
+            state.credit++;
 
-        if (credit >= 10) {
-            currentMode = increaseRateIfPossible(currentMode);
-            emitDatarateChangedSignal(receiverAddress, currentMode);
-            EV_DETAIL << "Increased rate to " << *currentMode << endl;
-            credit = 0;
+        if (state.credit >= 10) {
+            state.mode = increaseRateIfPossible(state.mode);
+            emitDatarateChangedSignal(state.address, state.mode);
+            EV_DETAIL << "Increased rate to " << *state.mode << endl;
+            state.credit = 0;
         }
 
-        resetStatisticalVariables();
+        resetStatisticalVariables(state);
     }
 }
 
 const IIeee80211Mode *OnoeRateControl::getRate(const MacAddress& receiverAddress)
 {
     Enter_Method("getRate");
-    computeModeIfTimerIsExpired(receiverAddress);
-    EV_INFO << "The current mode is " << currentMode << " the net bitrate is " << currentMode->getDataMode()->getNetBitrate() << std::endl;
-    return currentMode;
+    State& state = getState(receiverAddress);
+    computeModeIfTimerIsExpired(state);
+    EV_INFO << "The current mode is " << state.mode << " the net bitrate is " << state.mode->getDataMode()->getNetBitrate() << std::endl;
+    return state.mode;
 }
 
 } /* namespace ieee80211 */

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.h
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.h
@@ -34,12 +34,12 @@ class INET_API OnoeRateControl : public RateControlBase
     virtual void initialize(int stage) override;
     virtual void handleMessage(cMessage *msg) override;
 
-    virtual void computeMode();
+    virtual void computeMode(const MacAddress& receiverAddress);
     virtual void resetStatisticalVariables();
-    virtual void computeModeIfTimerIsExpired();
+    virtual void computeModeIfTimerIsExpired(const MacAddress& receiverAddress);
 
   public:
-    virtual const physicallayer::IIeee80211Mode *getRate() override;
+    virtual const physicallayer::IIeee80211Mode *getRate(const MacAddress& receiverAddress) override;
     virtual void frameTransmitted(Packet *frame, int retryCount, bool isSuccessful, bool isGivenUp) override;
     virtual void frameReceived(Packet *frame) override;
 };

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.h
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.h
@@ -19,24 +19,33 @@ namespace ieee80211 {
 class INET_API OnoeRateControl : public RateControlBase
 {
   protected:
-    simtime_t timer = SIMTIME_ZERO;
+    // Per-receiver adaptive state (formerly single-instance module members).
+    struct State {
+        MacAddress address; // the receiver this state belongs to (for per-station rate attribution)
+        const physicallayer::IIeee80211Mode *mode = nullptr;
+        simtime_t timer = SIMTIME_ZERO;
+        int numOfRetries = 0;
+        int numOfSuccTransmissions = 0;
+        int numOfGivenUpTransmissions = 0;
+        double avgRetriesPerFrame = 0;
+        int credit = 0;
+    };
+    std::map<MacAddress, State> stations;
+
+    // configuration, shared across stations
     simtime_t interval = SIMTIME_ZERO;
-
-    int numOfRetries = 0;
-    int numOfSuccTransmissions = 0;
-    int numOfGivenUpTransmissions = 0;
-
-    double avgRetriesPerFrame = 0;
-    int credit = 0;
 
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
     virtual void handleMessage(cMessage *msg) override;
 
-    virtual void computeMode(const MacAddress& receiverAddress);
-    virtual void resetStatisticalVariables();
-    virtual void computeModeIfTimerIsExpired(const MacAddress& receiverAddress);
+    virtual State& getState(const MacAddress& receiverAddress);
+    virtual void resetRateControl() override { stations.clear(); }
+
+    virtual void computeMode(State& state);
+    virtual void resetStatisticalVariables(State& state);
+    virtual void computeModeIfTimerIsExpired(State& state);
 
   public:
     virtual const physicallayer::IIeee80211Mode *getRate(const MacAddress& receiverAddress) override;

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.ned
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.ned
@@ -20,7 +20,7 @@ simple OnoeRateControl extends SimpleModule like IRateControl
         @class(OnoeRateControl);
         double initialRate @unit(bps) = default(-1bps); // -1 means the fastest mandatory rate
         double interval @unit(s) = default(1s);
-        displayStringTextFormat = default("{currentMode}");
+        displayStringTextFormat = default("{numStations} stations");
         @display("i=block/cogwheel");
         @signal[datarateChanged];
         @statistic[datarateChanged](title="datarate"; record=vector; interpolationmode=sample-hold); // aggregate rate over all stations (interleaved)

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.ned
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/OnoeRateControl.ned
@@ -23,6 +23,7 @@ simple OnoeRateControl extends SimpleModule like IRateControl
         displayStringTextFormat = default("{currentMode}");
         @display("i=block/cogwheel");
         @signal[datarateChanged];
-        @statistic[datarateChanged](title="datarate"; record=vector; interpolationmode=sample-hold);
+        @statistic[datarateChanged](title="datarate"; record=vector; interpolationmode=sample-hold); // aggregate rate over all stations (interleaved)
+        @statistic[dataratePerStation](title="data rate per station"; source=demux(datarateChanged); unit=bps; record=vector; interpolationmode=sample-hold); // one vector per receiver, demultiplexed by station
 }
 

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.cc
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.cc
@@ -8,6 +8,7 @@
 #include "inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.h"
 
 #include "inet/common/Simsignals.h"
+#include "inet/networklayer/common/L3AddressResolver.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -36,10 +37,24 @@ const IIeee80211Mode *RateControlBase::decreaseRateIfPossible(const IIeee80211Mo
     return newMode == nullptr ? currentMode : newMode;
 }
 
-void RateControlBase::emitDatarateChangedSignal()
+MacAddress RateControlBase::getReceiverAddress(Packet *frame) const
 {
-    bps rate = currentMode->getDataMode()->getNetBitrate();
-    emit(datarateChangedSignal, rate.get());
+    const auto& header = frame->peekAtFront<Ieee80211MacHeader>();
+    return header->getReceiverAddress();
+}
+
+void RateControlBase::emitDatarateChangedSignal(const MacAddress& receiver, const IIeee80211Mode *mode)
+{
+    bps rate = mode->getDataMode()->getNetBitrate();
+    // Emit once, tagging the value with the receiver as a named details object. The aggregate
+    // datarateChanged statistic ignores the details (so it is unchanged), while a demux(datarateChanged)
+    // statistic uses the details name to record a separate data-rate vector per station.
+    if (receiver.isBroadcast() || receiver.isMulticast())
+        emit(datarateChangedSignal, rate.get());
+    else {
+        cNamedObject details(L3AddressResolver().getHostNameWithMacAddress(receiver).c_str());
+        emit(datarateChangedSignal, rate.get(), &details);
+    }
 }
 
 void RateControlBase::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
@@ -50,7 +65,8 @@ void RateControlBase::receiveSignal(cComponent *source, simsignal_t signalID, cO
         modeSet = check_and_cast<Ieee80211ModeSet *>(obj);
         double initRate = par("initialRate");
         currentMode = initRate == -1 ? modeSet->getFastestMandatoryMode() : modeSet->getMode(bps(initRate));
-        emitDatarateChangedSignal();
+        // no particular station yet: the initial rate applies to all of them
+        emitDatarateChangedSignal(MacAddress::BROADCAST_ADDRESS, currentMode);
     }
 }
 

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.cc
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.cc
@@ -20,9 +20,6 @@ simsignal_t RateControlBase::datarateChangedSignal = cComponent::registerSignal(
 void RateControlBase::initialize(int stage)
 {
     ModeSetListener::initialize(stage);
-
-    if (stage == INITSTAGE_LOCAL)
-        WATCH_EXPR("currentMode", currentMode ? currentMode->getName() : "none");
 }
 
 const IIeee80211Mode *RateControlBase::increaseRateIfPossible(const IIeee80211Mode *currentMode)
@@ -41,6 +38,12 @@ MacAddress RateControlBase::getReceiverAddress(Packet *frame) const
 {
     const auto& header = frame->peekAtFront<Ieee80211MacHeader>();
     return header->getReceiverAddress();
+}
+
+const IIeee80211Mode *RateControlBase::getInitialMode()
+{
+    double initialRate = par("initialRate");
+    return initialRate == -1 ? modeSet->getFastestMandatoryMode() : modeSet->getMode(bps(initialRate));
 }
 
 void RateControlBase::emitDatarateChangedSignal(const MacAddress& receiver, const IIeee80211Mode *mode)
@@ -63,10 +66,7 @@ void RateControlBase::receiveSignal(cComponent *source, simsignal_t signalID, cO
 
     if (signalID == modesetChangedSignal) {
         modeSet = check_and_cast<Ieee80211ModeSet *>(obj);
-        double initRate = par("initialRate");
-        currentMode = initRate == -1 ? modeSet->getFastestMandatoryMode() : modeSet->getMode(bps(initRate));
-        // no particular station yet: the initial rate applies to all of them
-        emitDatarateChangedSignal(MacAddress::BROADCAST_ADDRESS, currentMode);
+        resetRateControl();
     }
 }
 

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.h
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.h
@@ -8,6 +8,7 @@
 #ifndef __INET_RATECONTROLBASE_H
 #define __INET_RATECONTROLBASE_H
 
+#include "inet/linklayer/common/MacAddress.h"
 #include "inet/linklayer/ieee80211/mac/common/ModeSetListener.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
 
@@ -20,20 +21,21 @@ class INET_API RateControlBase : public ModeSetListener, public IRateControl
     static simsignal_t datarateChangedSignal;
 
   protected:
-    const physicallayer::IIeee80211Mode *currentMode = nullptr;
-
-  protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
 
-    // The receiver of a frame the rate control is being given feedback about.
+    // The receiver MAC address of a transmitted (or received) frame, which keys the per-station state.
     virtual MacAddress getReceiverAddress(Packet *frame) const;
+    // The mode a newly seen station starts from: the initialRate parameter, or the fastest mandatory mode.
+    virtual const physicallayer::IIeee80211Mode *getInitialMode();
     // Emits datarateChanged with the receiver as a named details object, so a demux(datarateChanged)
     // result filter can record a separate data-rate vector per station. The aggregate datarateChanged
     // statistic ignores the details and is therefore unchanged. Group-addressed receivers are emitted
     // without details (aggregate only).
     virtual void emitDatarateChangedSignal(const MacAddress& receiver, const physicallayer::IIeee80211Mode *mode);
+    // Drops all per-station state; called by subclasses' override when the mode set changes.
+    virtual void resetRateControl() {}
 
     const physicallayer::IIeee80211Mode *increaseRateIfPossible(const physicallayer::IIeee80211Mode *currentMode);
     const physicallayer::IIeee80211Mode *decreaseRateIfPossible(const physicallayer::IIeee80211Mode *currentMode);

--- a/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.h
+++ b/src/inet/linklayer/ieee80211/mac/ratecontrol/RateControlBase.h
@@ -27,7 +27,13 @@ class INET_API RateControlBase : public ModeSetListener, public IRateControl
     virtual void initialize(int stage) override;
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
 
-    virtual void emitDatarateChangedSignal();
+    // The receiver of a frame the rate control is being given feedback about.
+    virtual MacAddress getReceiverAddress(Packet *frame) const;
+    // Emits datarateChanged with the receiver as a named details object, so a demux(datarateChanged)
+    // result filter can record a separate data-rate vector per station. The aggregate datarateChanged
+    // statistic ignores the details and is therefore unchanged. Group-addressed receivers are emitted
+    // without details (aggregate only).
+    virtual void emitDatarateChangedSignal(const MacAddress& receiver, const physicallayer::IIeee80211Mode *mode);
 
     const physicallayer::IIeee80211Mode *increaseRateIfPossible(const physicallayer::IIeee80211Mode *currentMode);
     const physicallayer::IIeee80211Mode *decreaseRateIfPossible(const physicallayer::IIeee80211Mode *currentMode);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -9,6 +9,7 @@
 
 #include "inet/common/ModuleAccess.h"
 #include "inet/common/Simsignals.h"
+#include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
 namespace inet {
@@ -37,6 +38,27 @@ void QosRateSelection::initialize(int stage)
         responseBlockAckFrameMode = (responseBlockAckFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(responseBlockAckFrameBitrate));
         double responseCtsFrameBitrate = par("responseCtsFrameBitrate");
         responseCtsFrameMode = (responseCtsFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(responseCtsFrameBitrate));
+    }
+}
+
+void QosRateSelection::ensurePerReceiverModesResolved()
+{
+    if (perReceiverResolved)
+        return;
+    perReceiverResolved = true;
+    auto perReceiverBitrate = check_and_cast<cValueMap *>(par("dataFrameBitratePerReceiver").objectValue());
+    for (auto& [path, value] : perReceiverBitrate->getFields()) {
+        auto module = findModuleByPath(path.c_str());
+        if (module == nullptr)
+            throw cRuntimeError("dataFrameBitratePerReceiver: cannot resolve receiver interface module path '%s'", path.c_str());
+        auto networkInterface = check_and_cast<NetworkInterface *>(module);
+        try {
+            auto mode = modeSet->getMode(bps(value.doubleValueInUnit("bps")), Hz(par("dataFrameBandwidth")), par("dataFrameNumSpatialStreams"));
+            perReceiverDataFrameMode[networkInterface->getMacAddress()] = mode;
+        }
+        catch (const cRuntimeError& e) {
+            throw cRuntimeError("dataFrameBitratePerReceiver: cannot use rate '%s' for receiver '%s': %s", value.str().c_str(), path.c_str(), e.what());
+        }
     }
 }
 
@@ -119,6 +141,15 @@ const IIeee80211Mode *QosRateSelection::computeResponseBlockAckFrameMode(Packet 
 
 const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader)
 {
+    // Per-receiver override for originated unicast data frames (see dataFrameBitratePerReceiver).
+    // Wins over the interface-wide dataFrameMode / rate control; group-addressed and management
+    // frames are left to the existing rules below.
+    if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && !dataOrMgmtHeader->getReceiverAddress().isMulticast()) {
+        ensurePerReceiverModesResolved();
+        auto it = perReceiverDataFrameMode.find(dataOrMgmtHeader->getReceiverAddress());
+        if (it != perReceiverDataFrameMode.end())
+            return it->second;
+    }
     if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && dataFrameMode)
         return dataFrameMode;
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -140,10 +140,10 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         // If both the BSSBasicRateSet parameter and the BSSBasicMCSSet parameter are empty (e.g., a scanning STA
         // that is not yet associated with a BSS), the frame shall be transmitted in a non-HT PPDU using one of the
         // mandatory PHY rates.
-        if (dataOrMgmtRateControl)
-            return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
-        else
-            return fastestMandatoryMode;
+        // The rate control is not consulted for these frames. It adapts to the feedback of one
+        // peer, and a group-addressed frame has no peer: it is never acknowledged, so nothing
+        // would ever correct a rate chosen for it.
+        return fastestMandatoryMode;
     }
     // A data or management frame not identified in 9.7.5.1 through 9.7.5.5 shall be sent using any data rate or MCS
     // subject to the following constraints:

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -141,7 +141,7 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         // that is not yet associated with a BSS), the frame shall be transmitted in a non-HT PPDU using one of the
         // mandatory PHY rates.
         if (dataOrMgmtRateControl)
-            return dataOrMgmtRateControl->getRate();
+            return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
         else
             return fastestMandatoryMode;
     }
@@ -159,7 +159,7 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         // TODO Supported Rates element, Extended Supported Rates element
         // TODO OperationalRateSet or the HTOperationalMCSset
         if (dataOrMgmtRateControl)
-            return dataOrMgmtRateControl->getRate();
+            return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
         else
             return fastestMandatoryMode;
     }

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h
@@ -48,10 +48,19 @@ class INET_API QosRateSelection : public IQosRateSelection, public ModeSetListen
     const physicallayer::IIeee80211Mode *responseCtsFrameMode = nullptr;
     const physicallayer::IIeee80211Mode *responseBlockAckFrameMode = nullptr;
 
+    // per-receiver unicast data-frame modes, resolved lazily from dataFrameBitratePerReceiver
+    std::map<MacAddress, const physicallayer::IIeee80211Mode *> perReceiverDataFrameMode;
+    bool perReceiverResolved = false;
+
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
+
+    // Builds perReceiverDataFrameMode on first use. Deferred out of initialize() because peer
+    // MAC addresses are assigned during INITSTAGE_LINK_LAYER with undefined intra-stage module
+    // ordering; the first transmitted data frame occurs after all init stages, so this is race-free.
+    virtual void ensurePerReceiverModesResolved();
 
     virtual const physicallayer::IIeee80211Mode *getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header, TxopProcedure *txopProcedure);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -34,6 +34,14 @@ simple QosRateSelection extends SimpleModule
         double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Unspecified by default
         int dataFrameNumSpatialStreams = default(-1); // Unspecified by default
 
+        // Per-receiver unicast data-frame rate. Keys are peer interface module paths (e.g.
+        // "host1.wlan[0]"), resolved to MAC addresses at run time; values are bitrates (bps).
+        // A unicast data frame whose receiver matches a key is transmitted at that rate;
+        // unmatched receivers fall back to dataFrameBitrate / the rate-control module. The
+        // bandwidth and spatial-stream count are taken from dataFrameBandwidth /
+        // dataFrameNumSpatialStreams. Empty by default (capability inert).
+        object dataFrameBitratePerReceiver = default({});
+
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);
         @display("i=block/cogwheel");

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -60,6 +60,27 @@ void RateSelection::initialize(int stage)
     }
 }
 
+void RateSelection::ensurePerReceiverModesResolved()
+{
+    if (perReceiverResolved)
+        return;
+    perReceiverResolved = true;
+    auto perReceiverBitrate = check_and_cast<cValueMap *>(par("dataFrameBitratePerReceiver").objectValue());
+    for (auto& [path, value] : perReceiverBitrate->getFields()) {
+        auto module = findModuleByPath(path.c_str());
+        if (module == nullptr)
+            throw cRuntimeError("dataFrameBitratePerReceiver: cannot resolve receiver interface module path '%s'", path.c_str());
+        auto networkInterface = check_and_cast<NetworkInterface *>(module);
+        try {
+            auto mode = modeSet->getMode(bps(value.doubleValueInUnit("bps")), Hz(par("dataFrameBandwidth")), par("dataFrameNumSpatialStreams"));
+            perReceiverDataFrameMode[networkInterface->getMacAddress()] = mode;
+        }
+        catch (const cRuntimeError& e) {
+            throw cRuntimeError("dataFrameBitratePerReceiver: cannot use rate '%s' for receiver '%s': %s", value.str().c_str(), path.c_str(), e.what());
+        }
+    }
+}
+
 const IIeee80211Mode *RateSelection::getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header)
 {
     const auto& modeReqTag = packet->findTag<Ieee80211ModeReq>();
@@ -114,6 +135,15 @@ const IIeee80211Mode *RateSelection::computeResponseCtsFrameMode(Packet *packet,
 //
 const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader)
 {
+    // Per-receiver override for originated unicast data frames (see dataFrameBitratePerReceiver).
+    // Wins over the interface-wide dataFrameMode / rate control; group-addressed and management
+    // frames are left to the existing rules below.
+    if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && !dataOrMgmtHeader->getReceiverAddress().isMulticast()) {
+        ensurePerReceiverModesResolved();
+        auto it = perReceiverDataFrameMode.find(dataOrMgmtHeader->getReceiverAddress());
+        if (it != perReceiverDataFrameMode.end())
+            return it->second;
+    }
     if (dataOrMgmtHeader->getReceiverAddress().isMulticast() && multicastFrameMode)
         return multicastFrameMode;
     if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && dataFrameMode)

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -10,6 +10,7 @@
 #include "inet/common/ModuleAccess.h"
 #include "inet/common/Simsignals.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
+#include "inet/networklayer/common/L3AddressResolver.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
@@ -199,6 +200,19 @@ void RateSelection::setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHea
 {
     ASSERT(mode != nullptr);
     packet->addTagIfAbsent<Ieee80211ModeReq>()->setMode(mode);
+}
+
+void RateSelection::emitDatarateSelected(cComponent *emitter, const Ptr<const Ieee80211MacHeader>& header, const IIeee80211Mode *mode)
+{
+    double rate = mode->getDataMode()->getNetBitrate().get<bps>();
+    auto dataHeader = dynamicPtrCast<const Ieee80211DataHeader>(header);
+    // naming the station sweeps the network, so skip it if nothing listens anyway
+    if (dataHeader != nullptr && !dataHeader->getReceiverAddress().isMulticast() && emitter->mayHaveListeners(IRateSelection::datarateSelectedSignal)) {
+        cNamedObject details(L3AddressResolver().getHostNameWithMacAddress(dataHeader->getReceiverAddress()).c_str());
+        emitter->emit(IRateSelection::datarateSelectedSignal, rate, &details);
+    }
+    else
+        emitter->emit(IRateSelection::datarateSelectedSignal, rate);
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -121,7 +121,7 @@ const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const 
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)
         return mgmtFrameMode;
     if (dataOrMgmtRateControl)
-        return dataOrMgmtRateControl->getRate();
+        return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
     else
         return fastestMandatoryMode;
 }

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -120,7 +120,10 @@ const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const 
         return dataFrameMode;
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)
         return mgmtFrameMode;
-    if (dataOrMgmtRateControl)
+    // Rate control adapts to the feedback of one peer, and a group-addressed frame has no peer:
+    // it is never acknowledged, so nothing would ever correct a rate chosen for it. Group-addressed
+    // frames therefore take a mandatory rate, as the clause above requires.
+    if (dataOrMgmtRateControl && !dataOrMgmtHeader->getReceiverAddress().isMulticast())
         return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
     else
         return fastestMandatoryMode;

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
@@ -48,10 +48,19 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
     const physicallayer::IIeee80211Mode *responseAckFrameMode = nullptr;
     const physicallayer::IIeee80211Mode *responseCtsFrameMode = nullptr;
 
+    // per-receiver unicast data-frame modes, resolved lazily from dataFrameBitratePerReceiver
+    std::map<MacAddress, const physicallayer::IIeee80211Mode *> perReceiverDataFrameMode;
+    bool perReceiverResolved = false;
+
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
+
+    // Builds perReceiverDataFrameMode on first use. Deferred out of initialize() because peer
+    // MAC addresses are assigned during INITSTAGE_LINK_LAYER with undefined intra-stage module
+    // ordering; the first transmitted data frame occurs after all init stages, so this is race-free.
+    virtual void ensurePerReceiverModesResolved();
 
     virtual const physicallayer::IIeee80211Mode *getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
@@ -69,6 +69,15 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
   public:
     static void setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header, const physicallayer::IIeee80211Mode *mode);
 
+    // Emits datarateSelected on behalf of a coordination function. Unicast data frames are tagged
+    // with the name of the receiving station as a named details object, so that a
+    // demux(datarateSelected) result filter or a statistic visualizer can key a separate
+    // per-station series on it; this mirrors the condition under which a per-receiver configured
+    // rate applies, so the details always name the station whose rate is reported. Control,
+    // management and group-addressed frames carry no per-station data rate and are emitted without
+    // details: the aggregate datarateSelected statistic still records them, a bar chart ignores them.
+    static void emitDatarateSelected(cComponent *emitter, const Ptr<const Ieee80211MacHeader>& header, const physicallayer::IIeee80211Mode *mode);
+
     // A control response frame is a control frame that is transmitted as a response to the reception of a frame a SIFS
     // time after the PPDU containing the frame that elicited the response, e.g. a CTS in response to an RTS
     // reception, an ACK in response to a DATA reception, a BlockAck in response to a BlockAckReq reception. In

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -29,6 +29,14 @@ simple RateSelection extends SimpleModule like IRateSelection
         double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Unspecified by default
         int dataFrameNumSpatialStreams = default(-1); // Unspecified by default
 
+        // Per-receiver unicast data-frame rate. Keys are peer interface module paths (e.g.
+        // "host1.wlan[0]"), resolved to MAC addresses at run time; values are bitrates (bps).
+        // A unicast data frame whose receiver matches a key is transmitted at that rate;
+        // unmatched receivers fall back to dataFrameBitrate / the rate-control module. The
+        // bandwidth and spatial-stream count are taken from dataFrameBandwidth /
+        // dataFrameNumSpatialStreams. Empty by default (capability inert).
+        object dataFrameBitratePerReceiver = default({});
+
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);
         @display("i=block/cogwheel");

--- a/src/inet/networklayer/common/L3AddressResolver.cc
+++ b/src/inet/networklayer/common/L3AddressResolver.cc
@@ -574,5 +574,20 @@ cModule *L3AddressResolver::findHostWithMacAddress(const MacAddress& addr)
     return entry ? entry->getInterfaceTable()->getHostModule() : nullptr;
 }
 
+std::string L3AddressResolver::getHostNameWithMacAddress(const MacAddress& addr)
+{
+    cModule *host = findHostWithMacAddress(addr);
+    if (host == nullptr)
+        return addr.str();
+    // the path relative to the network, so that hosts of the same name in different
+    // subnetworks get different names; for a host directly under the network this is
+    // just its name
+    std::string name = host->getFullPath();
+    std::string networkPrefix = std::string(host->getSimulation()->getSystemModule()->getFullName()) + ".";
+    if (name.compare(0, networkPrefix.length(), networkPrefix) == 0)
+        name.erase(0, networkPrefix.length());
+    return name;
+}
+
 } // namespace inet
 

--- a/src/inet/networklayer/common/L3AddressResolver.h
+++ b/src/inet/networklayer/common/L3AddressResolver.h
@@ -205,6 +205,15 @@ class INET_API L3AddressResolver
      * Find the host with the specified MAC address. Returns nullptr if not found.
      */
     virtual cModule *findHostWithMacAddress(const MacAddress& addr);
+
+    /**
+     * Returns a name identifying the host with the specified MAC address: its path
+     * relative to the network, which is just the host name unless the host is nested
+     * in a subnetwork. Falls back to the MAC address string if no such host is found.
+     * Useful wherever a peer has to be named by the address a model knows it by, e.g.
+     * to label the per-peer series of a demultiplexed statistic.
+     */
+    virtual std::string getHostNameWithMacAddress(const MacAddress& addr);
     //@}
 };
 

--- a/tests/module/AarfRateControlGroupAddressed_1.test
+++ b/tests/module/AarfRateControlGroupAddressed_1.test
@@ -1,0 +1,84 @@
+%description:
+Tests that AarfRateControl keeps no adaptive state for a group-addressed receiver.
+
+A group-addressed frame is never acknowledged, so the rate control never gets feedback about
+it. If such a frame were served from adaptive state of its own, that state would be created on
+the first broadcast and then raised once per interval by the periodic increase, with nothing
+able to lower it again.
+
+The source sends a unicast stream to sink and a broadcast stream at the same time. Every rate
+the rate control reports must therefore belong to sink: the count of the aggregate
+datarateChanged statistic must equal the count of sink's own dataratePerStation series, because
+a rate emitted for a group address would be untagged and would show up only in the aggregate.
+
+%#--------------------------------------------------------------------------------------------------------------
+%file: test.ned
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.AdhocHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+network AarfRateControlGroupAddressedTest
+{
+    submodules:
+        configurator: Ipv4NetworkConfigurator;
+        radioMedium: Ieee80211ScalarRadioMedium;
+        source: AdhocHost;
+        sink: AdhocHost;
+}
+
+%#--------------------------------------------------------------------------------------------------------------
+%inifile: omnetpp.ini
+[General]
+network = AarfRateControlGroupAddressedTest
+ned-path = .;../../../../src
+sim-time-limit = 2s
+cmdenv-express-mode = true
+**.vector-recording = false
+
+*.radioMedium.sameTransmissionStartTimeCheck = "ignore"
+*.radioMedium.backgroundNoise.power = -100dBm
+*.configurator.addStaticRoutes = true
+
+*.*.wlan[*].opMode = "g(erp)"
+*.*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
+*.*.wlan[*].agent.typename = ""
+*.*.wlan[*].radio.transmitter.power = 50mW
+
+*.*.mobility.typename = "StationaryMobility"
+**.mobility.initFromDisplayString = false
+*.source.mobility.initialX = 0m
+*.source.mobility.initialY = 0m
+*.source.mobility.initialZ = 0m
+*.sink.mobility.initialX = 20m
+*.sink.mobility.initialY = 0m
+*.sink.mobility.initialZ = 0m
+
+# a short interval, so an unfed group-addressed state would be raised many times over the run
+*.source.wlan[*].mac.dcf.rateControl.typename = "AarfRateControl"
+*.source.wlan[*].mac.dcf.rateControl.initialRate = 6Mbps
+*.source.wlan[*].mac.dcf.rateControl.interval = 0.05s
+*.source.wlan[*].mac.dcf.rateSelection.dataFrameBitrate = -1bps
+
+# a unicast stream; the group-addressed frames come from ARP, which broadcasts its requests
+*.source.numApps = 1
+*.source.app[0].typename = "UdpBasicApp"
+*.source.app[0].destAddresses = "sink"
+*.source.app[0].destPort = 5000
+*.source.app[0].messageLength = 1000B
+*.source.app[0].sendInterval = 1ms
+*.sink.numApps = 1
+*.sink.app[0].typename = "UdpSink"
+*.sink.app[0].localPort = 5000
+
+*.source.wlan[*].mac.dcf.rateControl.datarateChanged.result-recording-modes = count
+*.source.wlan[*].mac.dcf.rateControl.dataratePerStation.result-recording-modes = count
+
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: gawk '$1 == "scalar" && $2 ~ /\.source\./ { if ($3 == "datarateChanged:count") agg = $4; else if ($3 == "sink:dataratePerStation:count") per = $4; else if ($3 == "arpRequestSent:count") bc = $4 } END { printf "groupAddressedSent=%s\n", (bc > 0) ? "YES" : "NO"; printf "allRatesAttributed=%s\n", (agg > 0 && agg == per) ? "YES" : "NO"; printf "values aggregate=%d sinkSeries=%d arpRequests=%d\n", agg, per, bc }' results/*.sca > verdict.out
+%contains: verdict.out
+groupAddressedSent=YES
+allRatesAttributed=YES
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: grep "undisposed object:" test.out > test_undisposed.out || true
+%not-contains: test_undisposed.out
+undisposed object:

--- a/tests/module/AarfRateControlPerReceiver_1.test
+++ b/tests/module/AarfRateControlPerReceiver_1.test
@@ -1,0 +1,103 @@
+%description:
+Tests that AarfRateControl adapts its rate separately for each receiver, so that
+feedback from one peer does not move the rate used towards another.
+
+One source saturates two ad-hoc peers at once: nearSink 20 m away, farSink 1200 m
+away on a link poor enough that frames to it are lost and retried. The rate towards
+the near peer must therefore stay at the initial 54 Mbps, while the rate towards the
+far peer falls well below it, and both peers must keep receiving.
+
+Measured here: 54 Mbps towards the near peer and 24.7 Mbps towards the far one, with
+3653 and 1350 packets delivered.
+
+With one set of adaptive state per module (the behavior before rate control was keyed
+on the receiver) the two peers share a single rate, which the far peer's retries drag
+down to a blend of the two: 29.6 Mbps time-average, with the near peer served at that
+blended rate instead of the 54 Mbps its own link supports, delivering 3080 packets to
+the near peer and only 380 to the far one.
+
+%#--------------------------------------------------------------------------------------------------------------
+%file: test.ned
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.AdhocHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+network AarfRateControlPerReceiverTest
+{
+    submodules:
+        configurator: Ipv4NetworkConfigurator;
+        radioMedium: Ieee80211ScalarRadioMedium;
+        source: AdhocHost;
+        nearSink: AdhocHost;
+        farSink: AdhocHost;
+}
+
+%#--------------------------------------------------------------------------------------------------------------
+%inifile: omnetpp.ini
+[General]
+network = AarfRateControlPerReceiverTest
+ned-path = .;../../../../src
+sim-time-limit = 2s
+cmdenv-express-mode = true
+**.vector-recording = false
+
+*.radioMedium.sameTransmissionStartTimeCheck = "ignore"
+*.radioMedium.backgroundNoise.power = -100dBm
+*.*.ipv4.arp.typename = "GlobalArp"
+*.configurator.addStaticRoutes = false
+
+# ad-hoc, so no association is needed and a distant peer simply has a worse link
+*.*.wlan[*].opMode = "g(erp)"
+*.*.wlan[*].mgmt.typename = "Ieee80211MgmtAdhoc"
+*.*.wlan[*].agent.typename = ""
+*.*.wlan[*].radio.transmitter.power = 50mW
+
+*.*.mobility.typename = "StationaryMobility"
+**.mobility.initFromDisplayString = false
+*.source.mobility.initialX = 0m
+*.source.mobility.initialY = 0m
+*.source.mobility.initialZ = 0m
+*.nearSink.mobility.initialX = 20m
+*.nearSink.mobility.initialY = 0m
+*.nearSink.mobility.initialZ = 0m
+*.farSink.mobility.initialX = 1200m
+*.farSink.mobility.initialY = 0m
+*.farSink.mobility.initialZ = 0m
+
+# the rate control under test, adapting from the same starting rate for every peer
+*.source.wlan[*].mac.dcf.rateControl.typename = "AarfRateControl"
+*.source.wlan[*].mac.dcf.rateControl.initialRate = 54Mbps
+*.source.wlan[*].mac.dcf.rateControl.increaseThreshold = 20
+*.source.wlan[*].mac.dcf.rateControl.decreaseThreshold = 5
+*.source.wlan[*].mac.dcf.rateSelection.dataFrameBitrate = -1bps
+
+# the same saturating stream to each peer
+*.source.numApps = 2
+*.source.app[0].typename = "UdpBasicApp"
+*.source.app[0].destAddresses = "nearSink"
+*.source.app[0].destPort = 5000
+*.source.app[1].typename = "UdpBasicApp"
+*.source.app[1].destAddresses = "farSink"
+*.source.app[1].destPort = 5001
+*.source.app[*].messageLength = 1000B
+*.source.app[*].sendInterval = 0.5ms
+*.nearSink.numApps = 1
+*.nearSink.app[0].typename = "UdpSink"
+*.nearSink.app[0].localPort = 5000
+*.farSink.numApps = 1
+*.farSink.app[0].typename = "UdpSink"
+*.farSink.app[0].localPort = 5001
+
+# the per-station rates the verdict is computed from, as a scalar per peer
+*.source.wlan[*].mac.dcf.rateControl.dataratePerStation.result-recording-modes = timeavg
+
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: gawk '/(near|far)Sink:dataratePerStation:timeavg/ { match($3, /^([a-zA-Z]+)Sink:/, m); r[m[1]] = $4 } /(near|far)Sink\.app\[0\] packetReceived:count/ { match($2, /\.([a-zA-Z]+)Sink\./, m); c[m[1]] = $4 } END { printf "bothServed=%s\n", (c["near"] > 0 && c["far"] > 0) ? "YES" : "NO"; printf "nearRateUndragged=%s\n", (r["near"] > 50e6) ? "YES" : "NO"; printf "farRateReduced=%s\n", (r["far"] > 0 && r["far"] < 30e6) ? "YES" : "NO"; printf "values near=%.1fMbps far=%.1fMbps nearPk=%d farPk=%d\n", r["near"]/1e6, r["far"]/1e6, c["near"], c["far"] }' results/*.sca > verdict.out
+%contains: verdict.out
+bothServed=YES
+nearRateUndragged=YES
+farRateReduced=YES
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: grep "undisposed object:" test.out > test_undisposed.out || true
+%not-contains: test_undisposed.out
+undisposed object:


### PR DESCRIPTION
Makes IEEE 802.11 (Wi-Fi) rate control adapt separately for each receiver, makes the resulting
rates observable per station, and adds a way to configure a fixed rate per peer.

## Why

`AarfRateControl` and `OnoeRateControl` kept one set of adaptive state per module: a single
current mode, timer, probe flag, threshold and success counter. A station transmitting to
several peers therefore blended their feedback into one rate — a retry to a distant station
pushed the rate down for a nearby one, and vice versa. That is the normal case for an access
point serving clients at different distances, and it is the situation the model was least able
to represent.

## Reading order

The commits build on one another and should be read in order.

| # | Commit | What it does |
|---|---|---|
| 1 | `networklayer: name the host owning a MAC address` | `L3AddressResolver::getHostNameWithMacAddress()`, a shared helper, described without reference to 802.11 |
| 2 | `ieee80211: record the data rate per station` | `IRateControl::getRate()` takes the receiver; `datarateChanged` is tagged with the station; new `dataratePerStation` demux statistic. **No behavior change** |
| 3 | `ieee80211: make rate control adapt per receiver` | the behavior change, with its two module tests |
| 4 | `ieee80211: add per-receiver configured unicast data-frame rates` | the `dataFrameBitratePerReceiver` parameter |
| 5 | `ieee80211: tag datarateSelected with the receiving station` | the same station tagging for the per-frame signal |
| 6 | `doc: note the per-receiver 802.11 rate control in WHATSNEW` | the release note for the above |

Commit 2 deliberately precedes commit 3. The per-station statistic is meaningful with the old
single-state rate control too — it simply reports every station at the same rate — and putting it
first is what lets the behavior commit carry its own test. Commit 2 also carries the
`getRate(receiverAddress)` signature change, because attributing a rate to a station is
impossible until the rate control is told which station it is choosing for.

## Architectural surface

- **`IRateControl` (NED `moduleinterface` + C++ contract).** `getRate()` gains the receiver's MAC
  address. This is **backward incompatible for C++**: a rate control implemented outside INET
  stops compiling until its `getRate()` is given the new argument. All in-tree implementations
  and all three call sites are updated, and `WHATSNEW` records it.
- **`IRateSelection` (C++ contract).** Gains a static `emitDatarateSelected()` helper, so the two
  coordination functions emit the signal one way instead of each formatting it themselves.
- **Configuration surface.** `RateSelection` and `QosRateSelection` gain
  `dataFrameBitratePerReceiver`, an `object` parameter holding a map from peer interface module
  path to bitrate. Empty by default, so it is inert unless configured. Values are read with
  `doubleValueInUnit("bps")`, so `54Mbps` in an ini file is converted rather than assumed.
- **Statistics.** New `dataratePerStation` (`source=demux(datarateChanged)`) on both rate controls.
  The declaration of the aggregate `datarateChanged` statistic is unchanged and it still
  ignores the details, but the values it records move: the rate control no longer reports a rate
  when the mode set changes, and reports one per station when that station is first seen instead.
  The `datarateSelected` signal of `Dcf` and `Hcf` is tagged the same way.
- **Group-addressed frames.** Rate selection no longer consults the rate control for a
  group-addressed frame. Such a frame is never acknowledged, so `frameTransmitted()` is never
  called for it and adaptive state keyed on a group address could never be corrected — it would
  be created on the first broadcast and then raised once per `interval` for the rest of the run.
  They take a mandatory rate instead, which is what the 802.11 clause quoted above
  `computeDataOrMgmtFrameMode()` requires and what rate selection already did when no rate
  control is configured. This is a behavior change and `WHATSNEW` records it.
- **No new dependency deviation.** `doc/architecture/enforcement/check-architecture.sh` reports the
  same 25 pre-existing violations at this branch head as at `master`, listed in the same set. No
  new `AV-*` or `NV-*` row is needed.

## Tests

Rebased on `master` at `e38566236b`. All commands run from the branch head unless stated.

Build, every commit individually:

```
for c in $(git rev-list --reverse master..HEAD); do git checkout $c && make MODE=release -j$(nproc); done
```

→ all 6 commits build, exit 0, no warnings introduced.

Module test:

```
cd tests/module && inet_run_module_tests -m release -f AarfRateControl
```

→ `AarfRateControlPerReceiver_1.test PASS`, `AarfRateControlGroupAddressed_1.test PASS`

`AarfRateControlGroupAddressed_1` is a regression test for the group-addressed case above, and it
was checked to fail without the fix: with the rate control still consulted for group addresses it
reports an aggregate `datarateChanged:count` of 201 against a `sink:dataratePerStation:count` of
200 — the one extra, untagged emission being the state created for the broadcast address.

Architecture check:

```
bash doc/architecture/enforcement/check-architecture.sh
```

→ 25 violations, the identical set reported at `master` (`MobilityBase.cc` and `OsgEarthGround.cc`
for `AR-ORG-VIS-SPLIT`, plus the 23 known `common/` entries). The branch adds none.

## Fingerprints

Three checked-in fingerprint rows run this code, plus the `NoRateControl` row of the same
showcase, which is a useful control: it sets `rateControl.typename = ""`, so none of the rate
control code in this branch is instantiated there at all.

Each row was measured at this branch head and at `master`, for all four recorded ingredients:

```
inet --release -s -u Cmdenv -f omnetpp.ini -c <config> -r 0 --sim-time-limit=<limit> \
     --fingerprint="0000-0000/<ingredient>" <per-ingredient args from python/inet/test/fingerprint/task.py>
```

| Row | Config | tplx | ~tNl | ~tND | tyf (recorded → master → branch) |
|---|---|---|---|---|---|
| `examples.csv:663` `/examples/wireless/ratecontrol/` | `-c Mac` | = | = | = | `19fe-8b0e` → `1831-eed2` → `5760-36dc` |
| `showcases.csv:320` `/showcases/wireless/ratecontrol/` | `-c AarfRateControl` | = | = | = | `7539-d32d` → `c5c2-f722` → `3af4-f82b` |
| `showcases.csv:133` `/showcases/visualizer/canvas/instrumentfigures/` | `-c General` | = | = | = | `4266-0d42` → `96bc-93e1` → `8797-0cbc` |
| `showcases.csv:319` `/showcases/wireless/ratecontrol/` (control) | `-c NoRateControl` | = | = | = | `dad3-7f89` → `70a5-dc6f` → `70a5-dc6f` |

`=` means the recorded value, the value computed at `master`, and the value computed at this
branch head are all identical. The whole matrix was measured again after the
group-addressed change described above, and every one of the sixteen values came back identical:
no fingerprinted scenario ever emits a group-addressed data frame: the two showcase rows set
`GlobalArp` and carry unicast-only traffic, and `examples/wireless/ratecontrol` has no network
layer at all.

**No trajectory change.** All twelve deterministic values — `tplx`, `~tNl` and `~tND` across all
four rows — are identical at the recorded baseline, at `master`, and at this branch head. The
per-receiver adaptation is invisible to them because no fingerprinted scenario has a transmitter
with more than one peer: `RateControlTest` sends from every `cliHost[]` to a single `sinkClient`,
and the two showcase configs have one source and one sink. (That is also why the audit's
hypothesis about `state.timer = simTime()` moving these rows does not hold.)

**`tyf` moves, for a presentation-only reason.** The `y` ingredient fingerprints display strings.
This branch changes `displayStringTextFormat` on both rate controls from `{currentMode}` to
`{numStations} stations`, because once the adaptive state is per receiver there is no
module-level current mode left to display.

The `NoRateControl` row is the control that separates the two effects. It sets
`rateControl.typename = ""`, so none of the rate control code in this branch is instantiated
there — and its `tyf` value is **identical at `master` and at this branch** (`70a5-dc6f`). So:

- `recorded → master` is drift that already exists on `master`, in **all four** rows including the
  control. It is not caused by this branch. INET has hit this before; see
  `Fix: Update stale /tyf fingerprints from version 4.6.0` and `test: update "tyf" fingerprints`.
- `master → branch` appears in **exactly** the three rows that instantiate a rate control, and
  nowhere else. That delta is the display string change.

**The `tyf` column is stale across the whole test set, not just here.** Two measurements say so.
First, every recorded `tyf` value in the three CSVs comes from a single bulk commit, `42435492f1`
*"Tests: fingerprint: actualized tyf fingerprints"* (2026-05-28), which rewrote 190 rows at once;
530 commits have landed on `master` since. Second, rows that this branch cannot possibly affect are
equally stale at this branch head — three non-wireless examples, measured the same way:

| Row | recorded `tyf` | computed |
|---|---|---|
| `/showcases/measurement/datarate/` `-c General` | `c848-3d2a` | `502e-91c6` |
| `/showcases/measurement/endtoenddelay/` `-c General` | `1479-9b89` | `8437-2c2f` |
| `/showcases/measurement/jitter/` `-c General` | `75bd-8abc` | `43a2-7a4c` |

So `tyf` is maintained by periodic project-wide refresh rather than per change, which is the right
way to treat an ingredient that fingerprints display strings and canvas figures under a fake GUI and
that also moves with the OMNeT++ version.

No `tyf` baseline is therefore updated in this branch. Recording the three rate-control rows here
would turn nothing green — the rest of the column stays stale — and a fingerprint is a single hash
that cannot be split, so those rows would silently absorb 530 commits of unrelated drift under a
message claiming to explain a display-string change. The display string is a real and intended
`tyf` delta, and it will be picked up by the next project-wide `tyf` refresh along with everything
else.

## Notes

- The `TxopProcedure::getRemaining()` fix that the earlier version of this branch carried is gone:
  the identical fix has since landed on `master` as `f1b893288a`, and the rebase dropped our
  duplicate.


