### PR TITLE
ipv6: verify a care-of address before registering it with the home agent

### DIFF
--- a/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
+++ b/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
@@ -897,7 +897,18 @@ void Ipv6NeighbourDiscovery::makeTentativeAddressPermanent(const Ipv6Address& te
     ie->getProtocolDataForUpdate<Ipv6InterfaceData>()->setDadInProgress(false);
 
     if (!tentativeAddr.isLinkLocal()) {
-        // DAD completed for a global address -- nothing else to do
+        // DAD completed for a global address. When it is the care-of address formed at a
+        // handover, the mobile node may now register it with its home agent: until this
+        // point its uniqueness on the visited link was unverified (RFC 4862 Section 5.4).
+        auto git = dadGlobalList.find(ie->getInterfaceId());
+        if (git != dadGlobalList.end() && git->second.addr == tentativeAddr) {
+            [[maybe_unused]] bool homeNetwork = git->second.hFlag;
+            dadGlobalList.erase(git);
+#ifdef INET_WITH_MIPV6
+            if (rt6->isMobileNode() && !homeNetwork) // if we are not in the home network, send BUs
+                mipv6->initiateMipv6Protocol(ie, tentativeAddr);
+#endif
+        }
         return;
     }
 
@@ -908,7 +919,21 @@ void Ipv6NeighbourDiscovery::makeTentativeAddressPermanent(const Ipv6Address& te
     if (it != dadGlobalList.end()) {
         DadGlobalEntry& entry = it->second;
 
-        ie->getProtocolDataForUpdate<Ipv6InterfaceData>()->assignAddress(entry.addr, false, simTime() + entry.validLifetime,
+        // Clear the tentative flag on the addresses that were already on the interface when
+        // the Router Advertisement arrived: the link-local address whose DAD just completed,
+        // and the home address. This has to happen before the address formed from the new
+        // prefix is added below, because that address has not been verified yet.
+        for (int i = 0; i < ie->getProtocolData<Ipv6InterfaceData>()->getNumAddresses(); i++) {
+            Ipv6Address addr = ie->getProtocolData<Ipv6InterfaceData>()->getAddress(i);
+            ie->getProtocolDataForUpdate<Ipv6InterfaceData>()->permanentlyAssign(addr);
+        }
+
+        // RFC 4862 Section 5.4 requires DAD on every unicast address, so the care-of address
+        // formed from the new prefix is assigned as tentative; the loop at the end of this
+        // function starts DAD for it. The MIPv6 registration is not started here but when
+        // that DAD completes (see above), so no Binding Update can advertise an address
+        // whose uniqueness on the visited link is still unverified.
+        ie->getProtocolDataForUpdate<Ipv6InterfaceData>()->assignAddress(entry.addr, true, simTime() + entry.validLifetime,
                 simTime() + entry.preferredLifetime, entry.hFlag);
 
         // moved from processRAPrefixInfoForAddrAutoConf()
@@ -916,24 +941,9 @@ void Ipv6NeighbourDiscovery::makeTentativeAddressPermanent(const Ipv6Address& te
         if (!entry.CoA.isUnspecified())
             ie->getProtocolDataForUpdate<Ipv6InterfaceData>()->removeAddress(entry.CoA);
 
-        // set addresses on this interface to tentative=false
-        for (int i = 0; i < ie->getProtocolData<Ipv6InterfaceData>()->getNumAddresses(); i++) {
-            // TODO improve this code so that only addresses are permanently assigned
-            // which are formed based on the new prefix from the RA
-            Ipv6Address addr = ie->getProtocolData<Ipv6InterfaceData>()->getAddress(i);
-            ie->getProtocolDataForUpdate<Ipv6InterfaceData>()->permanentlyAssign(addr);
-        }
-
-#ifdef INET_WITH_MIPV6
-        // if we have MIPv6 protocols on this node we will eventually have to
-        // call some appropriate methods
-        if (rt6->isMobileNode()) {
-            if (entry.hFlag == false) // if we are not in the home network, send BUs
-                mipv6->initiateMipv6Protocol(ie, tentativeAddr);
-        }
-#endif
-
-        dadGlobalList.erase(it->first);
+        // The MIPv6 protocol is initiated once the care-of address assigned above has
+        // passed DAD; the dadGlobalList entry is kept until then. dadHasFailed() drops
+        // it, so a care-of address that is already in use is never registered.
     }
 
     // Assign global scope addresses to routers. The Ipv6FlatNetworkConfigurator assigns

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -380,9 +380,9 @@
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c MultiRadio -r 0,             20s,             ec17-5cc2/tplx;55f5-0894/~tNl, PASS,  wireless adhoc Ipv4
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c SingleRadio -r 0,            20s,             85a0-51b8/tplx;c07a-44e1/~tNl;3aa0-49ed/tyf, PASS,  wireless adhoc Ipv4
 
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             19b8-20a4/tplx;b378-071d/~tNl;d358-e3bb/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             3f0c-078d/tplx;04e1-1f03/~tNl;4199-2b15/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             0798-40c2/tplx;a682-8d0e/~tNl;cdb7-1b34/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             6204-6190/tplx;68f4-68c6/~tNl;76af-99d1/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             9faf-b8a8/tplx;f076-4454/~tNl;582f-fb5e/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             4ab1-dea8/tplx;9d55-36d4/~tNl;1f90-d7bf/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
 /examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             f614-da0d/tplx;8b55-7191/~tNl;b490-dc09/~tND;0277-d784/tyf, PASS, wireless EthernetMac
 
 /examples/mobility/,                 -f omnetpp.ini -c AnsimMobility -r 0,          10000s,          72f8-5c0b/tplx;0000-0000/~tNl;0000-0000/~tND;7dd1-18eb/tyf, PASS,

--- a/tests/fingerprint/mipv6-refactoring.csv
+++ b/tests/fingerprint/mipv6-refactoring.csv
@@ -8,9 +8,9 @@
 # empty-shim step, which kept these fingerprints bit-for-bit identical.
 
 # MIPv6 example — the primary test
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            aa29-a8c5/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            068b-23aa/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            c8dc-27c2/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            dfed-b54a/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            ab29-ae3f/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            2b0b-fa1a/~tNlb, PASS, wireless EthernetMac
 
 # IPv6 examples
 # MLD example — new PASS row; ~tNl locks the MLD Report/Query/Done/MAS-Query packet exchange (traffic+lengths);

--- a/tests/module/MIPv6_care_of_address_DAD.test
+++ b/tests/module/MIPv6_care_of_address_DAD.test
@@ -1,0 +1,134 @@
+%description:
+Tests that a care-of address formed at a handover undergoes Duplicate Address
+Detection (DAD) before it is used, as required by RFC 4862 Section 5.4, and that
+the Mobile Node does not register it with its Home Agent until that DAD passes.
+
+The Mobile Node boots on its home link (where it has only a link-local address,
+so the home address is verified through the single-address path), then moves to
+the foreign network. On arrival its interface already holds a link-local address
+and the home address, so address autoconfiguration takes the multi-address path.
+Before this test was added, that path assigned the care-of address as permanent
+and started no DAD for it, and the Binding Update advertised an address whose
+uniqueness on the visited link had never been tested.
+
+%#--------------------------------------------------------------------------------------------------------------
+%inifile: omnetpp.ini
+[General]
+record-vector-results = false
+**.neighbourDiscovery.cmdenv-log-level = trace
+**.mipv6.cmdenv-log-level = trace
+**.app[*].cmdenv-log-level = trace
+**.cmdenv-log-level = off
+cmdenv-event-banners = false
+ned-path = .;../../../../src;../../lib
+network = inet.test.moduletest.lib.Mipv6Network
+sim-time-limit = 60s
+cmdenv-express-mode = false
+cmdenv-log-prefix = "%C: "
+num-rngs = 3
+seed-set = 1
+**.mobility.rng-0 = 2
+
+# number of MNs and CNs
+*.total_mn = 1
+*.total_cn = 1
+
+**.neighbourDiscovery.minIntervalBetweenRAs = 0.03s
+**.neighbourDiscovery.maxIntervalBetweenRAs = 0.07s
+**.neighbourDiscovery.detectL2Movement = false   # legacy: detect movement from periodic RAs only
+
+# channel physical parameters
+*.radioMedium.mediumLimitCache.maxTransmissionPower = 2.0mW
+*.radioMedium.mediumLimitCache.minReceptionPower = -82dBm
+*.radioMedium.mediumLimitCache.minInterferencePower = -82dBm
+
+# access point
+**.wlan*.mgmt.numAuthSteps = 4
+
+# ALL APs common parameters
+**.AP*.wlan*.mgmt.beaconInterval = 0.1s
+
+# Access Point parameters
+**.AP_Home.wlan*.mgmt.ssid = "HOME"
+**.AP_Home.wlan*.address = "10:AA:00:00:00:01"
+**.AP_Home.eth[0].address = "10:AE:00:00:00:02"
+**.AP_Home.eth[0].duplexMode = true
+
+**.AP_1.wlan*.mgmt.ssid = "AP1"
+**.AP_1.wlan*.address = "10:AA:00:00:A1:01"
+**.AP_1.eth[0].address = "10:AE:00:00:A1:02"
+**.AP_1.eth[0].duplexMode = true
+
+# mobility
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxZ = 0m
+
+**.MN[0].mobility.typename = "RectangleMobility"
+**.MN[0].mobility.constraintAreaMinX = 180m
+**.MN[0].mobility.constraintAreaMinY = 170m
+**.MN[0].mobility.constraintAreaMaxX = 630m
+**.MN[0].mobility.constraintAreaMaxY = 180m
+**.MN[0].mobility.startPos = 0
+**.MN[0].mobility.speed = 10mps
+**.MN*.mobility.updateInterval = 0.1s
+
+# No apps needed - we just test the handover signaling
+**.MN*.numApps = 0
+**.CN*.numApps = 0
+
+# ip settings
+**.forwarding = false
+
+# Ethernet NIC configuration
+**.eth[*].queue.typename = "EthernetQosQueue"
+**.eth[*].queue.dataQueue.typename = "DropTailQueue"
+**.eth[*].queue.dataQueue.packetCapacity = 10
+**.eth*.duplexMode = true
+
+# analog model
+**.analogModel.ignorePartialInterference = true
+
+# wireless channels
+**.AP_Home.wlan*.radio.channelNumber = 1
+**.AP_1.wlan*.radio.channelNumber = 2
+**.MN*.wlan*.radio.channelNumber = 0
+
+# wireless configuration
+**.wlan*.agent.activeScan = true
+**.wlan*.agent.defaultSsid = ""
+**.wlan*.agent.channelsToScan = "1 2"
+**.wlan*.agent.probeDelay = 0.1s
+**.wlan*.agent.minChannelTime = 0.15s
+**.wlan*.agent.maxChannelTime = 0.3s
+**.wlan*.agent.authenticationTimeout = 5s
+**.wlan*.agent.associationTimeout = 5s
+
+# nic settings
+**.wlan*.bitrate = 2Mbps
+**.wlan*.mac.dcf.channelAccess.cwMin = 7
+**.radio.transmitter.power = 2.0mW
+
+**.constraintAreaMinX = 0m
+**.constraintAreaMinY = 0m
+**.constraintAreaMaxX = 850m
+**.constraintAreaMaxY = 850m
+
+%#--------------------------------------------------------------------------------------------------------------
+%subst: /omnetpp:://
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+Mipv6Network.MN[0].ipv6.neighbourDiscovery: Starting DAD for tentative global address aaaa:1:66:0:8aa:ff:fe00:8
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+Mipv6Network.MN[0].ipv6.neighbourDiscovery: DAD completed for address aaaa:1:66:0:8aa:ff:fe00:8 on wlan0, address is unique
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+Mipv6Network.MN[0].ipv6.mipv6: Initiating Mobile Ipv6 protocol...
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+Mipv6Network.Home_Agent.ipv6.mipv6: BU validation passed
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: grep "undisposed object:" test.out > test_undisposed.out || true
+%not-contains: test_undisposed.out
+undisposed object: (
+%#--------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A mobile node that hands over now verifies its new care-of address with Duplicate Address
Detection (DAD) before it registers that address with its home agent. Two things had to
change together for that to hold: the address has to undergo DAD at all, and the Binding
Update has to wait for the result. Either change alone still registers a contested address,
so they are in one commit.

Closes #1140

## The problem

`processRaPrefixInfoForAddrAutoConf()` splits on how many addresses the interface already
holds. With only a link-local address it assigns the new global address as tentative and
performs DAD -- the path added in `adfe5ba71e`. With more, which is exactly what a handover
looks like (link-local address plus the home address), it marks the existing addresses
tentative, probes the link-local address alone, and defers the new address to
`dadGlobalList`. `makeTentativeAddressPermanent()` then assigned it with `tentative = false`
and cleared the tentative flag on every address of the interface, so the "start DAD for a
tentative global address" loop at the end of that same function found nothing to do.

`examples/ipv6/mipv6roaming -c Roaming -r 0`, counting `DAD completed for address` for `MN[0]`:

| address | role | before | after |
| ------- | ---- | ------ | ----- |
| `fe80::8aa:ff:fe00:b`        | link-local   | 4 | 4 |
| `2001:db8:0:2:8aa:ff:fe00:b` | home address | 1 | 1 |
| `2001:db8:0:4:8aa:ff:fe00:b` | care-of      | **0** | 2 |
| `2001:db8:0:6:8aa:ff:fe00:b` | care-of      | **0** | 1 |

The home address is probed because at boot the interface holds only a link-local address and
takes the correct path; neither care-of address was ever probed.

RFC 4862 Section 5.4 names this exact shortcut and rules it out:

> -  Each individual unicast address SHOULD be tested for uniqueness.
>    Note that there are implementations deployed that only perform
>    Duplicate Address Detection for the link-local address and skip
>    the test for the global address that uses the same interface
>    identifier as that of the link-local address. [...] this kind of
>    "optimization" is NOT RECOMMENDED, and new implementations MUST
>    NOT do that optimization.

## The fix

**Perform the DAD.** The blanket `permanentlyAssign()` loop now runs *before* the address
formed from the new prefix is added, so it only restores the addresses that were already on
the interface; the new care-of address is then assigned as tentative and the existing loop
starts DAD for it.

**Wait for the result.** The registration used to start as soon as the *link-local* DAD
completed, so the Binding Update left 1.67 s before the care-of address was verified. MIPv6
sets the source address of that datagram explicitly, and the RFC 4862 guard in
`Ipv6::fragmentPostRouting()` only covers datagrams whose source address Ipv6 chooses itself,
so nothing held it back. The MIPv6 protocol is now started when the care-of address passes
its own DAD, the `dadGlobalList` entry being kept until then. `dadHasFailed()` already erases
that entry, so a care-of address that is already in use is never registered at all.

Each handover now reads:

```
43.224  DAD completed for address fe80::8aa:ff:fe00:b
43.224  Starting DAD for tentative global address 2001:db8:0:6:8aa:ff:fe00:b
44.670  DAD completed for address 2001:db8:0:6:8aa:ff:fe00:b
44.670  Initiating Mobile Ipv6 protocol...
44.670  controlInfo: DestAddr=2001:db8:0:2:8aa:ff:fe00:2 SrcAddr=2001:db8:0:6:8aa:ff:fe00:b
```

## Why both halves are needed

| change | care-of address probed | Binding Update waits | contested address registered? |
| ------ | ---------------------- | -------------------- | ----------------------------- |
| neither (master) | no  | no  | yes |
| DAD only         | yes | no  | yes -- the Binding Update is 1.67 s ahead of the result |
| deferral only    | no  | n/a | yes -- there is no result to wait for |
| both             | yes | yes | no |

## Verification

`tests/module/MIPv6_care_of_address_DAD.test` is added as a regression test. It fails on
unmodified master -- the run logs a DAD completion for the link-local address and for the
home address, but none for the care-of address `aaaa:1:66:0:8aa:ff:fe00:8` -- and passes here.

Both suites were baselined on unmodified `origin/master` before any change was made, and
diffed afterwards.

- **Module tests** (`-f 'IPv6|MIPv6|Ipv6'`): baseline 42 total, 40 PASS, 2 FAIL; now 43 total,
  41 PASS, 2 FAIL. The only difference is the new test. `MIPv6_tcp_handover.test` and
  `IPv6_packet_too_big.test` fail identically on unmodified master, so they are pre-existing
  and out of scope.
- **Fingerprints** (`-m ipv6 -F tyf`): 27 tests, all pass.

Fingerprints re-recorded for the three affected examples, per ingredient: `~tNl`, `~tND` and
`~tNlb` move because each handover now carries the extra DAD Neighbor Solicitations for the
care-of address; `tplx` moves because the Binding Update is delayed by one DAD interval
(+1.67 s and +1.36 s at the two handovers measured). Verified identical across two independent
runs. Graphical (`tyf`) fingerprints left as-is. `examples/ipv6/pmipv6` is unaffected.

Note that `ipv6/mipv6roaming`'s `~tNlb` in `mipv6-refactoring.csv` was **already stale on
unmodified master** (expected `c8dc-27c2`, actual `7ed8-bee3`), so this re-recording absorbs
that stale value as well as the intended change.

The extra DAD interval per handover is the cost RFC 6275 Section 11.5.3 discusses when it
says a mobile node "preferably SHOULD NOT delay DAD when configuring a new care-of address";
it is not a regression.

## Not addressed here

- The home address is marked tentative while the mobile node is **abroad**, where its
  uniqueness is irrelevant. It shares the two blanket loops touched here, but the current
  behaviour may be load-bearing by accident: while that address is tentative, packets sourced
  from it are deferred into `pendingDadQueue` rather than dropped by the topological guard in
  `Ipv6.cc`, so narrowing the loops needs measuring first.
- `Ipv6::fragmentPostRouting()` applies the RFC 4862 tentative-source check only to datagrams
  whose source address it chooses itself; any module that sets the source explicitly bypasses
  it. This pull request removes the MIPv6 trigger, but the general hole remains.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->