### PR TITLE
Fix remaining TXOP duration calculation

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.cc
+++ b/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.cc
@@ -96,7 +96,7 @@ simtime_t TxopProcedure::getRemaining() const
     if (start == -1)
         throw cRuntimeError("Txop has not started yet");
     auto now = simTime();
-    return now > start + limit ? 0 : now - start;
+    return now > start + limit ? 0 : start + limit - now;
 }
 
 simtime_t TxopProcedure::getDuration() const

--- a/tests/fingerprint/mipv6-refactoring.csv
+++ b/tests/fingerprint/mipv6-refactoring.csv
@@ -10,7 +10,7 @@
 # MIPv6 example — the primary test
 /examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            aa29-a8c5/~tNlb, PASS, wireless EthernetMac
 /examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            068b-23aa/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            c8dc-27c2/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            7ed8-bee3/~tNlb, PASS, wireless EthernetMac
 
 # IPv6 examples
 # MLD example — new PASS row; ~tNl locks the MLD Report/Query/Done/MAS-Query packet exchange (traffic+lengths);

--- a/tests/unit/Ieee80211TxopProcedure_1.test
+++ b/tests/unit/Ieee80211TxopProcedure_1.test
@@ -1,0 +1,86 @@
+%description:
+Tests that TxopProcedure reports the remaining time until the TXOP limit.
+
+%includes:
+#include "inet/linklayer/ieee80211/mac/originator/TxopProcedure.h"
+
+using namespace omnetpp;
+using namespace inet;
+using namespace inet::ieee80211;
+
+namespace Ieee80211TxopProcedure_1 {
+
+class TestTxopProcedure : public TxopProcedure
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_LOCAL)
+            limit = par("txopLimit");
+    }
+};
+
+Define_Module(TestTxopProcedure);
+
+} // namespace Ieee80211TxopProcedure_1
+
+%file: TestNetwork.ned
+
+import inet.linklayer.ieee80211.mac.originator.TxopProcedure;
+
+simple TestTxopProcedure extends TxopProcedure
+{
+    parameters:
+        @class(TestTxopProcedure);
+}
+
+network TestNetwork
+{
+    submodules:
+        test: Test;
+        txop: TestTxopProcedure {
+            parameters:
+                txopLimit = 10ms;
+        }
+}
+
+%inifile: omnetpp.ini
+[General]
+ned-path = .;../../../../src;../../lib
+network = TestNetwork
+
+%activity:
+
+auto txop = check_and_cast<TxopProcedure *>(cSimulation::getActiveSimulation()->getModuleByPath("txop"));
+
+auto getRemainingThrows = [txop]() {
+    try {
+        txop->getRemaining();
+        return false;
+    }
+    catch (const cRuntimeError&) {
+        return true;
+    }
+};
+
+ASSERT(getRemainingThrows());
+
+txop->startTxop(AC_VI);
+ASSERT(txop->getRemaining() == SimTime(10, SIMTIME_MS));
+
+wait(0.003);
+ASSERT(txop->getRemaining() == SimTime(7, SIMTIME_MS));
+
+wait(0.007);
+ASSERT(txop->getRemaining() == SIMTIME_ZERO);
+
+wait(0.001);
+ASSERT(txop->getRemaining() == SIMTIME_ZERO);
+
+txop->endTxop();
+ASSERT(getRemainingThrows());
+
+EV << "TXOP remaining time is correct at all boundaries.\n";
+
+%contains: stdout
+TXOP remaining time is correct at all boundaries.


### PR DESCRIPTION
## Summary

- fix `TxopProcedure::getRemaining()` to return the unspent TXOP duration
- preserve the existing zero clamp once the TXOP limit has expired
- add a focused unit test for timing boundaries and the TXOP lifecycle

## Root cause

While a TXOP was active, `getRemaining()` returned `simTime() - start`, which is the elapsed duration. Callers therefore received the spent portion of the TXOP as though it were the remaining transmission budget.

The corrected expression returns `start + limit - simTime()` before expiry and zero afterward.

## Impact

Code that uses the remaining TXOP duration can now make scheduling decisions from the actual available budget. The inactive-state behavior is unchanged: querying before the TXOP starts or after it ends still raises a runtime error.

## Validation

- `source ./setenv -q && make MODE=release -j$(nproc)`
- `source ./setenv -q && inet_run_unit_tests -m release -f 'Ieee80211TxopProcedure_1\.test'`

The focused test covers the inactive state, the full limit at startup, partial elapsed time, exact expiry, post-expiry clamping, and the state after ending the TXOP.
