### PR TITLE
mipv6: complete a first home registration in a single Binding Update

### DIFF
--- a/src/inet/networklayer/ipv6/Mipv6InterfaceData.h
+++ b/src/inet/networklayer/ipv6/Mipv6InterfaceData.h
@@ -31,10 +31,19 @@ namespace inet {
 #define MIPv6_MAX_UPDATE_RATE                  3 // times
 #define MIPv6_PREFIX_ADV_RETRIES               3 // retransmissions
 #define MIPv6_PREFIX_ADV_TIMEOUT               3 // seconds
-#define MIPv6_INITIAL_BINDACK_TIMEOUT_FIRST    1 // seconds
 #define MIPv6_MAX_RR_BINDING_LIFETIME          420 // seconds
 #define MIPv6_MAX_HA_BINDING_LIFETIME          3600 // seconds (1 hour)
 /***************END of RFC 3775 Protocol Constants*****************************/
+
+/*********RFC 3775: Section 13 Protocol Configuration Variables****************/
+// InitialBindackTimeoutFirstReg is the initial Binding Update retransmission
+// timeout of a home registration for which the mobile node holds no binding
+// yet. RFC 3775 and RFC 6275 derive its 1.5 second default as 1.5 times
+// RetransTimer (RFC 4861) times DupAddrDetectTransmits (RFC 4862), so that the
+// timer outlasts the Duplicate Address Detection that the home agent performs
+// before it acknowledges such a registration.
+#define MIPv6_INITIAL_BINDACK_TIMEOUT_FIRST    1.5 // seconds
+/*********END of RFC 3775 Protocol Configuration Variables*********************/
 
 /**
  * Mobile IPv6 (RFC 3775) per-interface data: the Mobile Node's home address and

--- a/src/inet/networklayer/mipv6/Mipv6.cc
+++ b/src/inet/networklayer/mipv6/Mipv6.cc
@@ -412,13 +412,21 @@ void Mipv6::createBUTimer(const Ipv6Address& buDest, NetworkInterface *ie, const
        If the mobile node is sending a Binding Update and does not have
        an existing binding at the home agent, it SHOULD use
        InitialBindackTimeoutFirstReg (see Section 13) as a value for the
-       initial retransmission timer.*/
-    if (!bul->isInBindingUpdateList(buDest))
+       initial retransmission timer.  This long retransmission interval
+       will allow the home agent to complete the Duplicate Address
+       Detection procedure mandated in this case*/
+    // hasActiveBinding() is the test the RFC describes. A Binding Update List entry
+    // exists from the moment a Binding Update is attempted -- the createBUTimer()
+    // overload above creates one through fetch() -- so its mere presence says nothing
+    // about whether the home agent holds a binding. Only a home registration makes the
+    // home agent run Duplicate Address Detection, so a first Binding Update sent to a
+    // correspondent node keeps the shorter INITIAL_BINDACK_TIMEOUT.
+    if (homeRegistration && !bul->hasActiveBinding(buDest))
         buIfEntry->ackTimeout = ie->getProtocolData<Mipv6InterfaceData>()->_getInitialBindAckTimeoutFirst(); // the backoff constant gets initialised here
     /*Otherwise, the mobile node should use the specified value of
        INITIAL_BINDACK_TIMEOUT for the initial retransmission timer.*/
     else
-        buIfEntry->ackTimeout = ie->getProtocolData<Mipv6InterfaceData>()->_getInitialBindAckTimeout(); // if there's an entry in the BUL, use different value
+        buIfEntry->ackTimeout = ie->getProtocolData<Mipv6InterfaceData>()->_getInitialBindAckTimeout();
 
     buIfEntry->homeRegistration = homeRegistration;
 

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -380,9 +380,9 @@
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c MultiRadio -r 0,             20s,             ec17-5cc2/tplx;55f5-0894/~tNl, PASS,  wireless adhoc Ipv4
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c SingleRadio -r 0,            20s,             85a0-51b8/tplx;c07a-44e1/~tNl;3aa0-49ed/tyf, PASS,  wireless adhoc Ipv4
 
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             19b8-20a4/tplx;b378-071d/~tNl;d358-e3bb/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             3f0c-078d/tplx;04e1-1f03/~tNl;4199-2b15/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             0798-40c2/tplx;a682-8d0e/~tNl;cdb7-1b34/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             1b65-9399/tplx;7c59-82c1/~tNl;8fe2-6dff/~tND;294d-c189/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             a792-7cff/tplx;d858-66a6/~tNl;4f74-d139/~tND;6826-7aa6/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             96e7-53b1/tplx;94b5-af90/~tNl;d72a-de62/~tND;89c6-1d0f/tyf, PASS, wireless EthernetMac
 /examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             f614-da0d/tplx;8b55-7191/~tNl;b490-dc09/~tND;0277-d784/tyf, PASS, wireless EthernetMac
 
 /examples/mobility/,                 -f omnetpp.ini -c AnsimMobility -r 0,          10000s,          72f8-5c0b/tplx;0000-0000/~tNl;0000-0000/~tND;7dd1-18eb/tyf, PASS,

--- a/tests/fingerprint/mipv6-refactoring.csv
+++ b/tests/fingerprint/mipv6-refactoring.csv
@@ -8,9 +8,9 @@
 # empty-shim step, which kept these fingerprints bit-for-bit identical.
 
 # MIPv6 example — the primary test
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            aa29-a8c5/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            068b-23aa/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            c8dc-27c2/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            bc88-95b3/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            abae-e24b/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            1d35-5070/~tNlb, PASS, wireless EthernetMac
 
 # IPv6 examples
 # MLD example — new PASS row; ~tNl locks the MLD Report/Query/Done/MAS-Query packet exchange (traffic+lengths);


### PR DESCRIPTION
Makes a first Mobile IPv6 home registration complete in a single Binding Update, as
RFC 6275 intends. Two independent defects had to be fixed together; either one alone
leaves the behaviour unchanged.

Closes #1132
Closes #1133

## The problem

The Home Agent (HA) models Duplicate Address Detection (DAD) as a 1 second delay before
it returns the Binding Acknowledgement (BA) for a new home address, which matches
`DupAddrDetectTransmits` x `RetransTimer`. The Mobile Node (MN) waited exactly 1 second
before retransmitting, so the Binding Acknowledgement (BA) could never win. Measured in
`examples/ipv6/mipv6 -c Handover` before the fix:

| Event | Time (s) |
| --- | --- |
| Binding Update (BU) #1 sent by Mobile Node (MN) | 21.750074 |
| Binding Update (BU) #1 received by Home Agent (HA) | 21.750737 |
| Mobile Node (MN) retransmission timer expires (+1.000 s) | 22.750074 |
| Binding Update (BU) #2 sent | 22.750074 |
| Binding Acknowledgement (BA) for Binding Update (BU) #1 arrives | 22.752424 |
| Binding Acknowledgement (BA) for Binding Update (BU) #2 arrives | 22.753396 |

The acknowledgement lost by 2.35 ms. RFC 6275 sizes `InitialBindackTimeoutFirstReg` at
1.5 times the Duplicate Address Detection (DAD) time precisely to provide that margin.

## The two defects

**1 — the branch that reads the value is unreachable (#1132).** `Mipv6::createBUTimer()`
implements the RFC 6275 section 11.8 rule, but its two-argument overload calls
`BindingUpdateList::fetch()`, a lookup-or-**create**, before the four-argument overload
tests `!bul->isInBindingUpdateList(buDest)`. The entry always exists by then, so
`_getInitialBindAckTimeoutFirst()` was never called on any path. Raising
`MIPv6_INITIAL_BINDACK_TIMEOUT_FIRST` to 7 changed nothing at all, which is how this
surfaced.

Fixed by testing what the RFC actually names — an existing binding — through
`hasActiveBinding()`, and only for a home registration, since a Binding Update (BU) sent
to a Correspondent Node (CN) triggers no Duplicate Address Detection (DAD) and keeps
`INITIAL_BINDACK_TIMEOUT`.

**2 — the value itself is wrong (#1133).** `MIPv6_INITIAL_BINDACK_TIMEOUT_FIRST` was 1,
where RFC 3775 and RFC 6275 section 13 specify a default of 1.5 seconds. The definition
also sat inside the section 12 protocol-constants block although it is a section 13
protocol configuration variable, and has been moved to a correctly labelled block.

## Why both commits are needed

| State | Binding Updates (BUs) for the first registration |
| --- | --- |
| Before this pull request | 2 |
| Value raised to 7 s, branch still dead | 2 (no effect whatsoever) |
| Branch repaired, value left at 1 s | 2 |
| Both commits | **1** |

The first commit is behaviour-neutral in isolation, because both constants hold 1 second
at that point. Its fingerprints and module test results are byte-identical to those of its
parent, so every commit on this branch is green.

## Verification

- `examples/ipv6/mipv6 -c Handover` now sends one Binding Update (BU); the initial timer is
  1.5 s and the Binding Acknowledgement (BA) arrives 1.0012 s after the Binding Update (BU).
- Fingerprints: the three MIPv6 example rows in `tests/fingerprint/examples.csv` and in
  `tests/fingerprint/mipv6-refactoring.csv` are re-recorded and pass. The `pmipv6` row is
  deliberately untouched — it is unaffected, and its stale `tyf` value reproduces identically
  on unmodified master. Three of the re-recorded rows also carried a stale `tyf` value, and
  `mipv6roaming` a stale `~tNlb` value, before this change; the re-recording absorbs them.
- MIPv6 module tests: 10 pass. `MIPv6_tcp_handover` fails identically on unmodified master
  (no TCP data arrives), so that failure is pre-existing and out of scope here.

## Not addressed here

RFC 6275 section 13 states that mobile nodes MUST allow `InitialBindackTimeoutFirstReg` to
be configured by system management. It remains a `#define`. Exposing it as a NED parameter
next to `maxHaBindingLifeTime` and `maxRrBindingLifeTime` is a separate enhancement; #1133
records it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->