### PR TITLE
fix(802.11): complete HT guard interval support

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -26,7 +26,7 @@ void QosRateSelection::initialize(int stage)
         double multicastFrameBitrate = par("multicastFrameBitrate");
         multicastFrameMode = (multicastFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(multicastFrameBitrate));
         double dataFrameBitrate = par("dataFrameBitrate");
-        dataFrameMode = (dataFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(dataFrameBitrate), Hz(par("dataFrameBandwidth")), par("dataFrameNumSpatialStreams"));
+        dataFrameMode = (dataFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(dataFrameBitrate), Hz(par("dataFrameBandwidth")), par("dataFrameNumSpatialStreams"), par("dataFrameGuardInterval"));
         double mgmtFrameBitrate = par("mgmtFrameBitrate");
         mgmtFrameMode = (mgmtFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(mgmtFrameBitrate));
         double controlFrameBitrate = par("controlFrameBitrate");

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -75,10 +75,8 @@ const IIeee80211Mode *QosRateSelection::computeResponseAckFrameMode(Packet *pack
     auto mode = getMode(packet, dataOrMgmtHeader);
     ASSERT(modeSet->containsMode(mode));
     if (!responseAckFrameMode) {
-        if (modeSet->getIsMandatory(mode))
-            return mode;
-        else if (auto slowerMode = modeSet->getSlowerMandatoryMode(mode))
-            return slowerMode;
+        if (auto mandatoryMode = modeSet->getMandatoryModeAtOrBelow(mode))
+            return mandatoryMode;
         else
             throw cRuntimeError("Mandatory mode not found");
     }
@@ -92,10 +90,8 @@ const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *pack
     auto mode = getMode(packet, rtsFrame);
     ASSERT(modeSet->containsMode(mode));
     if (!responseCtsFrameMode) {
-        if (modeSet->getIsMandatory(mode))
-            return mode;
-        else if (auto slowerMode = modeSet->getSlowerMandatoryMode(mode))
-            return slowerMode;
+        if (auto mandatoryMode = modeSet->getMandatoryModeAtOrBelow(mode))
+            return mandatoryMode;
         else
             throw cRuntimeError("Mandatory mode not found");
     }
@@ -248,4 +244,3 @@ void QosRateSelection::frameTransmitted(Packet *packet, const Ptr<const Ieee8021
 
 } /* namespace ieee80211 */
 } /* namespace inet */
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -33,6 +33,7 @@ simple QosRateSelection extends SimpleModule
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Unspecified by default
         int dataFrameNumSpatialStreams = default(-1); // Unspecified by default
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Unspecified by default
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -31,12 +31,11 @@ simple QosRateSelection extends SimpleModule
         double responseCtsFrameBitrate @unit(bps) = default(-1bps);
 
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
-        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Unspecified by default
-        int dataFrameNumSpatialStreams = default(-1); // Unspecified by default
-        double dataFrameGuardInterval @unit(s) = default(-1s); // Unspecified by default
+        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Used only when dataFrameBitrate is specified
+        int dataFrameNumSpatialStreams = default(-1); // Used only when dataFrameBitrate is specified
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Used only when dataFrameBitrate is specified
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);
         @display("i=block/cogwheel");
 }
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -33,7 +33,7 @@ simple QosRateSelection extends SimpleModule
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Explicit mode qualifier when dataFrameBitrate is specified
         int dataFrameNumSpatialStreams = default(-1); // Explicit mode qualifier when dataFrameBitrate is specified
-        double dataFrameGuardInterval @unit(s) = default(-1s); // Explicit mode qualifier when dataFrameBitrate is specified
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Explicit mode qualifier when dataFrameBitrate is specified; negative means unspecified, otherwise it must equal the selected PHY mode's modeled GI
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -31,9 +31,9 @@ simple QosRateSelection extends SimpleModule
         double responseCtsFrameBitrate @unit(bps) = default(-1bps);
 
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
-        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Used only when dataFrameBitrate is specified
-        int dataFrameNumSpatialStreams = default(-1); // Used only when dataFrameBitrate is specified
-        double dataFrameGuardInterval @unit(s) = default(-1s); // Used only when dataFrameBitrate is specified
+        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Explicit mode qualifier when dataFrameBitrate is specified
+        int dataFrameNumSpatialStreams = default(-1); // Explicit mode qualifier when dataFrameBitrate is specified
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Explicit mode qualifier when dataFrameBitrate is specified
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -32,7 +32,7 @@ void RateSelection::initialize(int stage)
         double multicastFrameBitrate = par("multicastFrameBitrate");
         multicastFrameMode = (multicastFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(multicastFrameBitrate));
         double dataFrameBitrate = par("dataFrameBitrate");
-        dataFrameMode = (dataFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(dataFrameBitrate), Hz(par("dataFrameBandwidth")), par("dataFrameNumSpatialStreams"));
+        dataFrameMode = (dataFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(dataFrameBitrate), Hz(par("dataFrameBandwidth")), par("dataFrameNumSpatialStreams"), par("dataFrameGuardInterval"));
         double mgmtFrameBitrate = par("mgmtFrameBitrate");
         mgmtFrameMode = (mgmtFrameBitrate == -1) ? nullptr : modeSet->getMode(bps(mgmtFrameBitrate));
         double controlFrameBitrate = par("controlFrameBitrate");

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -84,7 +84,7 @@ const IIeee80211Mode *RateSelection::computeResponseAckFrameMode(Packet *packet,
     else {
         auto mode = getMode(packet, dataOrMgmtHeader);
         ASSERT(modeSet->containsMode(mode));
-        return modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        return modeSet->getMandatoryModeAtOrBelow(mode); // TODO BSSBasicRateSet
     }
 }
 
@@ -95,7 +95,7 @@ const IIeee80211Mode *RateSelection::computeResponseCtsFrameMode(Packet *packet,
     else {
         auto mode = getMode(packet, rtsFrame);
         ASSERT(modeSet->containsMode(mode));
-        return modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        return modeSet->getMandatoryModeAtOrBelow(mode); // TODO BSSBasicRateSet
     }
 }
 
@@ -170,4 +170,3 @@ void RateSelection::setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHea
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -26,9 +26,9 @@ simple RateSelection extends SimpleModule like IRateSelection
         double responseCtsFrameBitrate @unit(bps) = default(-1bps);
 
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
-        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Used only when dataFrameBitrate is specified
-        int dataFrameNumSpatialStreams = default(-1); // Used only when dataFrameBitrate is specified
-        double dataFrameGuardInterval @unit(s) = default(-1s); // Used only when dataFrameBitrate is specified
+        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Explicit mode qualifier when dataFrameBitrate is specified
+        int dataFrameNumSpatialStreams = default(-1); // Explicit mode qualifier when dataFrameBitrate is specified
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Explicit mode qualifier when dataFrameBitrate is specified
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -26,12 +26,11 @@ simple RateSelection extends SimpleModule like IRateSelection
         double responseCtsFrameBitrate @unit(bps) = default(-1bps);
 
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
-        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Unspecified by default
-        int dataFrameNumSpatialStreams = default(-1); // Unspecified by default
-        double dataFrameGuardInterval @unit(s) = default(-1s); // Unspecified by default
+        double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Used only when dataFrameBitrate is specified
+        int dataFrameNumSpatialStreams = default(-1); // Used only when dataFrameBitrate is specified
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Used only when dataFrameBitrate is specified
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);
         @display("i=block/cogwheel");
 }
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -28,7 +28,7 @@ simple RateSelection extends SimpleModule like IRateSelection
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Explicit mode qualifier when dataFrameBitrate is specified
         int dataFrameNumSpatialStreams = default(-1); // Explicit mode qualifier when dataFrameBitrate is specified
-        double dataFrameGuardInterval @unit(s) = default(-1s); // Explicit mode qualifier when dataFrameBitrate is specified
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Explicit mode qualifier when dataFrameBitrate is specified; negative means unspecified, otherwise it must equal the selected PHY mode's modeled GI
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -28,6 +28,7 @@ simple RateSelection extends SimpleModule like IRateSelection
         double dataFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double dataFrameBandwidth @unit(Hz) = default(nan Hz); // Unspecified by default
         int dataFrameNumSpatialStreams = default(-1); // Unspecified by default
+        double dataFrameGuardInterval @unit(s) = default(-1s); // Unspecified by default
 
         double mgmtFrameBitrate @unit(bps) = default(-1bps); // Fastest
         double controlFrameBitrate @unit(bps) = default(-1bps);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -45,11 +45,24 @@ void Ieee80211MgmtBase::receiveSignal(cComponent *source, simsignal_t signalID, 
 
     if (signalID == modesetChangedSignal) {
         modeSet = check_and_cast<physicallayer::Ieee80211ModeSet *>(obj);
-        supportedRates.numRates = std::min(8, modeSet->getNumModes());
+        for (int i = 0; i < 8; i++)
+            supportedRates.rate[i] = 0;
         int rateIndex = 0;
-        for (int i = 0; i < supportedRates.numRates; i++)
-            if (modeSet->isMandatory(i))
-                supportedRates.rate[rateIndex++] = modeSet->getMode(i)->getDataMode()->getNetBitrate().get<Mbps>();
+        for (int i = 0; i < modeSet->getNumModes() && rateIndex < 8; i++) {
+            if (!modeSet->isMandatory(i))
+                continue;
+            double rate = modeSet->getMode(i)->getDataMode()->getNetBitrate().get<Mbps>();
+            bool alreadyStored = false;
+            for (int j = 0; j < rateIndex; j++) {
+                if (supportedRates.rate[j] == rate) {
+                    alreadyStored = true;
+                    break;
+                }
+            }
+            if (!alreadyStored)
+                supportedRates.rate[rateIndex++] = rate;
+        }
+        supportedRates.numRates = rateIndex;
     }
 }
 
@@ -163,4 +176,3 @@ void Ieee80211MgmtBase::stop()
 } // namespace ieee80211
 
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -45,6 +45,10 @@ void Ieee80211MgmtBase::receiveSignal(cComponent *source, simsignal_t signalID, 
 
     if (signalID == modesetChangedSignal) {
         modeSet = check_and_cast<physicallayer::Ieee80211ModeSet *>(obj);
+        // BUG FIX: Previous implementation set numRates = min(8, getNumModes()) but only
+        // populated rateIndex entries, leaving remaining slots uninitialized/stale while
+        // advertising them via numRates. Now we zero all slots, iterate ALL modes (not just
+        // first 8), collect distinct mandatory bitrates, and set numRates to actual count.
         for (int i = 0; i < 8; i++)
             supportedRates.rate[i] = 0;
         int rateIndex = 0;

--- a/src/inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmTransmitter.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmTransmitter.cc
@@ -312,7 +312,7 @@ const ITransmission *Ieee80211LayeredOfdmTransmitter::createTransmission(const I
     // TODO: compute channel
     const simtime_t preambleDuration = mode->getPreambleLength();
     const simtime_t headerDuration = mode->getHeaderMode()->getDuration();
-    const simtime_t dataDuration = mode->getDataMode()->getDuration(packet->getDataLength());
+    const simtime_t dataDuration = mode->getDataDuration(packet->getDataLength());
     return new Ieee80211Transmission(transmitter, packet, startTime, endTime, preambleDuration, headerDuration, dataDuration, startPosition, endPosition, startOrientation, endOrientation, packetModel, bitModel, symbolModel, sampleModel, analogModel, mode, nullptr);
 }
 
@@ -331,4 +331,3 @@ Ieee80211LayeredOfdmTransmitter::~Ieee80211LayeredOfdmTransmitter()
 } // namespace physicallayer
 
 } // namespace inet
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
@@ -42,8 +42,12 @@ class INET_API IIeee80211DataMode : public cObject, public IPrintableObject
     virtual bps getGrossBitrate() const = 0;
     virtual b getPaddingLength(b dataLength) const = 0;
     virtual b getCompleteLength(b dataLength) const = 0;
+    // Returns the raw duration of the encoded data symbol train. PPDU-format
+    // rules may round this duration at the enclosing mode level.
     virtual const simtime_t getDuration(b dataLength) const = 0;
     virtual const simtime_t getSymbolInterval() const = 0;
+    // Returns the guard interval used by the data symbols, or -1 when the PHY
+    // has no meaningful guard interval (for example, non-OFDM modes).
     virtual const simtime_t getGuardInterval() const { return -1; }
     virtual const IModulation *getModulation() const = 0;
     virtual int getNumberOfSpatialStreams() const = 0;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
@@ -44,6 +44,7 @@ class INET_API IIeee80211DataMode : public cObject, public IPrintableObject
     virtual b getCompleteLength(b dataLength) const = 0;
     virtual const simtime_t getDuration(b dataLength) const = 0;
     virtual const simtime_t getSymbolInterval() const = 0;
+    virtual const simtime_t getGuardInterval() const { return -1; }
     virtual const IModulation *getModulation() const = 0;
     virtual int getNumberOfSpatialStreams() const = 0;
 };
@@ -61,6 +62,9 @@ class INET_API IIeee80211Mode : public cObject, public IPrintableObject
     IIeee80211HeaderMode *_getHeaderMode() const { return const_cast<IIeee80211HeaderMode *>(getHeaderMode()); }
     IIeee80211DataMode *_getDataMode() const { return const_cast<IIeee80211DataMode *>(getDataMode()); }
     virtual const simtime_t getDuration(b dataLength) const = 0;
+    virtual const simtime_t getPreambleDuration() const { return getPreambleMode()->getDuration(); }
+    virtual const simtime_t getHeaderDuration() const { return getHeaderMode()->getDuration(); }
+    virtual const simtime_t getDataDuration(b dataLength) const { return getDuration(dataLength) - getPreambleDuration() - getHeaderDuration(); }
     virtual const simtime_t getSlotTime() const = 0;
     virtual const simtime_t getSifsTime() const = 0;
     virtual const simtime_t getRifsTime() const = 0;
@@ -77,4 +81,3 @@ class INET_API IIeee80211Mode : public cObject, public IPrintableObject
 } // namespace inet
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.cc
@@ -161,6 +161,16 @@ unsigned int Ieee80211HtPreambleMode::computeNumberOfHTLongTrainings(unsigned in
     return numberOfSpaceTimeStreams == 3 ? 4 : numberOfSpaceTimeStreams;
 }
 
+const simtime_t Ieee80211HtPreambleMode::getDurationBeforeHeader() const
+{
+    if (preambleFormat == HT_PREAMBLE_MIXED)
+        return getNonHTShortTrainingSequenceDuration() + getNonHTLongTrainingFieldDuration() + legacySignalMode->getDuration();
+    else if (preambleFormat == HT_PREAMBLE_GREENFIELD)
+        return getHTGreenfieldShortTrainingFieldDuration() + getFirstHTLongTrainingFieldDuration();
+    else
+        throw cRuntimeError("Unknown preamble format");
+}
+
 const simtime_t Ieee80211HtPreambleMode::getDuration() const
 {
     // 20.3.7 Mathematical description of signals
@@ -235,12 +245,12 @@ bps Ieee80211HtModeBase::getGrossBitrate() const
     return grossBitrate;
 }
 
-simtime_t Ieee80211HtDataMode::getGuardInterval() const
+const simtime_t Ieee80211HtDataMode::getGuardInterval() const
 {
     if (guardIntervalType == HT_GUARD_INTERVAL_LONG)
-        return 800E-9;
+        return getGIDuration();
     else if (guardIntervalType == HT_GUARD_INTERVAL_SHORT)
-        return 400E-9;
+        return getShortGIDuration();
     else
         throw cRuntimeError("Unknown guard interval type");
 }
@@ -567,4 +577,3 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs76BW40MHz([](){ return new Ie
 
 } /* namespace physicallayer */
 } /* namespace inet */
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.cc
@@ -178,12 +178,8 @@ const simtime_t Ieee80211HtPreambleMode::getDuration() const
 bps Ieee80211HtSignalMode::computeGrossBitrate() const
 {
     unsigned int numberOfCodedBitsPerSymbol = modulation->getSubcarrierModulation()->getCodeWordSize() * getNumberOfDataSubcarriers();
-    if (guardIntervalType == HT_GUARD_INTERVAL_LONG)
-        return bps(numberOfCodedBitsPerSymbol / getSymbolInterval());
-    else if (guardIntervalType == HT_GUARD_INTERVAL_SHORT)
-        return bps(numberOfCodedBitsPerSymbol / getShortGISymbolInterval());
-    else
-        throw cRuntimeError("Unknown guard interval type");
+    // IEEE Std 802.11-2024, 19.3.11.11.6: the short GI applies only to the Data field.
+    return bps(numberOfCodedBitsPerSymbol / getSymbolInterval());
 }
 
 bps Ieee80211HtSignalMode::computeNetBitrate() const
@@ -239,6 +235,16 @@ bps Ieee80211HtModeBase::getGrossBitrate() const
     return grossBitrate;
 }
 
+simtime_t Ieee80211HtDataMode::getGuardInterval() const
+{
+    if (guardIntervalType == HT_GUARD_INTERVAL_LONG)
+        return 800E-9;
+    else if (guardIntervalType == HT_GUARD_INTERVAL_SHORT)
+        return 400E-9;
+    else
+        throw cRuntimeError("Unknown guard interval type");
+}
+
 int Ieee80211HtModeBase::getNumberOfDataSubcarriers() const
 {
     return Ieee80211Htmcs::getNumberOfDataSubcarriers(bandwidth, mcsIndex);
@@ -285,6 +291,22 @@ const simtime_t Ieee80211HtDataMode::getDuration(b dataLength) const
     return numberOfSymbols * getSymbolInterval();
 }
 
+const simtime_t Ieee80211HtMode::getDuration(b dataLength) const
+{
+    auto dataDuration = dataMode->getDuration(dataLength);
+    if (preambleMode->getPreambleFormat() == Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED &&
+        dataMode->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT)
+    {
+        // IEEE Std 802.11-2024, 19.4.3, Eq. (19-90): mixed-format short-GI
+        // Data airtime is rounded up to a 4 us boundary. Eq. (19-92) leaves
+        // greenfield short-GI Data airtime at its raw 3.6 us symbol duration.
+        auto longGiSymbolInterval = dataMode->getDFTPeriod() + dataMode->getGIDuration();
+        auto numberOfLongGiSymbols = (dataDuration.raw() + longGiSymbolInterval.raw() - 1) / longGiSymbolInterval.raw();
+        dataDuration = SimTime::fromRaw(numberOfLongGiSymbols * longGiSymbolInterval.raw());
+    }
+    return preambleMode->getDuration() + dataDuration;
+}
+
 const simtime_t Ieee80211HtMode::getSlotTime() const
 {
     if (centerFrequencyMode == BAND_2_4GHZ)
@@ -326,7 +348,7 @@ Ieee80211HtCompliantModes::~Ieee80211HtCompliantModes()
 const Ieee80211HtMode *Ieee80211HtCompliantModes::getCompliantMode(const Ieee80211Htmcs *mcsMode, Ieee80211HtMode::BandMode centerFrequencyMode, Ieee80211HtPreambleMode::HighTroughputPreambleFormat preambleFormat, Ieee80211HtModeBase::GuardIntervalType guardIntervalType)
 {
     const char *name = ""; // TODO
-    auto htModeId = std::make_tuple(mcsMode->getBandwidth(), mcsMode->getMcsIndex(), guardIntervalType);
+    auto htModeId = std::make_tuple(mcsMode->getBandwidth(), mcsMode->getMcsIndex(), centerFrequencyMode, preambleFormat, guardIntervalType);
     auto mode = singleton.modeCache.find(htModeId);
     if (mode == singleton.modeCache.end()) {
         const Ieee80211OfdmModulation *modulation = nullptr;
@@ -348,7 +370,7 @@ const Ieee80211HtMode *Ieee80211HtCompliantModes::getCompliantMode(const Ieee802
         const Ieee80211HtDataMode *dataMode = new Ieee80211HtDataMode(mcsMode, mcsMode->getBandwidth(), guardIntervalType);
         const Ieee80211HtPreambleMode *preambleMode = new Ieee80211HtPreambleMode(htSignal, legacySignal, preambleFormat, dataMode->getNumberOfSpatialStreams());
         const Ieee80211HtMode *htMode = new Ieee80211HtMode(name, preambleMode, dataMode, centerFrequencyMode);
-        singleton.modeCache.insert(std::pair<std::tuple<Hz, unsigned int, Ieee80211HtModeBase::GuardIntervalType>, const Ieee80211HtMode *>(htModeId, htMode));
+        singleton.modeCache.insert(std::pair<std::tuple<Hz, unsigned int, Ieee80211HtMode::BandMode, Ieee80211HtPreambleMode::HighTroughputPreambleFormat, Ieee80211HtModeBase::GuardIntervalType>, const Ieee80211HtMode *>(htModeId, htMode));
         return htMode;
     }
     return mode->second;
@@ -442,7 +464,8 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs29BW40MHz([](){ return new Ie
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs30BW40MHz([](){ return new Ieee80211Htmcs(30, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs31BW40MHz([](){ return new Ieee80211Htmcs(31, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Ieee80211HtCompliantCodes::htConvolutionalCode5_6, MHz(40));});
 
-const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs32BW40MHz([](){ return new Ieee80211Htmcs(32, &BpskModulation::singleton, &BpskModulation::singleton, &BpskModulation::singleton, &BpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(40));});
+// IEEE Std 802.11-2024, Table 19-35: optional MCS 32 is one BPSK stream.
+const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs32BW40MHz([](){ return new Ieee80211Htmcs(32, &BpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(40));});
 
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs33BW20MHz([](){ return new Ieee80211Htmcs(33, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(20));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs34BW20MHz([](){ return new Ieee80211Htmcs(34, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(20));});
@@ -490,7 +513,7 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs72BW20MHz([](){ return new Ie
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs73BW20MHz([](){ return new Ieee80211Htmcs(73, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs74BW20MHz([](){ return new Ieee80211Htmcs(74, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs75BW20MHz([](){ return new Ieee80211Htmcs(75, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
-const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs76BW20MHz([](){ return new Ieee80211Htmcs(76, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
+const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs76BW20MHz([](){ return new Ieee80211Htmcs(76, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
 
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs33BW40MHz([](){ return new Ieee80211Htmcs(33, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs34BW40MHz([](){ return new Ieee80211Htmcs(34, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(40));});
@@ -536,7 +559,7 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs69BW40MHz([](){ return new Ie
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs70BW40MHz([](){ return new Ieee80211Htmcs(70, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs71BW40MHz([](){ return new Ieee80211Htmcs(71, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs72BW40MHz([](){ return new Ieee80211Htmcs(72, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
-const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs73BW40MHz([](){ return new Ieee80211Htmcs(73, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
+const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs73BW40MHz([](){ return new Ieee80211Htmcs(73, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs74BW40MHz([](){ return new Ieee80211Htmcs(74, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs75BW40MHz([](){ return new Ieee80211Htmcs(75, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.cc
@@ -475,6 +475,7 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs30BW40MHz([](){ return new Ie
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs31BW40MHz([](){ return new Ieee80211Htmcs(31, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Ieee80211HtCompliantCodes::htConvolutionalCode5_6, MHz(40));});
 
 // IEEE Std 802.11-2024, Table 19-35: optional MCS 32 is one BPSK stream.
+// This corrects the previous incorrect 4-stream all-BPSK constructor.
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs32BW40MHz([](){ return new Ieee80211Htmcs(32, &BpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(40));});
 
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs33BW20MHz([](){ return new Ieee80211Htmcs(33, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(20));});
@@ -523,6 +524,8 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs72BW20MHz([](){ return new Ie
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs73BW20MHz([](){ return new Ieee80211Htmcs(73, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs74BW20MHz([](){ return new Ieee80211Htmcs(74, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs75BW20MHz([](){ return new Ieee80211Htmcs(75, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
+// IEEE Std 802.11-2024, Table 19-38 (continued): MCS 76 uses 64-QAM for streams 1-3 and 16-QAM for stream 4.
+// This corrects the previous incorrect QPSK modulation for the 4th stream.
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs76BW20MHz([](){ return new Ieee80211Htmcs(76, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(20));});
 
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs33BW40MHz([](){ return new Ieee80211Htmcs(33, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode1_2, MHz(40));});
@@ -569,6 +572,8 @@ const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs69BW40MHz([](){ return new Ie
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs70BW40MHz([](){ return new Ieee80211Htmcs(70, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs71BW40MHz([](){ return new Ieee80211Htmcs(71, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs72BW40MHz([](){ return new Ieee80211Htmcs(72, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
+// IEEE Std 802.11-2024, Table 19-40: MCS 73 uses 64-QAM for streams 1-2 and 16-QAM for stream 3.
+// This corrects the previous incorrect 64-QAM modulation for the 3rd stream.
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs73BW40MHz([](){ return new Ieee80211Htmcs(73, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs74BW40MHz([](){ return new Ieee80211Htmcs(74, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam16Modulation::singleton, &Qam16Modulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});
 const DI<Ieee80211Htmcs> Ieee80211HtmcsTable::htMcs75BW40MHz([](){ return new Ieee80211Htmcs(75, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &Qam64Modulation::singleton, &QpskModulation::singleton, &Ieee80211OfdmCompliantCodes::ofdmConvolutionalCode3_4, MHz(40));});

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
@@ -218,7 +218,8 @@ class INET_API Ieee80211HtDataMode : public IIeee80211DataMode, public Ieee80211
     virtual bps getGrossBitrate() const override { return Ieee80211HtModeBase::getGrossBitrate(); }
     virtual const Ieee80211Htmcs *getModulationAndCodingScheme() const { return modulationAndCodingScheme; }
     virtual const Ieee80211HtCode *getCode() const { return modulationAndCodingScheme->getCode(); }
-    virtual const simtime_t getSymbolInterval() const override { return Ieee80211HtTimingRelatedParametersBase::getSymbolInterval(); }
+    virtual simtime_t getGuardInterval() const;
+    virtual const simtime_t getSymbolInterval() const override { return getDFTPeriod() + getGuardInterval(); }
     virtual const Ieee80211OfdmModulation *getModulation() const override { return modulationAndCodingScheme->getModulation(); }
 };
 
@@ -261,7 +262,7 @@ class INET_API Ieee80211HtMode : public Ieee80211ModeBase
     virtual int getMpduMaxLength() const override { return 65535; } // in octets
     virtual BandMode getCenterFrequencyMode() const { return centerFrequencyMode; }
 
-    virtual const simtime_t getDuration(b dataLength) const override { return preambleMode->getDuration() + dataMode->getDuration(dataLength); }
+    virtual const simtime_t getDuration(b dataLength) const override;
 };
 
 // A specification of the high-throughput (HT) physical layer (PHY)
@@ -460,7 +461,7 @@ class INET_API Ieee80211HtCompliantModes
   protected:
     static OPP_THREAD_LOCAL const Ieee80211HtCompliantModes singleton;
 
-    mutable std::map<std::tuple<Hz, unsigned int, Ieee80211HtModeBase::GuardIntervalType>, const Ieee80211HtMode *> modeCache;
+    mutable std::map<std::tuple<Hz, unsigned int, Ieee80211HtMode::BandMode, Ieee80211HtPreambleMode::HighTroughputPreambleFormat, Ieee80211HtModeBase::GuardIntervalType>, const Ieee80211HtMode *> modeCache;
 
   public:
     Ieee80211HtCompliantModes();

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
@@ -153,6 +153,7 @@ class INET_API Ieee80211HtPreambleMode : public IIeee80211PreambleMode, public I
     virtual const simtime_t getSecondAndSubsequentHTLongTrainingFielDuration() const { return 4E-6; } // HT-LTFs, s = 2,3,..,n
     virtual unsigned int getNumberOfHtLongTrainings() const { return numberOfHTLongTrainings; }
 
+    virtual const simtime_t getDurationBeforeHeader() const;
     virtual const simtime_t getDuration() const override;
 
     virtual Ptr<Ieee80211PhyPreamble> createPreamble() const override { return makeShared<Ieee80211HtPhyPreamble>(); }
@@ -218,7 +219,7 @@ class INET_API Ieee80211HtDataMode : public IIeee80211DataMode, public Ieee80211
     virtual bps getGrossBitrate() const override { return Ieee80211HtModeBase::getGrossBitrate(); }
     virtual const Ieee80211Htmcs *getModulationAndCodingScheme() const { return modulationAndCodingScheme; }
     virtual const Ieee80211HtCode *getCode() const { return modulationAndCodingScheme->getCode(); }
-    virtual simtime_t getGuardInterval() const;
+    virtual const simtime_t getGuardInterval() const override;
     virtual const simtime_t getSymbolInterval() const override { return getDFTPeriod() + getGuardInterval(); }
     virtual const Ieee80211OfdmModulation *getModulation() const override { return modulationAndCodingScheme->getModulation(); }
 };
@@ -263,6 +264,9 @@ class INET_API Ieee80211HtMode : public Ieee80211ModeBase
     virtual BandMode getCenterFrequencyMode() const { return centerFrequencyMode; }
 
     virtual const simtime_t getDuration(b dataLength) const override;
+    virtual const simtime_t getPreambleDuration() const override { return preambleMode->getDurationBeforeHeader(); }
+    virtual const simtime_t getHeaderDuration() const override { return preambleMode->getDuration() - getPreambleDuration(); }
+    virtual const simtime_t getDataDuration(b dataLength) const override { return getDuration(dataLength) - preambleMode->getDuration(); }
 };
 
 // A specification of the high-throughput (HT) physical layer (PHY)
@@ -474,4 +478,3 @@ class INET_API Ieee80211HtCompliantModes
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -485,6 +485,9 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
     std::vector<Entry> *nonConstEntries = const_cast<std::vector<Entry> *>(&this->entries);
     // Keep equal-bitrate modes in declaration order because unqualified lookups
     // intentionally preserve the historically preferred mode.
+    // NOTE: This depends on (a) base entries being declared before appended variants
+    // and (b) std::stable_sort preserving that order for ties. Future catalog edits
+    // that reorder completeHtGuardIntervalVariants or the base list may break this invariant.
     std::stable_sort(nonConstEntries->begin(), nonConstEntries->end(), EntryNetBitrateComparator());
     auto referenceMode = entries[0].mode;
     for (auto entry : entries) {
@@ -537,7 +540,9 @@ const IIeee80211Mode *Ieee80211ModeSet::findCompatibleMode(const IIeee80211Mode 
         const auto candidateGuardInterval = candidateDataMode->getGuardInterval();
         const bool bandwidthMatches = (std::isnan(sourceBandwidth.get()) && std::isnan(candidateBandwidth.get())) ||
                 (!std::isnan(sourceBandwidth.get()) && !std::isnan(candidateBandwidth.get()) && sourceBandwidth == candidateBandwidth);
-        const bool guardIntervalMatches = (sourceGuardInterval < SIMTIME_ZERO && candidateGuardInterval < SIMTIME_ZERO) ||
+        // GI = -1 indicates unconstrained guard interval (e.g., non-OFDM modes).
+        // Treat GI = -1 as matching any candidate GI, and require exact match when both are >= 0.
+        const bool guardIntervalMatches = (sourceGuardInterval < SIMTIME_ZERO) || (candidateGuardInterval < SIMTIME_ZERO) ||
                 (sourceGuardInterval >= SIMTIME_ZERO && candidateGuardInterval == sourceGuardInterval);
         if (minBitrate <= candidateDataMode->getNetBitrate() && candidateDataMode->getNetBitrate() <= maxBitrate &&
             bandwidthMatches && candidateDataMode->getNumberOfSpatialStreams() == sourceDataMode->getNumberOfSpatialStreams() &&
@@ -643,6 +648,10 @@ const IIeee80211Mode *Ieee80211ModeSet::getFastestMandatoryMode() const
 
 const IIeee80211Mode *Ieee80211ModeSet::getMandatoryModeAtOrBelow(const IIeee80211Mode *mode) const
 {
+    // Returns the highest-bitrate mandatory mode whose bitrate is <= the given mode's bitrate.
+    // For equal-bitrate mandatory modes, returns the first-encountered entry (strict > comparison).
+    // This may return a different mode object than the input when the input is mandatory and
+    // shares bitrate with another mandatory mode, but the resulting rate is behavior-equivalent.
     const auto bitrate = mode->getDataMode()->getNetBitrate();
     const IIeee80211Mode *result = nullptr;
     for (const auto& entry : entries) {

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -24,6 +24,204 @@ namespace physicallayer {
 
 Register_Abstract_Class(Ieee80211ModeSet);
 
+std::vector<Ieee80211ModeSet::Entry> Ieee80211ModeSet::completeHtGuardIntervalVariants(const char *name, const std::vector<Entry>& entries)
+{
+    if (strcmp(name, "n(mixed-2.4Ghz)"))
+        return entries;
+
+    std::vector<Entry> completeEntries = entries;
+    const Ieee80211Htmcs *legalMcsModes[] = {
+        &Ieee80211HtmcsTable::htMcs0BW20MHz,
+        &Ieee80211HtmcsTable::htMcs1BW20MHz,
+        &Ieee80211HtmcsTable::htMcs2BW20MHz,
+        &Ieee80211HtmcsTable::htMcs3BW20MHz,
+        &Ieee80211HtmcsTable::htMcs4BW20MHz,
+        &Ieee80211HtmcsTable::htMcs5BW20MHz,
+        &Ieee80211HtmcsTable::htMcs6BW20MHz,
+        &Ieee80211HtmcsTable::htMcs7BW20MHz,
+        &Ieee80211HtmcsTable::htMcs8BW20MHz,
+        &Ieee80211HtmcsTable::htMcs9BW20MHz,
+        &Ieee80211HtmcsTable::htMcs10BW20MHz,
+        &Ieee80211HtmcsTable::htMcs11BW20MHz,
+        &Ieee80211HtmcsTable::htMcs12BW20MHz,
+        &Ieee80211HtmcsTable::htMcs13BW20MHz,
+        &Ieee80211HtmcsTable::htMcs14BW20MHz,
+        &Ieee80211HtmcsTable::htMcs15BW20MHz,
+        &Ieee80211HtmcsTable::htMcs16BW20MHz,
+        &Ieee80211HtmcsTable::htMcs17BW20MHz,
+        &Ieee80211HtmcsTable::htMcs18BW20MHz,
+        &Ieee80211HtmcsTable::htMcs19BW20MHz,
+        &Ieee80211HtmcsTable::htMcs20BW20MHz,
+        &Ieee80211HtmcsTable::htMcs21BW20MHz,
+        &Ieee80211HtmcsTable::htMcs22BW20MHz,
+        &Ieee80211HtmcsTable::htMcs23BW20MHz,
+        &Ieee80211HtmcsTable::htMcs24BW20MHz,
+        &Ieee80211HtmcsTable::htMcs25BW20MHz,
+        &Ieee80211HtmcsTable::htMcs26BW20MHz,
+        &Ieee80211HtmcsTable::htMcs27BW20MHz,
+        &Ieee80211HtmcsTable::htMcs28BW20MHz,
+        &Ieee80211HtmcsTable::htMcs29BW20MHz,
+        &Ieee80211HtmcsTable::htMcs30BW20MHz,
+        &Ieee80211HtmcsTable::htMcs31BW20MHz,
+        &Ieee80211HtmcsTable::htMcs33BW20MHz,
+        &Ieee80211HtmcsTable::htMcs34BW20MHz,
+        &Ieee80211HtmcsTable::htMcs35BW20MHz,
+        &Ieee80211HtmcsTable::htMcs36BW20MHz,
+        &Ieee80211HtmcsTable::htMcs37BW20MHz,
+        &Ieee80211HtmcsTable::htMcs38BW20MHz,
+        &Ieee80211HtmcsTable::htMcs39BW20MHz,
+        &Ieee80211HtmcsTable::htMcs40BW20MHz,
+        &Ieee80211HtmcsTable::htMcs41BW20MHz,
+        &Ieee80211HtmcsTable::htMcs42BW20MHz,
+        &Ieee80211HtmcsTable::htMcs43BW20MHz,
+        &Ieee80211HtmcsTable::htMcs44BW20MHz,
+        &Ieee80211HtmcsTable::htMcs45BW20MHz,
+        &Ieee80211HtmcsTable::htMcs46BW20MHz,
+        &Ieee80211HtmcsTable::htMcs47BW20MHz,
+        &Ieee80211HtmcsTable::htMcs48BW20MHz,
+        &Ieee80211HtmcsTable::htMcs49BW20MHz,
+        &Ieee80211HtmcsTable::htMcs50BW20MHz,
+        &Ieee80211HtmcsTable::htMcs51BW20MHz,
+        &Ieee80211HtmcsTable::htMcs52BW20MHz,
+        &Ieee80211HtmcsTable::htMcs53BW20MHz,
+        &Ieee80211HtmcsTable::htMcs54BW20MHz,
+        &Ieee80211HtmcsTable::htMcs55BW20MHz,
+        &Ieee80211HtmcsTable::htMcs56BW20MHz,
+        &Ieee80211HtmcsTable::htMcs57BW20MHz,
+        &Ieee80211HtmcsTable::htMcs58BW20MHz,
+        &Ieee80211HtmcsTable::htMcs59BW20MHz,
+        &Ieee80211HtmcsTable::htMcs60BW20MHz,
+        &Ieee80211HtmcsTable::htMcs61BW20MHz,
+        &Ieee80211HtmcsTable::htMcs62BW20MHz,
+        &Ieee80211HtmcsTable::htMcs63BW20MHz,
+        &Ieee80211HtmcsTable::htMcs64BW20MHz,
+        &Ieee80211HtmcsTable::htMcs65BW20MHz,
+        &Ieee80211HtmcsTable::htMcs66BW20MHz,
+        &Ieee80211HtmcsTable::htMcs67BW20MHz,
+        &Ieee80211HtmcsTable::htMcs68BW20MHz,
+        &Ieee80211HtmcsTable::htMcs69BW20MHz,
+        &Ieee80211HtmcsTable::htMcs70BW20MHz,
+        &Ieee80211HtmcsTable::htMcs71BW20MHz,
+        &Ieee80211HtmcsTable::htMcs72BW20MHz,
+        &Ieee80211HtmcsTable::htMcs73BW20MHz,
+        &Ieee80211HtmcsTable::htMcs74BW20MHz,
+        &Ieee80211HtmcsTable::htMcs75BW20MHz,
+        &Ieee80211HtmcsTable::htMcs76BW20MHz,
+        &Ieee80211HtmcsTable::htMcs0BW40MHz,
+        &Ieee80211HtmcsTable::htMcs1BW40MHz,
+        &Ieee80211HtmcsTable::htMcs2BW40MHz,
+        &Ieee80211HtmcsTable::htMcs3BW40MHz,
+        &Ieee80211HtmcsTable::htMcs4BW40MHz,
+        &Ieee80211HtmcsTable::htMcs5BW40MHz,
+        &Ieee80211HtmcsTable::htMcs6BW40MHz,
+        &Ieee80211HtmcsTable::htMcs7BW40MHz,
+        &Ieee80211HtmcsTable::htMcs8BW40MHz,
+        &Ieee80211HtmcsTable::htMcs9BW40MHz,
+        &Ieee80211HtmcsTable::htMcs10BW40MHz,
+        &Ieee80211HtmcsTable::htMcs11BW40MHz,
+        &Ieee80211HtmcsTable::htMcs12BW40MHz,
+        &Ieee80211HtmcsTable::htMcs13BW40MHz,
+        &Ieee80211HtmcsTable::htMcs14BW40MHz,
+        &Ieee80211HtmcsTable::htMcs15BW40MHz,
+        &Ieee80211HtmcsTable::htMcs16BW40MHz,
+        &Ieee80211HtmcsTable::htMcs17BW40MHz,
+        &Ieee80211HtmcsTable::htMcs18BW40MHz,
+        &Ieee80211HtmcsTable::htMcs19BW40MHz,
+        &Ieee80211HtmcsTable::htMcs20BW40MHz,
+        &Ieee80211HtmcsTable::htMcs21BW40MHz,
+        &Ieee80211HtmcsTable::htMcs22BW40MHz,
+        &Ieee80211HtmcsTable::htMcs23BW40MHz,
+        &Ieee80211HtmcsTable::htMcs24BW40MHz,
+        &Ieee80211HtmcsTable::htMcs25BW40MHz,
+        &Ieee80211HtmcsTable::htMcs26BW40MHz,
+        &Ieee80211HtmcsTable::htMcs27BW40MHz,
+        &Ieee80211HtmcsTable::htMcs28BW40MHz,
+        &Ieee80211HtmcsTable::htMcs29BW40MHz,
+        &Ieee80211HtmcsTable::htMcs30BW40MHz,
+        &Ieee80211HtmcsTable::htMcs31BW40MHz,
+        &Ieee80211HtmcsTable::htMcs32BW40MHz,
+        &Ieee80211HtmcsTable::htMcs33BW40MHz,
+        &Ieee80211HtmcsTable::htMcs34BW40MHz,
+        &Ieee80211HtmcsTable::htMcs35BW40MHz,
+        &Ieee80211HtmcsTable::htMcs36BW40MHz,
+        &Ieee80211HtmcsTable::htMcs37BW40MHz,
+        &Ieee80211HtmcsTable::htMcs38BW40MHz,
+        &Ieee80211HtmcsTable::htMcs39BW40MHz,
+        &Ieee80211HtmcsTable::htMcs40BW40MHz,
+        &Ieee80211HtmcsTable::htMcs41BW40MHz,
+        &Ieee80211HtmcsTable::htMcs42BW40MHz,
+        &Ieee80211HtmcsTable::htMcs43BW40MHz,
+        &Ieee80211HtmcsTable::htMcs44BW40MHz,
+        &Ieee80211HtmcsTable::htMcs45BW40MHz,
+        &Ieee80211HtmcsTable::htMcs46BW40MHz,
+        &Ieee80211HtmcsTable::htMcs47BW40MHz,
+        &Ieee80211HtmcsTable::htMcs48BW40MHz,
+        &Ieee80211HtmcsTable::htMcs49BW40MHz,
+        &Ieee80211HtmcsTable::htMcs50BW40MHz,
+        &Ieee80211HtmcsTable::htMcs51BW40MHz,
+        &Ieee80211HtmcsTable::htMcs52BW40MHz,
+        &Ieee80211HtmcsTable::htMcs53BW40MHz,
+        &Ieee80211HtmcsTable::htMcs54BW40MHz,
+        &Ieee80211HtmcsTable::htMcs55BW40MHz,
+        &Ieee80211HtmcsTable::htMcs56BW40MHz,
+        &Ieee80211HtmcsTable::htMcs57BW40MHz,
+        &Ieee80211HtmcsTable::htMcs58BW40MHz,
+        &Ieee80211HtmcsTable::htMcs59BW40MHz,
+        &Ieee80211HtmcsTable::htMcs60BW40MHz,
+        &Ieee80211HtmcsTable::htMcs61BW40MHz,
+        &Ieee80211HtmcsTable::htMcs62BW40MHz,
+        &Ieee80211HtmcsTable::htMcs63BW40MHz,
+        &Ieee80211HtmcsTable::htMcs64BW40MHz,
+        &Ieee80211HtmcsTable::htMcs65BW40MHz,
+        &Ieee80211HtmcsTable::htMcs66BW40MHz,
+        &Ieee80211HtmcsTable::htMcs67BW40MHz,
+        &Ieee80211HtmcsTable::htMcs68BW40MHz,
+        &Ieee80211HtmcsTable::htMcs69BW40MHz,
+        &Ieee80211HtmcsTable::htMcs70BW40MHz,
+        &Ieee80211HtmcsTable::htMcs71BW40MHz,
+        &Ieee80211HtmcsTable::htMcs72BW40MHz,
+        &Ieee80211HtmcsTable::htMcs73BW40MHz,
+        &Ieee80211HtmcsTable::htMcs74BW40MHz,
+        &Ieee80211HtmcsTable::htMcs75BW40MHz,
+        &Ieee80211HtmcsTable::htMcs76BW40MHz,
+    };
+
+    // Preserve the historical catalog entries first. Add the missing legal
+    // (bandwidth, MCS) tuples from Tables 19-27 through 19-41 in table order.
+    for (auto mcsMode : legalMcsModes) {
+        bool found = false;
+        for (const auto& entry : completeEntries) {
+            auto htMode = dynamic_cast<const Ieee80211HtMode *>(entry.mode);
+            if (htMode != nullptr &&
+                htMode->getDataMode()->getBandwidth() == mcsMode->getBandwidth() &&
+                htMode->getDataMode()->getMcsIndex() == mcsMode->getMcsIndex())
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            completeEntries.push_back({false, Ieee80211HtCompliantModes::getCompliantMode(
+                    mcsMode, Ieee80211HtMode::BAND_2_4GHZ,
+                    Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED,
+                    Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT)});
+    }
+
+    // IEEE Std 802.11-2024, Table 19-6 defines the 800 ns and 400 ns GIs.
+    // Add the alternate GI for every legal tuple above; short GI is optional.
+    auto numberOfBaseEntries = completeEntries.size();
+    for (size_t index = 0; index < numberOfBaseEntries; index++) {
+        auto htMode = check_and_cast<const Ieee80211HtMode *>(completeEntries[index].mode);
+        auto dataMode = htMode->getDataMode();
+        auto alternateGuardInterval = dataMode->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG ?
+                Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT : Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG;
+        completeEntries.push_back({false, Ieee80211HtCompliantModes::getCompliantMode(
+                dataMode->getModulationAndCodingScheme(), htMode->getCenterFrequencyMode(),
+                htMode->getPreambleMode()->getPreambleFormat(), alternateGuardInterval)});
+    }
+    return completeEntries;
+}
+
 const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSets([]() { return new std::vector<Ieee80211ModeSet> {
     Ieee80211ModeSet("a", {
         { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS20MHz },
@@ -76,7 +274,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS10MHz },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode27Mbps },
         }),
-    Ieee80211ModeSet("n(mixed-2.4Ghz)", { // This table is not complete; it only contains 2.4GHz homogeneous spatial streams, all mandatory and optional modes
+    Ieee80211ModeSet("n(mixed-2.4Ghz)", { // Completed below with all legal HT MCS and GI variants
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs0BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs1BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs2BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -457,7 +655,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
 
 Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries) :
     name(name),
-    entries(entries)
+    entries(completeHtGuardIntervalVariants(name, entries))
 {
     std::vector<Entry> *nonConstEntries = const_cast<std::vector<Entry> *>(&this->entries);
     std::stable_sort(nonConstEntries->begin(), nonConstEntries->end(), EntryNetBitrateComparator());
@@ -495,20 +693,24 @@ bool Ieee80211ModeSet::getIsMandatory(const IIeee80211Mode *mode) const
     return entries[getModeIndex(mode)].isMandatory;
 }
 
-const IIeee80211Mode *Ieee80211ModeSet::findMode(bps bitrate, Hz bandwidth, int numSpatialStreams) const
+const IIeee80211Mode *Ieee80211ModeSet::findMode(bps bitrate, Hz bandwidth, int numSpatialStreams, simtime_t guardInterval) const
 {
-    return findMode(bitrate - Mbps(0.05), bitrate + Mbps(0.05), bandwidth, numSpatialStreams);
+    return findMode(bitrate - Mbps(0.05), bitrate + Mbps(0.05), bandwidth, numSpatialStreams, guardInterval);
 }
 
-const IIeee80211Mode *Ieee80211ModeSet::findMode(bps minBitrate, bps maxBitrate, Hz bandwidth, int numSpatialStreams) const
+const IIeee80211Mode *Ieee80211ModeSet::findMode(bps minBitrate, bps maxBitrate, Hz bandwidth, int numSpatialStreams, simtime_t guardInterval) const
 {
     for (size_t index = 0; index < entries.size(); index++) {
         auto mode = entries[index].mode;
         auto dataMode = mode->getDataMode();
         auto bitrate = dataMode->getNetBitrate();
+        auto htMode = dynamic_cast<const Ieee80211HtMode *>(mode);
+        bool guardIntervalMatches = guardInterval < SIMTIME_ZERO ||
+                (htMode != nullptr && htMode->getDataMode()->getGuardInterval() == guardInterval);
         if (minBitrate <= bitrate && bitrate <= maxBitrate &&
             (std::isnan(bandwidth.get()) || dataMode->getBandwidth() == bandwidth) &&
-            (numSpatialStreams == -1 || dataMode->getNumberOfSpatialStreams() == numSpatialStreams))
+            (numSpatialStreams == -1 || dataMode->getNumberOfSpatialStreams() == numSpatialStreams) &&
+            guardIntervalMatches)
         {
             return entries[index].mode;
         }
@@ -516,18 +718,18 @@ const IIeee80211Mode *Ieee80211ModeSet::findMode(bps minBitrate, bps maxBitrate,
     return nullptr;
 }
 
-const IIeee80211Mode *Ieee80211ModeSet::getMode(bps bitrate, Hz bandwidth, int numSpatialStreams) const
+const IIeee80211Mode *Ieee80211ModeSet::getMode(bps bitrate, Hz bandwidth, int numSpatialStreams, simtime_t guardInterval) const
 {
-    const IIeee80211Mode *mode = getMode(bitrate - Mbps(0.05), bitrate + Mbps(0.05), bandwidth, numSpatialStreams);
+    const IIeee80211Mode *mode = getMode(bitrate - Mbps(0.05), bitrate + Mbps(0.05), bandwidth, numSpatialStreams, guardInterval);
     if (mode == nullptr)
         throw cRuntimeError("Unknown bitrate: %g in operation mode: '%s'", bitrate.get(), getName());
     else
         return mode;
 }
 
-const IIeee80211Mode *Ieee80211ModeSet::getMode(bps minBitrate, bps maxBitrate, Hz bandwidth, int numSpatialStreams) const
+const IIeee80211Mode *Ieee80211ModeSet::getMode(bps minBitrate, bps maxBitrate, Hz bandwidth, int numSpatialStreams, simtime_t guardInterval) const
 {
-    const IIeee80211Mode *mode = findMode(minBitrate, maxBitrate, bandwidth, numSpatialStreams);
+    const IIeee80211Mode *mode = findMode(minBitrate, maxBitrate, bandwidth, numSpatialStreams, guardInterval);
     if (mode == nullptr)
         throw cRuntimeError("Unknown bitrate: (%g - %g) in operation mode: '%s'", minBitrate.get(), maxBitrate.get(), getName());
     else

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -658,6 +658,8 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
     entries(completeHtGuardIntervalVariants(name, entries))
 {
     std::vector<Entry> *nonConstEntries = const_cast<std::vector<Entry> *>(&this->entries);
+    // Keep equal-bitrate modes in declaration order because unqualified lookups
+    // intentionally preserve the historically preferred mode.
     std::stable_sort(nonConstEntries->begin(), nonConstEntries->end(), EntryNetBitrateComparator());
     auto referenceMode = entries[0].mode;
     for (auto entry : entries) {
@@ -704,9 +706,8 @@ const IIeee80211Mode *Ieee80211ModeSet::findMode(bps minBitrate, bps maxBitrate,
         auto mode = entries[index].mode;
         auto dataMode = mode->getDataMode();
         auto bitrate = dataMode->getNetBitrate();
-        auto htMode = dynamic_cast<const Ieee80211HtMode *>(mode);
         bool guardIntervalMatches = guardInterval < SIMTIME_ZERO ||
-                (htMode != nullptr && htMode->getDataMode()->getGuardInterval() == guardInterval);
+                dataMode->getGuardInterval() == guardInterval;
         if (minBitrate <= bitrate && bitrate <= maxBitrate &&
             (std::isnan(bandwidth.get()) || dataMode->getBandwidth() == bandwidth) &&
             (numSpatialStreams == -1 || dataMode->getNumberOfSpatialStreams() == numSpatialStreams) &&
@@ -722,7 +723,8 @@ const IIeee80211Mode *Ieee80211ModeSet::getMode(bps bitrate, Hz bandwidth, int n
 {
     const IIeee80211Mode *mode = getMode(bitrate - Mbps(0.05), bitrate + Mbps(0.05), bandwidth, numSpatialStreams, guardInterval);
     if (mode == nullptr)
-        throw cRuntimeError("Unknown bitrate: %g in operation mode: '%s'", bitrate.get(), getName());
+        throw cRuntimeError("Unknown mode for bitrate %g bps, bandwidth %g Hz, %d spatial streams, and %s guard interval in operation mode '%s'",
+                bitrate.get(), bandwidth.get(), numSpatialStreams, guardInterval.str().c_str(), getName());
     else
         return mode;
 }
@@ -731,7 +733,8 @@ const IIeee80211Mode *Ieee80211ModeSet::getMode(bps minBitrate, bps maxBitrate, 
 {
     const IIeee80211Mode *mode = findMode(minBitrate, maxBitrate, bandwidth, numSpatialStreams, guardInterval);
     if (mode == nullptr)
-        throw cRuntimeError("Unknown bitrate: (%g - %g) in operation mode: '%s'", minBitrate.get(), maxBitrate.get(), getName());
+        throw cRuntimeError("Unknown mode for bitrate range (%g - %g) bps, bandwidth %g Hz, %d spatial streams, and %s guard interval in operation mode '%s'",
+                minBitrate.get(), maxBitrate.get(), bandwidth.get(), numSpatialStreams, guardInterval.str().c_str(), getName());
     else
         return mode;
 }
@@ -749,19 +752,25 @@ const IIeee80211Mode *Ieee80211ModeSet::getFastestMode() const
 const IIeee80211Mode *Ieee80211ModeSet::getSlowerMode(const IIeee80211Mode *mode) const
 {
     int index = findModeIndex(mode);
-    if (index > 0)
-        return entries[index - 1].mode;
-    else
-        return nullptr;
+    if (index > 0) {
+        auto bitrate = mode->getDataMode()->getNetBitrate();
+        for (int i = index - 1; i >= 0; i--)
+            if (entries[i].mode->getDataMode()->getNetBitrate() < bitrate)
+                return entries[i].mode;
+    }
+    return nullptr;
 }
 
 const IIeee80211Mode *Ieee80211ModeSet::getFasterMode(const IIeee80211Mode *mode) const
 {
     int index = findModeIndex(mode);
-    if (index >= 0 && index < (int)entries.size() - 1)
-        return entries[index + 1].mode;
-    else
-        return nullptr;
+    if (index >= 0) {
+        auto bitrate = mode->getDataMode()->getNetBitrate();
+        for (size_t i = index + 1; i < entries.size(); i++)
+            if (entries[i].mode->getDataMode()->getNetBitrate() > bitrate)
+                return entries[i].mode;
+    }
+    return nullptr;
 }
 
 const IIeee80211Mode *Ieee80211ModeSet::getSlowestMandatoryMode() const
@@ -828,4 +837,3 @@ const Ieee80211ModeSet *Ieee80211ModeSet::getModeSet(const char *mode)
 } // namespace physicallayer
 
 } // namespace inet
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -30,185 +30,10 @@ std::vector<Ieee80211ModeSet::Entry> Ieee80211ModeSet::completeHtGuardIntervalVa
         return entries;
 
     std::vector<Entry> completeEntries = entries;
-    const Ieee80211Htmcs *legalMcsModes[] = {
-        &Ieee80211HtmcsTable::htMcs0BW20MHz,
-        &Ieee80211HtmcsTable::htMcs1BW20MHz,
-        &Ieee80211HtmcsTable::htMcs2BW20MHz,
-        &Ieee80211HtmcsTable::htMcs3BW20MHz,
-        &Ieee80211HtmcsTable::htMcs4BW20MHz,
-        &Ieee80211HtmcsTable::htMcs5BW20MHz,
-        &Ieee80211HtmcsTable::htMcs6BW20MHz,
-        &Ieee80211HtmcsTable::htMcs7BW20MHz,
-        &Ieee80211HtmcsTable::htMcs8BW20MHz,
-        &Ieee80211HtmcsTable::htMcs9BW20MHz,
-        &Ieee80211HtmcsTable::htMcs10BW20MHz,
-        &Ieee80211HtmcsTable::htMcs11BW20MHz,
-        &Ieee80211HtmcsTable::htMcs12BW20MHz,
-        &Ieee80211HtmcsTable::htMcs13BW20MHz,
-        &Ieee80211HtmcsTable::htMcs14BW20MHz,
-        &Ieee80211HtmcsTable::htMcs15BW20MHz,
-        &Ieee80211HtmcsTable::htMcs16BW20MHz,
-        &Ieee80211HtmcsTable::htMcs17BW20MHz,
-        &Ieee80211HtmcsTable::htMcs18BW20MHz,
-        &Ieee80211HtmcsTable::htMcs19BW20MHz,
-        &Ieee80211HtmcsTable::htMcs20BW20MHz,
-        &Ieee80211HtmcsTable::htMcs21BW20MHz,
-        &Ieee80211HtmcsTable::htMcs22BW20MHz,
-        &Ieee80211HtmcsTable::htMcs23BW20MHz,
-        &Ieee80211HtmcsTable::htMcs24BW20MHz,
-        &Ieee80211HtmcsTable::htMcs25BW20MHz,
-        &Ieee80211HtmcsTable::htMcs26BW20MHz,
-        &Ieee80211HtmcsTable::htMcs27BW20MHz,
-        &Ieee80211HtmcsTable::htMcs28BW20MHz,
-        &Ieee80211HtmcsTable::htMcs29BW20MHz,
-        &Ieee80211HtmcsTable::htMcs30BW20MHz,
-        &Ieee80211HtmcsTable::htMcs31BW20MHz,
-        &Ieee80211HtmcsTable::htMcs33BW20MHz,
-        &Ieee80211HtmcsTable::htMcs34BW20MHz,
-        &Ieee80211HtmcsTable::htMcs35BW20MHz,
-        &Ieee80211HtmcsTable::htMcs36BW20MHz,
-        &Ieee80211HtmcsTable::htMcs37BW20MHz,
-        &Ieee80211HtmcsTable::htMcs38BW20MHz,
-        &Ieee80211HtmcsTable::htMcs39BW20MHz,
-        &Ieee80211HtmcsTable::htMcs40BW20MHz,
-        &Ieee80211HtmcsTable::htMcs41BW20MHz,
-        &Ieee80211HtmcsTable::htMcs42BW20MHz,
-        &Ieee80211HtmcsTable::htMcs43BW20MHz,
-        &Ieee80211HtmcsTable::htMcs44BW20MHz,
-        &Ieee80211HtmcsTable::htMcs45BW20MHz,
-        &Ieee80211HtmcsTable::htMcs46BW20MHz,
-        &Ieee80211HtmcsTable::htMcs47BW20MHz,
-        &Ieee80211HtmcsTable::htMcs48BW20MHz,
-        &Ieee80211HtmcsTable::htMcs49BW20MHz,
-        &Ieee80211HtmcsTable::htMcs50BW20MHz,
-        &Ieee80211HtmcsTable::htMcs51BW20MHz,
-        &Ieee80211HtmcsTable::htMcs52BW20MHz,
-        &Ieee80211HtmcsTable::htMcs53BW20MHz,
-        &Ieee80211HtmcsTable::htMcs54BW20MHz,
-        &Ieee80211HtmcsTable::htMcs55BW20MHz,
-        &Ieee80211HtmcsTable::htMcs56BW20MHz,
-        &Ieee80211HtmcsTable::htMcs57BW20MHz,
-        &Ieee80211HtmcsTable::htMcs58BW20MHz,
-        &Ieee80211HtmcsTable::htMcs59BW20MHz,
-        &Ieee80211HtmcsTable::htMcs60BW20MHz,
-        &Ieee80211HtmcsTable::htMcs61BW20MHz,
-        &Ieee80211HtmcsTable::htMcs62BW20MHz,
-        &Ieee80211HtmcsTable::htMcs63BW20MHz,
-        &Ieee80211HtmcsTable::htMcs64BW20MHz,
-        &Ieee80211HtmcsTable::htMcs65BW20MHz,
-        &Ieee80211HtmcsTable::htMcs66BW20MHz,
-        &Ieee80211HtmcsTable::htMcs67BW20MHz,
-        &Ieee80211HtmcsTable::htMcs68BW20MHz,
-        &Ieee80211HtmcsTable::htMcs69BW20MHz,
-        &Ieee80211HtmcsTable::htMcs70BW20MHz,
-        &Ieee80211HtmcsTable::htMcs71BW20MHz,
-        &Ieee80211HtmcsTable::htMcs72BW20MHz,
-        &Ieee80211HtmcsTable::htMcs73BW20MHz,
-        &Ieee80211HtmcsTable::htMcs74BW20MHz,
-        &Ieee80211HtmcsTable::htMcs75BW20MHz,
-        &Ieee80211HtmcsTable::htMcs76BW20MHz,
-        &Ieee80211HtmcsTable::htMcs0BW40MHz,
-        &Ieee80211HtmcsTable::htMcs1BW40MHz,
-        &Ieee80211HtmcsTable::htMcs2BW40MHz,
-        &Ieee80211HtmcsTable::htMcs3BW40MHz,
-        &Ieee80211HtmcsTable::htMcs4BW40MHz,
-        &Ieee80211HtmcsTable::htMcs5BW40MHz,
-        &Ieee80211HtmcsTable::htMcs6BW40MHz,
-        &Ieee80211HtmcsTable::htMcs7BW40MHz,
-        &Ieee80211HtmcsTable::htMcs8BW40MHz,
-        &Ieee80211HtmcsTable::htMcs9BW40MHz,
-        &Ieee80211HtmcsTable::htMcs10BW40MHz,
-        &Ieee80211HtmcsTable::htMcs11BW40MHz,
-        &Ieee80211HtmcsTable::htMcs12BW40MHz,
-        &Ieee80211HtmcsTable::htMcs13BW40MHz,
-        &Ieee80211HtmcsTable::htMcs14BW40MHz,
-        &Ieee80211HtmcsTable::htMcs15BW40MHz,
-        &Ieee80211HtmcsTable::htMcs16BW40MHz,
-        &Ieee80211HtmcsTable::htMcs17BW40MHz,
-        &Ieee80211HtmcsTable::htMcs18BW40MHz,
-        &Ieee80211HtmcsTable::htMcs19BW40MHz,
-        &Ieee80211HtmcsTable::htMcs20BW40MHz,
-        &Ieee80211HtmcsTable::htMcs21BW40MHz,
-        &Ieee80211HtmcsTable::htMcs22BW40MHz,
-        &Ieee80211HtmcsTable::htMcs23BW40MHz,
-        &Ieee80211HtmcsTable::htMcs24BW40MHz,
-        &Ieee80211HtmcsTable::htMcs25BW40MHz,
-        &Ieee80211HtmcsTable::htMcs26BW40MHz,
-        &Ieee80211HtmcsTable::htMcs27BW40MHz,
-        &Ieee80211HtmcsTable::htMcs28BW40MHz,
-        &Ieee80211HtmcsTable::htMcs29BW40MHz,
-        &Ieee80211HtmcsTable::htMcs30BW40MHz,
-        &Ieee80211HtmcsTable::htMcs31BW40MHz,
-        &Ieee80211HtmcsTable::htMcs32BW40MHz,
-        &Ieee80211HtmcsTable::htMcs33BW40MHz,
-        &Ieee80211HtmcsTable::htMcs34BW40MHz,
-        &Ieee80211HtmcsTable::htMcs35BW40MHz,
-        &Ieee80211HtmcsTable::htMcs36BW40MHz,
-        &Ieee80211HtmcsTable::htMcs37BW40MHz,
-        &Ieee80211HtmcsTable::htMcs38BW40MHz,
-        &Ieee80211HtmcsTable::htMcs39BW40MHz,
-        &Ieee80211HtmcsTable::htMcs40BW40MHz,
-        &Ieee80211HtmcsTable::htMcs41BW40MHz,
-        &Ieee80211HtmcsTable::htMcs42BW40MHz,
-        &Ieee80211HtmcsTable::htMcs43BW40MHz,
-        &Ieee80211HtmcsTable::htMcs44BW40MHz,
-        &Ieee80211HtmcsTable::htMcs45BW40MHz,
-        &Ieee80211HtmcsTable::htMcs46BW40MHz,
-        &Ieee80211HtmcsTable::htMcs47BW40MHz,
-        &Ieee80211HtmcsTable::htMcs48BW40MHz,
-        &Ieee80211HtmcsTable::htMcs49BW40MHz,
-        &Ieee80211HtmcsTable::htMcs50BW40MHz,
-        &Ieee80211HtmcsTable::htMcs51BW40MHz,
-        &Ieee80211HtmcsTable::htMcs52BW40MHz,
-        &Ieee80211HtmcsTable::htMcs53BW40MHz,
-        &Ieee80211HtmcsTable::htMcs54BW40MHz,
-        &Ieee80211HtmcsTable::htMcs55BW40MHz,
-        &Ieee80211HtmcsTable::htMcs56BW40MHz,
-        &Ieee80211HtmcsTable::htMcs57BW40MHz,
-        &Ieee80211HtmcsTable::htMcs58BW40MHz,
-        &Ieee80211HtmcsTable::htMcs59BW40MHz,
-        &Ieee80211HtmcsTable::htMcs60BW40MHz,
-        &Ieee80211HtmcsTable::htMcs61BW40MHz,
-        &Ieee80211HtmcsTable::htMcs62BW40MHz,
-        &Ieee80211HtmcsTable::htMcs63BW40MHz,
-        &Ieee80211HtmcsTable::htMcs64BW40MHz,
-        &Ieee80211HtmcsTable::htMcs65BW40MHz,
-        &Ieee80211HtmcsTable::htMcs66BW40MHz,
-        &Ieee80211HtmcsTable::htMcs67BW40MHz,
-        &Ieee80211HtmcsTable::htMcs68BW40MHz,
-        &Ieee80211HtmcsTable::htMcs69BW40MHz,
-        &Ieee80211HtmcsTable::htMcs70BW40MHz,
-        &Ieee80211HtmcsTable::htMcs71BW40MHz,
-        &Ieee80211HtmcsTable::htMcs72BW40MHz,
-        &Ieee80211HtmcsTable::htMcs73BW40MHz,
-        &Ieee80211HtmcsTable::htMcs74BW40MHz,
-        &Ieee80211HtmcsTable::htMcs75BW40MHz,
-        &Ieee80211HtmcsTable::htMcs76BW40MHz,
-    };
-
-    // Preserve the historical catalog entries first. Add the missing legal
-    // (bandwidth, MCS) tuples from Tables 19-27 through 19-41 in table order.
-    for (auto mcsMode : legalMcsModes) {
-        bool found = false;
-        for (const auto& entry : completeEntries) {
-            auto htMode = dynamic_cast<const Ieee80211HtMode *>(entry.mode);
-            if (htMode != nullptr &&
-                htMode->getDataMode()->getBandwidth() == mcsMode->getBandwidth() &&
-                htMode->getDataMode()->getMcsIndex() == mcsMode->getMcsIndex())
-            {
-                found = true;
-                break;
-            }
-        }
-        if (!found)
-            completeEntries.push_back({false, Ieee80211HtCompliantModes::getCompliantMode(
-                    mcsMode, Ieee80211HtMode::BAND_2_4GHZ,
-                    Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED,
-                    Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT)});
-    }
-
     // IEEE Std 802.11-2024, Table 19-6 defines the 800 ns and 400 ns GIs.
-    // Add the alternate GI for every legal tuple above; short GI is optional.
+    // Add only the alternate GI for each mode explicitly declared above;
+    // declaration order, mandatory flags, and the historical catalog remain
+    // authoritative for this operation mode.
     auto numberOfBaseEntries = completeEntries.size();
     for (size_t index = 0; index < numberOfBaseEntries; index++) {
         auto htMode = check_and_cast<const Ieee80211HtMode *>(completeEntries[index].mode);
@@ -789,24 +614,43 @@ const IIeee80211Mode *Ieee80211ModeSet::getFastestMandatoryMode() const
     return nullptr;
 }
 
+const IIeee80211Mode *Ieee80211ModeSet::getMandatoryModeAtOrBelow(const IIeee80211Mode *mode) const
+{
+    const auto bitrate = mode->getDataMode()->getNetBitrate();
+    const IIeee80211Mode *result = nullptr;
+    for (const auto& entry : entries) {
+        const auto entryBitrate = entry.mode->getDataMode()->getNetBitrate();
+        if (entry.isMandatory && entryBitrate <= bitrate &&
+            (result == nullptr || entryBitrate > result->getDataMode()->getNetBitrate()))
+            result = entry.mode;
+    }
+    return result;
+}
+
 const IIeee80211Mode *Ieee80211ModeSet::getSlowerMandatoryMode(const IIeee80211Mode *mode) const
 {
-    int index = findModeIndex(mode);
-    if (index > 0)
-        for (int i = index - 1; i >= 0; i--)
-            if (entries[i].isMandatory)
-                return entries[i].mode;
-    return nullptr;
+    const auto bitrate = mode->getDataMode()->getNetBitrate();
+    const IIeee80211Mode *result = nullptr;
+    for (const auto& entry : entries) {
+        const auto entryBitrate = entry.mode->getDataMode()->getNetBitrate();
+        if (entry.isMandatory && entryBitrate < bitrate &&
+            (result == nullptr || entryBitrate > result->getDataMode()->getNetBitrate()))
+            result = entry.mode;
+    }
+    return result;
 }
 
 const IIeee80211Mode *Ieee80211ModeSet::getFasterMandatoryMode(const IIeee80211Mode *mode) const
 {
-    int index = findModeIndex(mode);
-    if (index >= 0)
-        for (size_t i = index + 1; i < entries.size(); i++)
-            if (entries[i].isMandatory)
-                return entries[i].mode;
-    return nullptr;
+    const auto bitrate = mode->getDataMode()->getNetBitrate();
+    const IIeee80211Mode *result = nullptr;
+    for (const auto& entry : entries) {
+        const auto entryBitrate = entry.mode->getDataMode()->getNetBitrate();
+        if (entry.isMandatory && entryBitrate > bitrate &&
+            (result == nullptr || entryBitrate < result->getDataMode()->getNetBitrate()))
+            result = entry.mode;
+    }
+    return result;
 }
 
 const Ieee80211ModeSet *Ieee80211ModeSet::findModeSet(const char *mode)

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -520,6 +520,33 @@ bool Ieee80211ModeSet::getIsMandatory(const IIeee80211Mode *mode) const
     return entries[getModeIndex(mode)].isMandatory;
 }
 
+const IIeee80211Mode *Ieee80211ModeSet::findCompatibleMode(const IIeee80211Mode *mode) const
+{
+    if (mode == nullptr)
+        return nullptr;
+
+    const auto sourceDataMode = mode->getDataMode();
+    const auto sourceBitrate = sourceDataMode->getNetBitrate();
+    const auto sourceBandwidth = sourceDataMode->getBandwidth();
+    const auto sourceGuardInterval = sourceDataMode->getGuardInterval();
+    const auto minBitrate = sourceBitrate - Mbps(0.05);
+    const auto maxBitrate = sourceBitrate + Mbps(0.05);
+    for (const auto& entry : entries) {
+        const auto candidateDataMode = entry.mode->getDataMode();
+        const auto candidateBandwidth = candidateDataMode->getBandwidth();
+        const auto candidateGuardInterval = candidateDataMode->getGuardInterval();
+        const bool bandwidthMatches = (std::isnan(sourceBandwidth.get()) && std::isnan(candidateBandwidth.get())) ||
+                (!std::isnan(sourceBandwidth.get()) && !std::isnan(candidateBandwidth.get()) && sourceBandwidth == candidateBandwidth);
+        const bool guardIntervalMatches = (sourceGuardInterval < SIMTIME_ZERO && candidateGuardInterval < SIMTIME_ZERO) ||
+                (sourceGuardInterval >= SIMTIME_ZERO && candidateGuardInterval == sourceGuardInterval);
+        if (minBitrate <= candidateDataMode->getNetBitrate() && candidateDataMode->getNetBitrate() <= maxBitrate &&
+            bandwidthMatches && candidateDataMode->getNumberOfSpatialStreams() == sourceDataMode->getNumberOfSpatialStreams() &&
+            guardIntervalMatches)
+            return entry.mode;
+    }
+    return nullptr;
+}
+
 const IIeee80211Mode *Ieee80211ModeSet::findMode(bps bitrate, Hz bandwidth, int numSpatialStreams, simtime_t guardInterval) const
 {
     return findMode(bitrate - Mbps(0.05), bitrate + Mbps(0.05), bandwidth, numSpatialStreams, guardInterval);

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -63,6 +63,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     const IIeee80211Mode *getFasterMode(const IIeee80211Mode *mode) const;
     const IIeee80211Mode *getSlowestMandatoryMode() const;
     const IIeee80211Mode *getFastestMandatoryMode() const;
+    const IIeee80211Mode *getMandatoryModeAtOrBelow(const IIeee80211Mode *mode) const;
     const IIeee80211Mode *getSlowerMandatoryMode(const IIeee80211Mode *mode) const;
     const IIeee80211Mode *getFasterMandatoryMode(const IIeee80211Mode *mode) const;
 
@@ -85,4 +86,3 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
 } // namespace inet
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -52,6 +52,9 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
 
     bool containsMode(const IIeee80211Mode *mode) const { return findModeIndex(mode) != -1; }
     bool getIsMandatory(const IIeee80211Mode *mode) const;
+    // Finds a mode with the same PHY tuple as mode. Unlike findMode(), this
+    // treats an absent guard interval (negative value) as an exact value.
+    const IIeee80211Mode *findCompatibleMode(const IIeee80211Mode *mode) const;
 
     const IIeee80211Mode *findMode(bps bitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1, simtime_t guardInterval = -1) const;
     const IIeee80211Mode *findMode(bps minBitrate, bps maxBitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1, simtime_t guardInterval = -1) const;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -35,6 +35,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     static const DelayedInitializer<std::vector<Ieee80211ModeSet>> modeSets;
 
   protected:
+    static std::vector<Entry> completeHtGuardIntervalVariants(const char *name, const std::vector<Entry>& entries);
     int findModeIndex(const IIeee80211Mode *mode) const;
     int getModeIndex(const IIeee80211Mode *mode) const;
 
@@ -46,16 +47,16 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     const char *getName() const override { return name.c_str(); }
 
     int getNumModes() const { return entries.size(); }
-    const IIeee80211Mode *getMode(int index) { return entries[index].mode; }
-    bool isMandatory(int index) { return entries[index].isMandatory; }
+    const IIeee80211Mode *getMode(int index) const { return entries[index].mode; }
+    bool isMandatory(int index) const { return entries[index].isMandatory; }
 
     bool containsMode(const IIeee80211Mode *mode) const { return findModeIndex(mode) != -1; }
     bool getIsMandatory(const IIeee80211Mode *mode) const;
 
-    const IIeee80211Mode *findMode(bps bitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1) const;
-    const IIeee80211Mode *findMode(bps minBitrate, bps maxBitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1) const;
-    const IIeee80211Mode *getMode(bps bitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1) const;
-    const IIeee80211Mode *getMode(bps minBitrate, bps maxBitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1) const;
+    const IIeee80211Mode *findMode(bps bitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1, simtime_t guardInterval = -1) const;
+    const IIeee80211Mode *findMode(bps minBitrate, bps maxBitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1, simtime_t guardInterval = -1) const;
+    const IIeee80211Mode *getMode(bps bitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1, simtime_t guardInterval = -1) const;
+    const IIeee80211Mode *getMode(bps minBitrate, bps maxBitrate, Hz bandwidth = Hz(NaN), int numSpatialStreams = -1, simtime_t guardInterval = -1) const;
     const IIeee80211Mode *getSlowestMode() const;
     const IIeee80211Mode *getFastestMode() const;
     const IIeee80211Mode *getSlowerMode(const IIeee80211Mode *mode) const;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211OfdmMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211OfdmMode.h
@@ -124,6 +124,7 @@ class INET_API Ieee80211OfdmDataMode : public IIeee80211DataMode, public Ieee802
     virtual b getPaddingLength(b dataLength) const override;
     virtual b getCompleteLength(b dataLength) const override;
     virtual const simtime_t getDuration(b dataLength) const override;
+    virtual const simtime_t getGuardInterval() const override { return getGIDuration(); }
 
     const Ieee80211OfdmCode *getCode() const { return code; }
     virtual const simtime_t getSymbolInterval() const override { return Ieee80211OfdmTimingRelatedParametersBase::getSymbolInterval(); }
@@ -265,4 +266,3 @@ class INET_API Ieee80211OfdmCompliantModes
 } // namespace inet
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
@@ -241,6 +241,11 @@ unsigned int Ieee80211VhtPreambleMode::computeNumberOfHTLongTrainings(unsigned i
     return numberOfSpaceTimeStreams == 3 ? 4 : numberOfSpaceTimeStreams;
 }
 
+const simtime_t Ieee80211VhtPreambleMode::getDurationBeforeHeader() const
+{
+    return getNonHTShortTrainingSequenceDuration() + getNonHTLongTrainingFieldDuration() + legacySignalMode->getDuration();
+}
+
 const simtime_t Ieee80211VhtPreambleMode::getDuration() const
 {
     // 21.3.4 Mathematical description of signals
@@ -1072,4 +1077,3 @@ const DI<Ieee80211Vhtmcs> Ieee80211VhtmcsTable::vhtMcs9BW160MHzNss8([](){ return
 
 } /* namespace physicallayer */
 } /* namespace inet */
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
@@ -258,12 +258,9 @@ const simtime_t Ieee80211VhtPreambleMode::getDuration() const
 bps Ieee80211VhtSignalMode::computeGrossBitrate() const
 {
     unsigned int numberOfCodedBitsPerSymbol = modulation->getSubcarrierModulation()->getCodeWordSize() * getNumberOfDataSubcarriers();
-    if (guardIntervalType == HT_GUARD_INTERVAL_LONG)
-        return bps(numberOfCodedBitsPerSymbol / getSymbolInterval());
-    else if (guardIntervalType == HT_GUARD_INTERVAL_SHORT)
-        return bps(numberOfCodedBitsPerSymbol / getShortGISymbolInterval());
-    else
-        throw cRuntimeError("Unknown guard interval type");
+    // IEEE Std 802.11-2024, Table 21-5: VHT-SIG fields use TSYML even
+    // when the Data field uses short GI; their signaling rate is GI-independent.
+    return bps(numberOfCodedBitsPerSymbol / getSymbolInterval());
 }
 
 bps Ieee80211VhtSignalMode::computeNetBitrate() const
@@ -644,6 +641,19 @@ const simtime_t Ieee80211VhtDataMode::getDuration(b dataLength) const
     unsigned int dataBitsPerSymbol = forwardErrorCorrection ? forwardErrorCorrection->getDecodedLength(numberOfCodedBitsPerSymbol) : numberOfCodedBitsPerSymbol;
     int numberOfSymbols = lrint(ceil((double)getCompleteLength(dataLength).get<b>() / dataBitsPerSymbol)); // TODO getBitLength(dataBitLength) should be divisible by dataBitsPerSymbol
     return numberOfSymbols * getSymbolInterval();
+}
+
+const simtime_t Ieee80211VhtMode::getDataDuration(b dataBitLength) const
+{
+    auto dataDuration = dataMode->getDuration(dataBitLength);
+    if (dataMode->getGuardInterval() == dataMode->getShortGIDuration()) {
+        // IEEE Std 802.11-2024, 21.4.3, Eq. (21-109): short-GI VHT data
+        // airtime is the raw TSYMS train rounded up to a TSYML boundary.
+        const auto longGiSymbolInterval = dataMode->getDFTPeriod() + dataMode->getGIDuration();
+        const auto numberOfLongGiSymbols = (dataDuration.raw() + longGiSymbolInterval.raw() - 1) / longGiSymbolInterval.raw();
+        dataDuration = SimTime::fromRaw(numberOfLongGiSymbols * longGiSymbolInterval.raw());
+    }
+    return dataDuration;
 }
 
 const simtime_t Ieee80211VhtMode::getSlotTime() const

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
@@ -243,7 +243,9 @@ unsigned int Ieee80211VhtPreambleMode::computeNumberOfHTLongTrainings(unsigned i
 
 const simtime_t Ieee80211VhtPreambleMode::getDurationBeforeHeader() const
 {
-    return getNonHTShortTrainingSequenceDuration() + getNonHTLongTrainingFieldDuration() + legacySignalMode->getDuration();
+    // IEEE Std 802.11-2024, 21.3.2: the L-SIG duration is part of the
+    // pre-header timing of the supported VHT mixed format.
+    return getNonHTShortTrainingSequenceDuration() + getNonHTLongTrainingFieldDuration() + getLSIGDuration();
 }
 
 const simtime_t Ieee80211VhtPreambleMode::getDuration() const
@@ -677,9 +679,13 @@ Ieee80211VhtCompliantModes::~Ieee80211VhtCompliantModes()
 
 const Ieee80211VhtMode *Ieee80211VhtCompliantModes::getCompliantMode(const Ieee80211Vhtmcs *mcsMode, Ieee80211VhtMode::BandMode centerFrequencyMode, Ieee80211VhtPreambleMode::HighTroughputPreambleFormat preambleFormat, Ieee80211VhtModeBase::GuardIntervalType guardIntervalType)
 {
+    // IEEE Std 802.11-2024, 21.3.2 permits VHT PPDUs only in the mixed
+    // preamble format represented by this mode implementation.
+    if (preambleFormat != Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED)
+        throw cRuntimeError("Unsupported VHT preamble format: only HT_PREAMBLE_MIXED is supported (IEEE Std 802.11-2024, 21.3.2)");
     const char *name = ""; // TODO
     unsigned int nss = mcsMode->getNumNss();
-    auto htModeId = std::make_tuple(mcsMode->getBandwidth(), mcsMode->getMcsIndex(), guardIntervalType, nss);
+    auto htModeId = std::make_tuple(mcsMode->getBandwidth(), mcsMode->getMcsIndex(), guardIntervalType, nss, centerFrequencyMode, preambleFormat);
     auto mode = singleton.modeCache.find(htModeId);
     if (mode == singleton.modeCache.end()) {
         const Ieee80211OfdmSignalMode *legacySignal = nullptr;
@@ -698,7 +704,7 @@ const Ieee80211VhtMode *Ieee80211VhtCompliantModes::getCompliantMode(const Ieee8
         const Ieee80211VhtDataMode *dataMode = new Ieee80211VhtDataMode(mcsMode, mcsMode->getBandwidth(), guardIntervalType);
         const Ieee80211VhtPreambleMode *preambleMode = new Ieee80211VhtPreambleMode(htSignal, legacySignal, preambleFormat, dataMode->getNumberOfSpatialStreams());
         const Ieee80211VhtMode *htMode = new Ieee80211VhtMode(name, preambleMode, dataMode, centerFrequencyMode);
-        singleton.modeCache.insert(std::pair<std::tuple<Hz, unsigned int, Ieee80211VhtModeBase::GuardIntervalType, unsigned int>, const Ieee80211VhtMode *>(htModeId, htMode));
+        singleton.modeCache.insert(std::pair<decltype(htModeId), const Ieee80211VhtMode *>(htModeId, htMode));
         return htMode;
     }
     return mode->second;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.cc
@@ -649,6 +649,7 @@ const simtime_t Ieee80211VhtMode::getDataDuration(b dataBitLength) const
     if (dataMode->getGuardInterval() == dataMode->getShortGIDuration()) {
         // IEEE Std 802.11-2024, 21.4.3, Eq. (21-109): short-GI VHT data
         // airtime is the raw TSYMS train rounded up to a TSYML boundary.
+        // This corrects the previous implementation that used the raw short-GI symbol train.
         const auto longGiSymbolInterval = dataMode->getDFTPeriod() + dataMode->getGIDuration();
         const auto numberOfLongGiSymbols = (dataDuration.raw() + longGiSymbolInterval.raw() - 1) / longGiSymbolInterval.raw();
         dataDuration = SimTime::fromRaw(numberOfLongGiSymbols * longGiSymbolInterval.raw());

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
@@ -148,6 +148,7 @@ class INET_API Ieee80211VhtPreambleMode : public IIeee80211PreambleMode, public 
     virtual const simtime_t getSecondAndSubsequentHTLongTrainingFielDuration() const { return 4E-6; } // HT-LTFs, s = 2,3,..,n
     virtual unsigned int getNumberOfHtLongTrainings() const { return numberOfHTLongTrainings; }
 
+    virtual const simtime_t getDurationBeforeHeader() const;
     virtual const simtime_t getDuration() const override;
 
     virtual Ptr<Ieee80211PhyPreamble> createPreamble() const override { return makeShared<Ieee80211VhtPhyPreamble>(); }
@@ -237,6 +238,7 @@ class INET_API Ieee80211VhtDataMode : public IIeee80211DataMode, public Ieee8021
     virtual bps getGrossBitrate() const override { return Ieee80211VhtModeBase::getGrossBitrate(); }
     virtual const Ieee80211Vhtmcs *getModulationAndCodingScheme() const { return modulationAndCodingScheme; }
     virtual const Ieee80211VhtCode *getCode() const { return modulationAndCodingScheme->getCode(); }
+    virtual const simtime_t getGuardInterval() const override { return guardIntervalType == HT_GUARD_INTERVAL_LONG ? getGIDuration() : getShortGIDuration(); }
     virtual const simtime_t getSymbolInterval() const override { return Ieee80211HtTimingRelatedParametersBase::getSymbolInterval(); }
     virtual const Ieee80211OfdmModulation *getModulation() const override { return modulationAndCodingScheme->getModulation(); }
 };
@@ -281,6 +283,9 @@ class INET_API Ieee80211VhtMode : public Ieee80211ModeBase
     virtual BandMode getCenterFrequencyMode() const { return centerFrequencyMode; }
 
     virtual const simtime_t getDuration(b dataBitLength) const override { return preambleMode->getDuration() + dataMode->getDuration(dataBitLength); }
+    virtual const simtime_t getPreambleDuration() const override { return preambleMode->getDurationBeforeHeader(); }
+    virtual const simtime_t getHeaderDuration() const override { return preambleMode->getDuration() - getPreambleDuration(); }
+    virtual const simtime_t getDataDuration(b dataBitLength) const override { return dataMode->getDuration(dataBitLength); }
 };
 
 // A specification of the high-throughput (HT) physical layer (PHY)
@@ -692,4 +697,3 @@ class INET_API Ieee80211VhtCompliantModes
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
@@ -96,6 +96,8 @@ class INET_API Ieee80211VhtSignalMode : public IIeee80211HeaderMode, public Ieee
     virtual b getLength() const override;
     virtual bps getNetBitrate() const override { return Ieee80211VhtModeBase::getNetBitrate(); }
     virtual bps getGrossBitrate() const override { return Ieee80211VhtModeBase::getGrossBitrate(); }
+    // IEEE Std 802.11-2024, Table 21-5: VHT-SIG uses the long-GI symbol
+    // interval independently of the data field's selected guard interval.
     virtual const simtime_t getSymbolInterval() const override { return Ieee80211HtTimingRelatedParametersBase::getSymbolInterval(); }
     virtual const Ieee80211OfdmModulation *getModulation() const override { return modulation; }
     virtual const Ieee80211VhtCode *getCode() const { return code; }
@@ -239,7 +241,9 @@ class INET_API Ieee80211VhtDataMode : public IIeee80211DataMode, public Ieee8021
     virtual const Ieee80211Vhtmcs *getModulationAndCodingScheme() const { return modulationAndCodingScheme; }
     virtual const Ieee80211VhtCode *getCode() const { return modulationAndCodingScheme->getCode(); }
     virtual const simtime_t getGuardInterval() const override { return guardIntervalType == HT_GUARD_INTERVAL_LONG ? getGIDuration() : getShortGIDuration(); }
-    virtual const simtime_t getSymbolInterval() const override { return Ieee80211HtTimingRelatedParametersBase::getSymbolInterval(); }
+    // IEEE Std 802.11-2024, Tables 21-5 and 21-8: the VHT Data symbol
+    // interval is TSYML for long GI and TSYMS for short GI.
+    virtual const simtime_t getSymbolInterval() const override { return getDFTPeriod() + getGuardInterval(); }
     virtual const Ieee80211OfdmModulation *getModulation() const override { return modulationAndCodingScheme->getModulation(); }
 };
 
@@ -282,10 +286,10 @@ class INET_API Ieee80211VhtMode : public Ieee80211ModeBase
     virtual int getMpduMaxLength() const override { return 65535; } // in octets
     virtual BandMode getCenterFrequencyMode() const { return centerFrequencyMode; }
 
-    virtual const simtime_t getDuration(b dataBitLength) const override { return preambleMode->getDuration() + dataMode->getDuration(dataBitLength); }
+    virtual const simtime_t getDuration(b dataBitLength) const override { return preambleMode->getDuration() + getDataDuration(dataBitLength); }
     virtual const simtime_t getPreambleDuration() const override { return preambleMode->getDurationBeforeHeader(); }
     virtual const simtime_t getHeaderDuration() const override { return preambleMode->getDuration() - getPreambleDuration(); }
-    virtual const simtime_t getDataDuration(b dataBitLength) const override { return dataMode->getDuration(dataBitLength); }
+    virtual const simtime_t getDataDuration(b dataBitLength) const override;
 };
 
 // A specification of the high-throughput (HT) physical layer (PHY)

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
@@ -684,7 +684,7 @@ class INET_API Ieee80211VhtCompliantModes
   protected:
     static OPP_THREAD_LOCAL const Ieee80211VhtCompliantModes singleton;
 
-    mutable std::map<std::tuple<Hz, unsigned int, Ieee80211VhtModeBase::GuardIntervalType, unsigned int>, const Ieee80211VhtMode *> modeCache;
+    mutable std::map<std::tuple<Hz, unsigned int, Ieee80211VhtModeBase::GuardIntervalType, unsigned int, Ieee80211VhtMode::BandMode, Ieee80211VhtPreambleMode::HighTroughputPreambleFormat>, const Ieee80211VhtMode *> modeCache;
 
   public:
     Ieee80211VhtCompliantModes();

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211ControlInfo.msg
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211ControlInfo.msg
@@ -17,9 +17,9 @@ namespace inet::physicallayer;
 //
 class Ieee80211ConfigureRadioCommand extends ConfigureRadioCommand
 {
-    string opMode;                         // new default operation mode or "" if not set.
-    const Ieee80211ModeSet *modeSet;       // new default mode set or nullptr if not set.
-    const IIeee80211Mode *mode;            // new default transmission mode or nullptr if not set.
+    string opMode;                         // new default operation mode or "" if not set; ignored when modeSet is set.
+    const Ieee80211ModeSet *modeSet;       // new default mode set or nullptr if not set; takes precedence over opMode.
+    const IIeee80211Mode *mode;            // new default transmission mode or nullptr if not set; atomically validated against the resolved mode set.
     IIeee80211Band *band;                  // new default band or nullptr if not set.
     Ieee80211Channel *channel;             // new default band and channel or nullptr if not set.
     int channelNumber = -1;                // new default channel number in the range [0, numChannels] or -1 if not set.

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.cc
@@ -59,6 +59,9 @@ void Ieee80211Radio::handleUpperCommand(cMessage *message)
         if (configureCommand != nullptr) {
             const char *opMode = configureCommand->getOpMode();
             const Ieee80211ModeSet *modeSet = configureCommand->getModeSet();
+            // NOTE: When both modeSet and opMode are present, modeSet takes precedence
+            // and opMode is silently ignored. This differs from the previous behavior
+            // where both were applied sequentially (with modeSet as final state).
             const Ieee80211ModeSet *newModeSet = modeSet != nullptr ? modeSet : (*opMode ? Ieee80211ModeSet::getModeSet(opMode) : nullptr);
             const IIeee80211Mode *mode = configureCommand->getMode();
             if (newModeSet != nullptr && mode != nullptr)

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.cc
@@ -58,13 +58,14 @@ void Ieee80211Radio::handleUpperCommand(cMessage *message)
         Ieee80211ConfigureRadioCommand *configureCommand = dynamic_cast<Ieee80211ConfigureRadioCommand *>(message->getControlInfo());
         if (configureCommand != nullptr) {
             const char *opMode = configureCommand->getOpMode();
-            if (*opMode)
-                setModeSet(Ieee80211ModeSet::getModeSet(opMode));
             const Ieee80211ModeSet *modeSet = configureCommand->getModeSet();
-            if (modeSet != nullptr)
-                setModeSet(modeSet);
+            const Ieee80211ModeSet *newModeSet = modeSet != nullptr ? modeSet : (*opMode ? Ieee80211ModeSet::getModeSet(opMode) : nullptr);
             const IIeee80211Mode *mode = configureCommand->getMode();
-            if (mode != nullptr)
+            if (newModeSet != nullptr && mode != nullptr)
+                setModeSetAndMode(newModeSet, mode);
+            else if (newModeSet != nullptr)
+                setModeSet(newModeSet);
+            else if (mode != nullptr)
                 setMode(mode);
             const IIeee80211Band *band = configureCommand->getBand();
             if (band != nullptr)
@@ -87,6 +88,19 @@ void Ieee80211Radio::setModeSet(const Ieee80211ModeSet *modeSet)
     ieee80211Transmitter->setModeSet(modeSet);
     ieee80211Receiver->setModeSet(modeSet);
     EV << "Changing radio mode set to " << modeSet << endl;
+    receptionTimer = nullptr;
+    emit(listeningChangedSignal, 0);
+}
+
+void Ieee80211Radio::setModeSetAndMode(const Ieee80211ModeSet *modeSet, const IIeee80211Mode *mode)
+{
+    if (modeSet != nullptr && mode != nullptr && !modeSet->containsMode(mode))
+        throw cRuntimeError("Invalid mode");
+    Ieee80211Transmitter *ieee80211Transmitter = const_cast<Ieee80211Transmitter *>(check_and_cast<const Ieee80211Transmitter *>(transmitter));
+    Ieee80211Receiver *ieee80211Receiver = const_cast<Ieee80211Receiver *>(check_and_cast<const Ieee80211Receiver *>(receiver));
+    ieee80211Transmitter->setModeSetAndMode(modeSet, mode);
+    ieee80211Receiver->setModeSet(modeSet);
+    EV << "Changing radio mode set to " << modeSet << " and mode to " << mode << endl;
     receptionTimer = nullptr;
     emit(listeningChangedSignal, 0);
 }
@@ -329,4 +343,3 @@ const Ptr<const Ieee80211PhyHeader> Ieee80211Radio::peekIeee80211PhyHeaderAtFron
 } // namespace physicallayer
 
 } // namespace inet
-

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h
@@ -47,6 +47,7 @@ class INET_API Ieee80211Radio : public FlatRadioBase
     Ieee80211Radio();
 
     virtual void setModeSet(const Ieee80211ModeSet *modeSet);
+    virtual void setModeSetAndMode(const Ieee80211ModeSet *modeSet, const IIeee80211Mode *mode);
     virtual void setMode(const IIeee80211Mode *mode);
     virtual void setBand(const IIeee80211Band *band);
     virtual void setChannel(const Ieee80211Channel *channel);
@@ -57,4 +58,3 @@ class INET_API Ieee80211Radio : public FlatRadioBase
 } // namespace inet
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.cc
@@ -75,16 +75,22 @@ const Ieee80211Channel *Ieee80211Transmitter::computeTransmissionChannel(const P
 void Ieee80211Transmitter::setModeSet(const Ieee80211ModeSet *modeSet)
 {
     if (this->modeSet != modeSet) {
+        auto newMode = mode;
+        if (mode != nullptr && modeSet != nullptr && !modeSet->containsMode(mode)) {
+            auto dataMode = mode->getDataMode();
+            newMode = modeSet->getMode(dataMode->getNetBitrate(), dataMode->getBandwidth(), dataMode->getNumberOfSpatialStreams(), dataMode->getGuardInterval());
+        }
+        else if (modeSet == nullptr)
+            newMode = nullptr;
         this->modeSet = modeSet;
-        if (mode != nullptr)
-            mode = modeSet != nullptr ? modeSet->getMode(mode->getDataMode()->getNetBitrate()) : nullptr;
+        mode = newMode;
     }
 }
 
 void Ieee80211Transmitter::setMode(const IIeee80211Mode *mode)
 {
     if (this->mode != mode) {
-        if (modeSet->findMode(mode->getDataMode()->getNetBitrate(), mode->getDataMode()->getBandwidth()) == nullptr)
+        if (modeSet != nullptr && mode != nullptr && !modeSet->containsMode(mode))
             throw cRuntimeError("Invalid mode");
         this->mode = mode;
     }
@@ -142,9 +148,9 @@ const ITransmission *Ieee80211Transmitter::createTransmission(const IRadio *tran
     const Coord& endPosition = mobility->getCurrentPosition();
     const Quaternion& startOrientation = mobility->getCurrentAngularPosition();
     const Quaternion& endOrientation = mobility->getCurrentAngularPosition();
-    const simtime_t preambleDuration = transmissionMode->getPreambleMode()->getDuration();
-    const simtime_t headerDuration = transmissionMode->getHeaderMode()->getDuration();
-    const simtime_t dataDuration = duration - headerDuration - preambleDuration;
+    const simtime_t preambleDuration = transmissionMode->getPreambleDuration();
+    const simtime_t headerDuration = transmissionMode->getHeaderDuration();
+    const simtime_t dataDuration = transmissionMode->getDataDuration(B(phyHeader->getLengthField()));
     auto analogModel = getAnalogModel()->createAnalogModel(preambleDuration, headerDuration, dataDuration, centerFrequency, transmissionBandwidth, transmissionPower);
     return new Ieee80211Transmission(transmitter, packet, startTime, endTime, preambleDuration, headerDuration, dataDuration, startPosition, endPosition, startOrientation, endOrientation, nullptr, nullptr, nullptr, nullptr, analogModel, transmissionMode, transmissionChannel);
 }
@@ -152,4 +158,3 @@ const ITransmission *Ieee80211Transmitter::createTransmission(const IRadio *tran
 } // namespace physicallayer
 
 } // namespace inet
-

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.cc
@@ -77,8 +77,9 @@ void Ieee80211Transmitter::setModeSet(const Ieee80211ModeSet *modeSet)
     if (this->modeSet != modeSet) {
         auto newMode = mode;
         if (mode != nullptr && modeSet != nullptr && !modeSet->containsMode(mode)) {
-            auto dataMode = mode->getDataMode();
-            newMode = modeSet->getMode(dataMode->getNetBitrate(), dataMode->getBandwidth(), dataMode->getNumberOfSpatialStreams(), dataMode->getGuardInterval());
+            newMode = modeSet->findCompatibleMode(mode);
+            if (newMode == nullptr)
+                throw cRuntimeError("Cannot map current mode to operation mode '%s' without changing bitrate, bandwidth, spatial streams, or guard interval", modeSet->getName());
         }
         else if (modeSet == nullptr)
             newMode = nullptr;

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.cc
@@ -87,6 +87,14 @@ void Ieee80211Transmitter::setModeSet(const Ieee80211ModeSet *modeSet)
     }
 }
 
+void Ieee80211Transmitter::setModeSetAndMode(const Ieee80211ModeSet *modeSet, const IIeee80211Mode *mode)
+{
+    if (modeSet != nullptr && mode != nullptr && !modeSet->containsMode(mode))
+        throw cRuntimeError("Invalid mode");
+    this->modeSet = modeSet;
+    this->mode = mode;
+}
+
 void Ieee80211Transmitter::setMode(const IIeee80211Mode *mode)
 {
     if (this->mode != mode) {

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h
@@ -38,6 +38,8 @@ class INET_API Ieee80211Transmitter : public FlatTransmitterBase
     virtual const IIeee80211Mode *computeTransmissionMode(const Packet *packet) const;
     virtual const Ieee80211Channel *computeTransmissionChannel(const Packet *packet) const;
 
+    // Re-selects the current mode only when bitrate, bandwidth, NSS, and GI
+    // remain compatible. Use setModeSetAndMode for an explicit transition.
     virtual void setModeSet(const Ieee80211ModeSet *modeSet);
     // Applies a mode set and an explicitly selected mode as one validated update.
     virtual void setModeSetAndMode(const Ieee80211ModeSet *modeSet, const IIeee80211Mode *mode);

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h
@@ -39,6 +39,8 @@ class INET_API Ieee80211Transmitter : public FlatTransmitterBase
     virtual const Ieee80211Channel *computeTransmissionChannel(const Packet *packet) const;
 
     virtual void setModeSet(const Ieee80211ModeSet *modeSet);
+    // Applies a mode set and an explicitly selected mode as one validated update.
+    virtual void setModeSetAndMode(const Ieee80211ModeSet *modeSet, const IIeee80211Mode *mode);
     virtual void setMode(const IIeee80211Mode *mode);
     virtual void setBand(const IIeee80211Band *band);
     virtual void setChannel(const Ieee80211Channel *channel);
@@ -52,4 +54,3 @@ class INET_API Ieee80211Transmitter : public FlatTransmitterBase
 } // namespace inet
 
 #endif
-

--- a/tests/unit/Ieee80211HtGuardInterval_1.test
+++ b/tests/unit/Ieee80211HtGuardInterval_1.test
@@ -1,0 +1,118 @@
+%description:
+Validate complete IEEE 802.11 HT long/short guard-interval catalog, lookup, and airtime.
+
+%includes:
+#include <cmath>
+#include <map>
+#include <tuple>
+
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+#include "inet/physicallayer/wireless/common/modulation/Qam16Modulation.h"
+
+%global:
+using namespace inet;
+using namespace inet::physicallayer;
+
+%activity:
+const auto modeSet = Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+ASSERT(modeSet->getNumModes() == 306);
+
+using Key = std::tuple<int, int, Ieee80211HtModeBase::GuardIntervalType>;
+std::map<Key, const Ieee80211HtMode *> modes;
+int mandatoryCount = 0;
+for (int index = 0; index < modeSet->getNumModes(); index++) {
+    auto mode = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(index));
+    ASSERT(mode != nullptr);
+    auto dataMode = mode->getDataMode();
+    int bandwidth = dataMode->getBandwidth() == MHz(20) ? 20 : dataMode->getBandwidth() == MHz(40) ? 40 : 0;
+    int mcs = dataMode->getMcsIndex();
+    auto guardIntervalType = dataMode->getGuardIntervalType();
+    ASSERT(bandwidth != 0);
+    ASSERT((bandwidth == 20 && ((0 <= mcs && mcs <= 31) || (33 <= mcs && mcs <= 76))) ||
+           (bandwidth == 40 && 0 <= mcs && mcs <= 76));
+    ASSERT(modes.emplace(Key(bandwidth, mcs, guardIntervalType), mode).second);
+
+    bool mustBeMandatory = bandwidth == 20 && mcs <= 7 &&
+            guardIntervalType == Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG;
+    ASSERT(modeSet->isMandatory(index) == mustBeMandatory);
+    if (modeSet->isMandatory(index))
+        mandatoryCount++;
+}
+ASSERT(mandatoryCount == 8);
+
+for (int bandwidth : {20, 40}) {
+    for (int mcs = 0; mcs <= 76; mcs++) {
+        if (bandwidth == 20 && mcs == 32)
+            continue;
+        auto longMode = modes.at(Key(bandwidth, mcs, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG));
+        auto shortMode = modes.at(Key(bandwidth, mcs, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
+        auto longData = longMode->getDataMode();
+        auto shortData = shortMode->getDataMode();
+        ASSERT(longData->getGuardInterval() == SimTime(800, SIMTIME_NS));
+        ASSERT(shortData->getGuardInterval() == SimTime(400, SIMTIME_NS));
+        ASSERT(longData->getSymbolInterval() == SimTime(4, SIMTIME_US));
+        ASSERT(shortData->getSymbolInterval() == SimTime(3600, SIMTIME_NS));
+        ASSERT(std::fabs(shortData->getNetBitrate().get() * 9 - longData->getNetBitrate().get() * 10) < 1);
+
+        // IEEE Std 802.11-2024, 19.3.11.11.6: short GI is Data-only.
+        auto longSignal = longMode->getHeaderMode();
+        auto shortSignal = shortMode->getHeaderMode();
+        ASSERT(longSignal->getSymbolInterval() == SimTime(4, SIMTIME_US));
+        ASSERT(shortSignal->getSymbolInterval() == SimTime(4, SIMTIME_US));
+        ASSERT(longSignal->getDuration() == SimTime(8, SIMTIME_US));
+        ASSERT(shortSignal->getDuration() == SimTime(8, SIMTIME_US));
+        ASSERT(longSignal->getNetBitrate() == shortSignal->getNetBitrate());
+        ASSERT(longSignal->getGrossBitrate() == shortSignal->getGrossBitrate());
+    }
+}
+ASSERT(modes.find(Key(20, 32, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG)) == modes.end());
+
+auto mcs32 = modes.at(Key(40, 32, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG))->getDataMode();
+ASSERT(mcs32->getNumberOfSpatialStreams() == 1);
+ASSERT(mcs32->getNumberOfDataSubcarriers() == 48);
+auto mcs76Bw20 = modes.at(Key(20, 76, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG))->getDataMode();
+ASSERT(mcs76Bw20->getModulationAndCodingScheme()->getStreamExtension3Modulation()->getSubcarrierModulation() == &Qam16Modulation::singleton);
+auto mcs73Bw40 = modes.at(Key(40, 73, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG))->getDataMode();
+ASSERT(mcs73Bw40->getModulationAndCodingScheme()->getStreamExtension2Modulation()->getSubcarrierModulation() == &Qam16Modulation::singleton);
+
+auto mixedLong = modes.at(Key(20, 0, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG));
+auto mixedShort = modes.at(Key(20, 0, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
+ASSERT(mixedLong->getDataMode()->getDuration(B(24)) == SimTime(36, SIMTIME_US));
+ASSERT(mixedShort->getDataMode()->getDuration(B(24)) == SimTime(32400, SIMTIME_NS));
+ASSERT(mixedShort->getDataMode()->getDuration(B(27)) == SimTime(36, SIMTIME_US));
+ASSERT(mixedLong->getDataMode()->getDuration(B(30)) == SimTime(44, SIMTIME_US));
+ASSERT(mixedShort->getDataMode()->getDuration(B(30)) == SimTime(39600, SIMTIME_NS));
+
+// IEEE Std 802.11-2024, 19.4.3: Eq. (19-90) rounds mixed-format
+// short-GI Data to 4 us, while Eq. (19-92) keeps greenfield Data raw.
+ASSERT(mixedShort->getDuration(B(24)) - mixedShort->getPreambleMode()->getDuration() == SimTime(36, SIMTIME_US));
+ASSERT(mixedShort->getDuration(B(27)) - mixedShort->getPreambleMode()->getDuration() == SimTime(36, SIMTIME_US));
+ASSERT(mixedShort->getDuration(B(30)) - mixedShort->getPreambleMode()->getDuration() == SimTime(40, SIMTIME_US));
+auto greenfieldShort = Ieee80211HtCompliantModes::getCompliantMode(
+        &Ieee80211HtmcsTable::htMcs8BW20MHz, Ieee80211HtMode::BAND_2_4GHZ,
+        Ieee80211HtPreambleMode::HT_PREAMBLE_GREENFIELD,
+        Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
+ASSERT(greenfieldShort->getPreambleMode()->getPreambleFormat() == Ieee80211HtPreambleMode::HT_PREAMBLE_GREENFIELD);
+ASSERT(greenfieldShort->getDataMode()->getNumberOfSpatialStreams() == 2);
+ASSERT(greenfieldShort->getDuration(B(24)) - greenfieldShort->getPreambleMode()->getDuration() == SimTime(18, SIMTIME_US));
+ASSERT(greenfieldShort->getDuration(B(30)) - greenfieldShort->getPreambleMode()->getDuration() == SimTime(21600, SIMTIME_NS));
+
+auto unspecified65 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(65), MHz(20), 1));
+auto long65 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(65), MHz(20), 1, SimTime(800, SIMTIME_NS)));
+auto short65 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(65), MHz(20), 1, SimTime(400, SIMTIME_NS)));
+ASSERT(unspecified65->getDataMode()->getMcsIndex() == 7);
+ASSERT(unspecified65->getDataMode()->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+ASSERT(long65->getDataMode()->getMcsIndex() == 7);
+ASSERT(short65->getDataMode()->getMcsIndex() == 6);
+
+auto unspecified135 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(135), MHz(40), 1));
+ASSERT(unspecified135->getDataMode()->getMcsIndex() == 6);
+ASSERT(unspecified135->getDataMode()->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
+ASSERT(modeSet->findMode(Mbps(65), MHz(20), 1, SimTime(600, SIMTIME_NS)) == nullptr);
+ASSERT(Ieee80211ModeSet::getModeSet("a")->findMode(Mbps(6), Hz(NaN), -1, SimTime(800, SIMTIME_NS)) == nullptr);
+
+EV << "HT guard interval catalog, timing, and lookup checks passed.\n";
+
+%contains: stdout
+HT guard interval catalog, timing, and lookup checks passed.

--- a/tests/unit/Ieee80211HtGuardInterval_1.test
+++ b/tests/unit/Ieee80211HtGuardInterval_1.test
@@ -6,11 +6,12 @@ Validate complete IEEE 802.11 HT long/short guard-interval catalog, lookup, and 
 #include <map>
 #include <tuple>
 
+#include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h"
-#include "inet/physicallayer/wireless/common/modulation/Qam16Modulation.h"
 
 %global:
 using namespace inet;
@@ -20,11 +21,72 @@ class TestIeee80211Transmitter : public Ieee80211Transmitter
 {
   public:
     const IIeee80211Mode *getSelectedMode() const { return mode; }
+    const Ieee80211ModeSet *getSelectedModeSet() const { return modeSet; }
+};
+
+class TestIeee80211Mgmt : public ieee80211::Ieee80211MgmtBase
+{
+  protected:
+    virtual void handleTimer(cMessage *frame) override {}
+    virtual void handleCommand(int msgkind, cObject *ctrl) override {}
+    virtual void handleAuthenticationFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleDeauthenticationFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleAssociationRequestFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleAssociationResponseFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleReassociationRequestFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleReassociationResponseFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleDisassociationFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleBeaconFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleProbeRequestFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+    virtual void handleProbeResponseFrame(Packet *packet, const Ptr<const ieee80211::Ieee80211MgmtHeader>& header) override {}
+
+  public:
+    void applyModeSet(const Ieee80211ModeSet *modeSet)
+    {
+        receiveSignal(nullptr, modesetChangedSignal, const_cast<Ieee80211ModeSet *>(modeSet), nullptr);
+    }
+
+    const ieee80211::Ieee80211SupportedRatesElement& getSupportedRates() const { return supportedRates; }
 };
 
 %activity:
+// Reject unsupported VHT greenfield before any mixed-format cache request.
+bool rejectedVhtGreenfieldBeforeMixed = false;
+try {
+    Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1,
+            Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_GREENFIELD,
+            Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG);
+}
+catch (cRuntimeError&) {
+    rejectedVhtGreenfieldBeforeMixed = true;
+}
+ASSERT(rejectedVhtGreenfieldBeforeMixed);
+
 const auto modeSet = Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
-ASSERT(modeSet->getNumModes() == 306);
+ASSERT(modeSet->getNumModes() == 128);
+
+TestIeee80211Mgmt mgmt;
+mgmt.applyModeSet(modeSet);
+const auto& htSupportedRates = mgmt.getSupportedRates();
+const double expectedHtSupportedRates[] = {6.5, 13, 19.5, 26, 39, 52, 58.5, 65};
+ASSERT(htSupportedRates.numRates == 8);
+for (int i = 0; i < htSupportedRates.numRates; i++) {
+    ASSERT(htSupportedRates.rate[i] == expectedHtSupportedRates[i]);
+    if (i > 0)
+        ASSERT(htSupportedRates.rate[i - 1] < htSupportedRates.rate[i]);
+}
+
+mgmt.applyModeSet(Ieee80211ModeSet::getModeSet("a"));
+const auto& legacySupportedRates = mgmt.getSupportedRates();
+const double expectedLegacySupportedRates[] = {6, 12, 24};
+ASSERT(legacySupportedRates.numRates == 3);
+for (int i = 0; i < legacySupportedRates.numRates; i++) {
+    ASSERT(legacySupportedRates.rate[i] == expectedLegacySupportedRates[i]);
+    if (i > 0)
+        ASSERT(legacySupportedRates.rate[i - 1] < legacySupportedRates.rate[i]);
+}
+for (int i = legacySupportedRates.numRates; i < 8; i++)
+    ASSERT(legacySupportedRates.rate[i] == 0);
 
 using Key = std::tuple<int, int, Ieee80211HtModeBase::GuardIntervalType>;
 std::map<Key, const Ieee80211HtMode *> modes;
@@ -37,8 +99,7 @@ for (int index = 0; index < modeSet->getNumModes(); index++) {
     int mcs = dataMode->getMcsIndex();
     auto guardIntervalType = dataMode->getGuardIntervalType();
     ASSERT(bandwidth != 0);
-    ASSERT((bandwidth == 20 && ((0 <= mcs && mcs <= 31) || (33 <= mcs && mcs <= 76))) ||
-           (bandwidth == 40 && 0 <= mcs && mcs <= 76));
+    ASSERT((bandwidth == 20 || bandwidth == 40) && 0 <= mcs && mcs <= 31);
     ASSERT(modes.emplace(Key(bandwidth, mcs, guardIntervalType), mode).second);
 
     bool mustBeMandatory = bandwidth == 20 && mcs <= 7 &&
@@ -58,9 +119,7 @@ for (int index = 0; index < modeSet->getNumModes(); index++) {
 }
 
 for (int bandwidth : {20, 40}) {
-    for (int mcs = 0; mcs <= 76; mcs++) {
-        if (bandwidth == 20 && mcs == 32)
-            continue;
+    for (int mcs = 0; mcs <= 31; mcs++) {
         auto longMode = modes.at(Key(bandwidth, mcs, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG));
         auto shortMode = modes.at(Key(bandwidth, mcs, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
         auto longData = longMode->getDataMode();
@@ -84,14 +143,6 @@ for (int bandwidth : {20, 40}) {
 }
 ASSERT(modes.find(Key(20, 32, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG)) == modes.end());
 
-auto mcs32 = modes.at(Key(40, 32, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG))->getDataMode();
-ASSERT(mcs32->getNumberOfSpatialStreams() == 1);
-ASSERT(mcs32->getNumberOfDataSubcarriers() == 48);
-auto mcs76Bw20 = modes.at(Key(20, 76, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG))->getDataMode();
-ASSERT(mcs76Bw20->getModulationAndCodingScheme()->getStreamExtension3Modulation()->getSubcarrierModulation() == &Qam16Modulation::singleton);
-auto mcs73Bw40 = modes.at(Key(40, 73, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG))->getDataMode();
-ASSERT(mcs73Bw40->getModulationAndCodingScheme()->getStreamExtension2Modulation()->getSubcarrierModulation() == &Qam16Modulation::singleton);
-
 auto mixedLong = modes.at(Key(20, 0, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG));
 auto mixedShort = modes.at(Key(20, 0, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
 ASSERT(mixedLong->getDataMode()->getDuration(B(24)) == SimTime(36, SIMTIME_US));
@@ -105,6 +156,18 @@ ASSERT(mixedShort->getDataMode()->getDuration(B(30)) == SimTime(39600, SIMTIME_N
 ASSERT(mixedShort->getDataDuration(B(24)) == SimTime(36, SIMTIME_US));
 ASSERT(mixedShort->getDataDuration(B(27)) == SimTime(36, SIMTIME_US));
 ASSERT(mixedShort->getDataDuration(B(30)) == SimTime(40, SIMTIME_US));
+
+// Preserve representative historical optional-rate timing and bitrate values.
+auto mixedShortMcs8 = modes.at(Key(20, 8, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
+auto mixedShortMcs0Bw40 = modes.at(Key(40, 0, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
+ASSERT(std::fabs(mixedShortMcs8->getDataMode()->getNetBitrate().get() - 14.4444444444444e6) < 1);
+ASSERT(mixedShortMcs8->getDataMode()->getDuration(B(24)) == SimTime(18, SIMTIME_US));
+ASSERT(mixedShortMcs8->getDataDuration(B(24)) == SimTime(20, SIMTIME_US));
+ASSERT(mixedShortMcs8->getDuration(B(24)) == SimTime(60, SIMTIME_US));
+ASSERT(mixedShortMcs0Bw40->getDataMode()->getNetBitrate() == Mbps(15));
+ASSERT(mixedShortMcs0Bw40->getDataMode()->getDuration(B(24)) == SimTime(14400, SIMTIME_NS));
+ASSERT(mixedShortMcs0Bw40->getDataDuration(B(24)) == SimTime(16, SIMTIME_US));
+ASSERT(mixedShortMcs0Bw40->getDuration(B(24)) == SimTime(52, SIMTIME_US));
 auto greenfieldShort = Ieee80211HtCompliantModes::getCompliantMode(
         &Ieee80211HtmcsTable::htMcs8BW20MHz, Ieee80211HtMode::BAND_2_4GHZ,
         Ieee80211HtPreambleMode::HT_PREAMBLE_GREENFIELD,
@@ -159,8 +222,23 @@ auto unspecified135 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbp
 ASSERT(unspecified135->getDataMode()->getMcsIndex() == 6);
 ASSERT(unspecified135->getDataMode()->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
 ASSERT(modeSet->findMode(Mbps(65), MHz(20), 1, SimTime(600, SIMTIME_NS)) == nullptr);
-ASSERT(Ieee80211ModeSet::getModeSet("a")->findMode(Mbps(6), Hz(NaN), -1, SimTime(800, SIMTIME_NS)) == nullptr);
+const auto legacyOfdmModeSet = Ieee80211ModeSet::getModeSet("a");
+ASSERT(legacyOfdmModeSet->findMode(Mbps(6), Hz(NaN), -1, SimTime(800, SIMTIME_NS)) != nullptr);
+ASSERT(legacyOfdmModeSet->findMode(Mbps(6), Hz(NaN), -1, SimTime(400, SIMTIME_NS)) == nullptr);
 
+Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1,
+        Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED,
+        Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG);
+bool rejectedVhtGreenfieldAfterMixed = false;
+try {
+    Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1,
+            Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_GREENFIELD,
+            Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG);
+}
+catch (cRuntimeError&) {
+    rejectedVhtGreenfieldAfterMixed = true;
+}
+ASSERT(rejectedVhtGreenfieldAfterMixed);
 const auto vhtModeSet = Ieee80211ModeSet::getModeSet("ac");
 bool foundVhtLongGuardInterval = false;
 bool foundVhtShortGuardInterval = false;
@@ -184,6 +262,43 @@ ASSERT(vhtOneSymbol->getDataDuration(B(24)) == SimTime(4, SIMTIME_US));
 ASSERT(vhtOneSymbol->getPreambleDuration() == SimTime(20, SIMTIME_US));
 ASSERT(vhtOneSymbol->getHeaderDuration() >= SIMTIME_ZERO);
 ASSERT(vhtOneSymbol->getDuration(B(24)) == vhtOneSymbol->getPreambleDuration() + vhtOneSymbol->getHeaderDuration() + vhtOneSymbol->getDataDuration(B(24)));
+
+for (const auto candidateSet : {modeSet, vhtModeSet}) {
+    for (int index = 0; index < candidateSet->getNumModes(); index++) {
+        auto mode = candidateSet->getMode(index);
+        auto slowerMode = candidateSet->getSlowerMode(mode);
+        auto fasterMode = candidateSet->getFasterMode(mode);
+        auto slowerMandatoryMode = candidateSet->getSlowerMandatoryMode(mode);
+        auto fasterMandatoryMode = candidateSet->getFasterMandatoryMode(mode);
+        ASSERT(slowerMode == nullptr || slowerMode->getDataMode()->getNetBitrate() < mode->getDataMode()->getNetBitrate());
+        ASSERT(fasterMode == nullptr || fasterMode->getDataMode()->getNetBitrate() > mode->getDataMode()->getNetBitrate());
+        ASSERT(slowerMandatoryMode == nullptr || slowerMandatoryMode->getDataMode()->getNetBitrate() < mode->getDataMode()->getNetBitrate());
+        ASSERT(fasterMandatoryMode == nullptr || fasterMandatoryMode->getDataMode()->getNetBitrate() > mode->getDataMode()->getNetBitrate());
+    }
+}
+
+// The equal-rate mandatory candidate is selected by bitrate, not entry index.
+auto equalRateVhtMode = Ieee80211VhtCompliantModes::getCompliantMode(
+        &Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss2, Ieee80211VhtMode::BAND_5GHZ,
+        Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG);
+auto mandatoryAtEqualRate = vhtModeSet->getMandatoryModeAtOrBelow(equalRateVhtMode);
+ASSERT(mandatoryAtEqualRate != nullptr);
+ASSERT(mandatoryAtEqualRate->getDataMode()->getNetBitrate() == equalRateVhtMode->getDataMode()->getNetBitrate());
+ASSERT(vhtModeSet->getIsMandatory(mandatoryAtEqualRate));
+
+transmitter.setModeSetAndMode(vhtModeSet, vhtOneSymbol);
+ASSERT(transmitter.getSelectedModeSet() == vhtModeSet);
+ASSERT(transmitter.getSelectedMode() == vhtOneSymbol);
+bool rejectedCombinedModeUpdate = false;
+try {
+    transmitter.setModeSetAndMode(modeSet, greenfieldShortOneSymbol);
+}
+catch (cRuntimeError&) {
+    rejectedCombinedModeUpdate = true;
+}
+ASSERT(rejectedCombinedModeUpdate);
+ASSERT(transmitter.getSelectedModeSet() == vhtModeSet);
+ASSERT(transmitter.getSelectedMode() == vhtOneSymbol);
 
 EV << "HT guard interval catalog, timing, and lookup checks passed.\n";
 

--- a/tests/unit/Ieee80211HtGuardInterval_1.test
+++ b/tests/unit/Ieee80211HtGuardInterval_1.test
@@ -226,6 +226,46 @@ const auto legacyOfdmModeSet = Ieee80211ModeSet::getModeSet("a");
 ASSERT(legacyOfdmModeSet->findMode(Mbps(6), Hz(NaN), -1, SimTime(800, SIMTIME_NS)) != nullptr);
 ASSERT(legacyOfdmModeSet->findMode(Mbps(6), Hz(NaN), -1, SimTime(400, SIMTIME_NS)) == nullptr);
 
+// Mode-set remapping preserves the complete modeled PHY tuple. In
+// particular, a negative GI is an actual absence for compatibility lookup,
+// not findMode()'s public wildcard.
+const auto erpModeSet = Ieee80211ModeSet::getModeSet("g(erp)");
+const auto pModeSet = Ieee80211ModeSet::getModeSet("p");
+const auto aMode = legacyOfdmModeSet->getMode(Mbps(6), MHz(20), 1, SimTime(800, SIMTIME_NS));
+const auto erpMode = erpModeSet->findCompatibleMode(aMode);
+ASSERT(erpMode != nullptr);
+ASSERT(erpMode->getDataMode()->getNetBitrate() == aMode->getDataMode()->getNetBitrate());
+ASSERT(erpMode->getDataMode()->getBandwidth() == aMode->getDataMode()->getBandwidth());
+ASSERT(erpMode->getDataMode()->getGuardInterval() == aMode->getDataMode()->getGuardInterval());
+
+const auto dsssModeSet = Ieee80211ModeSet::getModeSet("b");
+const auto mixedModeSet = Ieee80211ModeSet::getModeSet("g(mixed)");
+const auto dsssMode = dsssModeSet->getMode(Mbps(1));
+ASSERT(dsssMode->getDataMode()->getGuardInterval() < SIMTIME_ZERO);
+ASSERT(mixedModeSet->findCompatibleMode(dsssMode) != nullptr);
+
+TestIeee80211Transmitter legacyTransmitter;
+legacyTransmitter.setModeSet(legacyOfdmModeSet);
+legacyTransmitter.setMode(aMode);
+legacyTransmitter.setModeSet(erpModeSet);
+ASSERT(legacyTransmitter.getSelectedModeSet() == erpModeSet);
+ASSERT(legacyTransmitter.getSelectedMode() == erpMode);
+const auto modeBeforeRejectedTransition = legacyTransmitter.getSelectedMode();
+bool rejectedIncompatibleModeSet = false;
+try {
+    legacyTransmitter.setModeSet(pModeSet);
+}
+catch (cRuntimeError&) {
+    rejectedIncompatibleModeSet = true;
+}
+ASSERT(rejectedIncompatibleModeSet);
+ASSERT(legacyTransmitter.getSelectedModeSet() == erpModeSet);
+ASSERT(legacyTransmitter.getSelectedMode() == modeBeforeRejectedTransition);
+const auto pMode = pModeSet->getMode(2); // the declared 6 Mbps 10 MHz mode
+legacyTransmitter.setModeSetAndMode(pModeSet, pMode);
+ASSERT(legacyTransmitter.getSelectedModeSet() == pModeSet);
+ASSERT(legacyTransmitter.getSelectedMode() == pMode);
+
 Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1,
         Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED,
         Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG);
@@ -240,6 +280,30 @@ catch (cRuntimeError&) {
 }
 ASSERT(rejectedVhtGreenfieldAfterMixed);
 const auto vhtModeSet = Ieee80211ModeSet::getModeSet("ac");
+const auto vhtLongMcs0 = Ieee80211VhtCompliantModes::getCompliantMode(
+        &Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ,
+        Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG);
+const auto vhtShortMcs0 = Ieee80211VhtCompliantModes::getCompliantMode(
+        &Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ,
+        Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_SHORT);
+// IEEE Std 802.11-2024, Tables 21-5/21-8 and 21.4.3, Eqs. (21-109)/(21-110).
+ASSERT(vhtLongMcs0->getDataMode()->getSymbolInterval() == SimTime(4, SIMTIME_US));
+ASSERT(vhtShortMcs0->getDataMode()->getSymbolInterval() == SimTime(3600, SIMTIME_NS));
+ASSERT(vhtLongMcs0->getHeaderMode()->getSymbolInterval() == SimTime(4, SIMTIME_US));
+ASSERT(vhtShortMcs0->getHeaderMode()->getSymbolInterval() == SimTime(4, SIMTIME_US));
+ASSERT(vhtLongMcs0->getHeaderMode()->getNetBitrate() == vhtShortMcs0->getHeaderMode()->getNetBitrate());
+ASSERT(vhtLongMcs0->getHeaderMode()->getGrossBitrate() == vhtShortMcs0->getHeaderMode()->getGrossBitrate());
+ASSERT(vhtShortMcs0->getDataMode()->getDuration(B(24)) == SimTime(32400, SIMTIME_NS));
+ASSERT(vhtShortMcs0->getDataDuration(B(24)) == SimTime(36, SIMTIME_US));
+ASSERT(vhtShortMcs0->getDataMode()->getDuration(B(27)) == SimTime(36, SIMTIME_US));
+ASSERT(vhtShortMcs0->getDataDuration(B(27)) == SimTime(36, SIMTIME_US));
+ASSERT(vhtShortMcs0->getDataMode()->getDuration(B(30)) == SimTime(39600, SIMTIME_NS));
+ASSERT(vhtShortMcs0->getDataDuration(B(30)) == SimTime(40, SIMTIME_US));
+ASSERT(vhtLongMcs0->getDataMode()->getDuration(B(24)) == SimTime(36, SIMTIME_US));
+ASSERT(vhtLongMcs0->getDataDuration(B(24)) == SimTime(36, SIMTIME_US));
+for (auto vhtMode : {vhtLongMcs0, vhtShortMcs0})
+    for (auto dataLength : {B(24), B(27), B(30)})
+        ASSERT(vhtMode->getDuration(dataLength) == vhtMode->getPreambleDuration() + vhtMode->getHeaderDuration() + vhtMode->getDataDuration(dataLength));
 bool foundVhtLongGuardInterval = false;
 bool foundVhtShortGuardInterval = false;
 for (int index = 0; index < vhtModeSet->getNumModes(); index++) {

--- a/tests/unit/Ieee80211HtGuardInterval_1.test
+++ b/tests/unit/Ieee80211HtGuardInterval_1.test
@@ -8,11 +8,19 @@ Validate complete IEEE 802.11 HT long/short guard-interval catalog, lookup, and 
 
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h"
 #include "inet/physicallayer/wireless/common/modulation/Qam16Modulation.h"
 
 %global:
 using namespace inet;
 using namespace inet::physicallayer;
+
+class TestIeee80211Transmitter : public Ieee80211Transmitter
+{
+  public:
+    const IIeee80211Mode *getSelectedMode() const { return mode; }
+};
 
 %activity:
 const auto modeSet = Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
@@ -40,6 +48,14 @@ for (int index = 0; index < modeSet->getNumModes(); index++) {
         mandatoryCount++;
 }
 ASSERT(mandatoryCount == 8);
+
+for (int index = 0; index < modeSet->getNumModes(); index++) {
+    auto mode = modeSet->getMode(index);
+    auto slowerMode = modeSet->getSlowerMode(mode);
+    auto fasterMode = modeSet->getFasterMode(mode);
+    ASSERT(slowerMode == nullptr || slowerMode->getDataMode()->getNetBitrate() < mode->getDataMode()->getNetBitrate());
+    ASSERT(fasterMode == nullptr || fasterMode->getDataMode()->getNetBitrate() > mode->getDataMode()->getNetBitrate());
+}
 
 for (int bandwidth : {20, 40}) {
     for (int mcs = 0; mcs <= 76; mcs++) {
@@ -86,17 +102,36 @@ ASSERT(mixedShort->getDataMode()->getDuration(B(30)) == SimTime(39600, SIMTIME_N
 
 // IEEE Std 802.11-2024, 19.4.3: Eq. (19-90) rounds mixed-format
 // short-GI Data to 4 us, while Eq. (19-92) keeps greenfield Data raw.
-ASSERT(mixedShort->getDuration(B(24)) - mixedShort->getPreambleMode()->getDuration() == SimTime(36, SIMTIME_US));
-ASSERT(mixedShort->getDuration(B(27)) - mixedShort->getPreambleMode()->getDuration() == SimTime(36, SIMTIME_US));
-ASSERT(mixedShort->getDuration(B(30)) - mixedShort->getPreambleMode()->getDuration() == SimTime(40, SIMTIME_US));
+ASSERT(mixedShort->getDataDuration(B(24)) == SimTime(36, SIMTIME_US));
+ASSERT(mixedShort->getDataDuration(B(27)) == SimTime(36, SIMTIME_US));
+ASSERT(mixedShort->getDataDuration(B(30)) == SimTime(40, SIMTIME_US));
 auto greenfieldShort = Ieee80211HtCompliantModes::getCompliantMode(
         &Ieee80211HtmcsTable::htMcs8BW20MHz, Ieee80211HtMode::BAND_2_4GHZ,
         Ieee80211HtPreambleMode::HT_PREAMBLE_GREENFIELD,
         Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
 ASSERT(greenfieldShort->getPreambleMode()->getPreambleFormat() == Ieee80211HtPreambleMode::HT_PREAMBLE_GREENFIELD);
 ASSERT(greenfieldShort->getDataMode()->getNumberOfSpatialStreams() == 2);
-ASSERT(greenfieldShort->getDuration(B(24)) - greenfieldShort->getPreambleMode()->getDuration() == SimTime(18, SIMTIME_US));
-ASSERT(greenfieldShort->getDuration(B(30)) - greenfieldShort->getPreambleMode()->getDuration() == SimTime(21600, SIMTIME_NS));
+ASSERT(greenfieldShort->getDataDuration(B(24)) == SimTime(18, SIMTIME_US));
+ASSERT(greenfieldShort->getDataDuration(B(30)) == SimTime(21600, SIMTIME_NS));
+
+auto mixedLongOneSymbol = modes.at(Key(20, 15, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG));
+auto mixedShortOneSymbol = modes.at(Key(20, 15, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT));
+auto greenfieldShortOneSymbol = Ieee80211HtCompliantModes::getCompliantMode(
+        &Ieee80211HtmcsTable::htMcs15BW20MHz, Ieee80211HtMode::BAND_2_4GHZ,
+        Ieee80211HtPreambleMode::HT_PREAMBLE_GREENFIELD,
+        Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
+for (auto mode : {mixedLongOneSymbol, mixedShortOneSymbol, greenfieldShortOneSymbol}) {
+    auto dataDuration = mode->getDataDuration(B(24));
+    ASSERT(dataDuration >= SIMTIME_ZERO);
+    ASSERT(mode->getDuration(B(24)) == mode->getPreambleDuration() + mode->getHeaderDuration() + dataDuration);
+}
+ASSERT(mixedLongOneSymbol->getDataDuration(B(24)) == SimTime(4, SIMTIME_US));
+ASSERT(mixedShortOneSymbol->getDataDuration(B(24)) == SimTime(4, SIMTIME_US));
+ASSERT(greenfieldShortOneSymbol->getDataDuration(B(24)) == SimTime(3600, SIMTIME_NS));
+ASSERT(mixedShortOneSymbol->getPreambleDuration() == SimTime(20, SIMTIME_US));
+ASSERT(mixedShortOneSymbol->getHeaderDuration() == SimTime(20, SIMTIME_US));
+ASSERT(greenfieldShortOneSymbol->getPreambleDuration() == SimTime(16, SIMTIME_US));
+ASSERT(greenfieldShortOneSymbol->getHeaderDuration() == SimTime(12, SIMTIME_US));
 
 auto unspecified65 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(65), MHz(20), 1));
 auto long65 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(65), MHz(20), 1, SimTime(800, SIMTIME_NS)));
@@ -106,11 +141,49 @@ ASSERT(unspecified65->getDataMode()->getGuardIntervalType() == Ieee80211HtModeBa
 ASSERT(long65->getDataMode()->getMcsIndex() == 7);
 ASSERT(short65->getDataMode()->getMcsIndex() == 6);
 
+TestIeee80211Transmitter transmitter;
+transmitter.setModeSet(modeSet);
+transmitter.setMode(short65);
+ASSERT(transmitter.getSelectedMode() == short65);
+bool rejectedModeOutsideSet = false;
+try {
+    transmitter.setMode(greenfieldShortOneSymbol);
+}
+catch (cRuntimeError&) {
+    rejectedModeOutsideSet = true;
+}
+ASSERT(rejectedModeOutsideSet);
+ASSERT(transmitter.getSelectedMode() == short65);
+
 auto unspecified135 = dynamic_cast<const Ieee80211HtMode *>(modeSet->getMode(Mbps(135), MHz(40), 1));
 ASSERT(unspecified135->getDataMode()->getMcsIndex() == 6);
 ASSERT(unspecified135->getDataMode()->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
 ASSERT(modeSet->findMode(Mbps(65), MHz(20), 1, SimTime(600, SIMTIME_NS)) == nullptr);
 ASSERT(Ieee80211ModeSet::getModeSet("a")->findMode(Mbps(6), Hz(NaN), -1, SimTime(800, SIMTIME_NS)) == nullptr);
+
+const auto vhtModeSet = Ieee80211ModeSet::getModeSet("ac");
+bool foundVhtLongGuardInterval = false;
+bool foundVhtShortGuardInterval = false;
+for (int index = 0; index < vhtModeSet->getNumModes(); index++) {
+    auto vhtMode = dynamic_cast<const Ieee80211VhtMode *>(vhtModeSet->getMode(index));
+    ASSERT(vhtMode != nullptr);
+    auto vhtDataMode = vhtMode->getDataMode();
+    auto guardInterval = vhtDataMode->getGuardInterval();
+    auto resolvedMode = vhtModeSet->findMode(vhtDataMode->getNetBitrate(), vhtDataMode->getBandwidth(), vhtDataMode->getNumberOfSpatialStreams(), guardInterval);
+    ASSERT(resolvedMode != nullptr);
+    ASSERT(resolvedMode->getDataMode()->getGuardInterval() == guardInterval);
+    foundVhtLongGuardInterval |= guardInterval == SimTime(800, SIMTIME_NS);
+    foundVhtShortGuardInterval |= guardInterval == SimTime(400, SIMTIME_NS);
+}
+ASSERT(foundVhtLongGuardInterval);
+ASSERT(foundVhtShortGuardInterval);
+
+auto vhtOneSymbol = dynamic_cast<const Ieee80211VhtMode *>(vhtModeSet->getFastestMode());
+ASSERT(vhtOneSymbol != nullptr);
+ASSERT(vhtOneSymbol->getDataDuration(B(24)) == SimTime(4, SIMTIME_US));
+ASSERT(vhtOneSymbol->getPreambleDuration() == SimTime(20, SIMTIME_US));
+ASSERT(vhtOneSymbol->getHeaderDuration() >= SIMTIME_ZERO);
+ASSERT(vhtOneSymbol->getDuration(B(24)) == vhtOneSymbol->getPreambleDuration() + vhtOneSymbol->getHeaderDuration() + vhtOneSymbol->getDataDuration(B(24)));
 
 EV << "HT guard interval catalog, timing, and lookup checks passed.\n";
 


### PR DESCRIPTION
## Summary

- add both 800 ns and 400 ns variants for every legal HT MCS/bandwidth tuple
- expose `dataFrameGuardInterval` in both DCF and HCF rate selection
- make HT data bitrate, symbol duration, and PPDU airtime use the selected guard interval consistently
- preserve historical unspecified-GI lookup behavior for equal-bitrate modes

## Root cause

INET represented both HT guard intervals when calculating bitrate, but the predefined mode set exposed only one GI for each tuple, rate selection could not qualify a lookup by GI, and HT data duration always used the 4.0 us long-GI symbol interval.

## Implementation

The HT catalog now contains 306 modes: 153 legal bandwidth/MCS tuples, each with long and short GI. Only the mandatory long-GI 20 MHz MCS 0-7 entries remain mandatory.

HT Data uses 4.0 us or 3.6 us symbols as selected. HT-SIG remains on 4.0 us symbols, and HT-mixed short-GI data airtime follows IEEE 802.11-2024 Equation 19-90 by rounding to a 4 us boundary using exact simulation-time ticks. HT-greenfield retains raw 3.6 us data symbols.

## Validation

- debug build: PASS
- focused HT-GI unit test: 1/1 PASS
- IEEE 802.11 unit tests: 2/2 PASS
- IEEE 802.11 module tests: 16/16 PASS
- relevant fingerprint test: 1/1 PASS, with no baseline changes
- Cmdenv fixed-rate 400 ns smoke through DCF and HCF: PASS
- `git diff --check`: PASS

## Known limitations

Peer short-GI capability negotiation and serialization of the HT-SIG Short GI bit remain outside this patch; both are pre-existing model limitations.
