### PR TITLE
IEEE 802.11: add HT capability/operation signalling and harden association lifecycle

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
@@ -21,7 +21,6 @@
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mac/Rx.h"
 #include "inet/linklayer/ieee80211/mac/contract/IContention.h"
-#include "inet/linklayer/ieee80211/mac/contract/IFrameSequence.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRx.h"
 #include "inet/linklayer/ieee80211/mac/contract/ITx.h"
 #include "inet/networklayer/contract/IInterfaceTable.h"
@@ -73,6 +72,9 @@ void Ieee80211Mac::initialize(int stage)
         tx = check_and_cast<ITx *>(getSubmodule("tx"));
         dcf = check_and_cast<Dcf *>(getSubmodule("dcf"));
         hcf = check_and_cast_nullable<Hcf *>(getSubmodule("hcf"));
+        auto managementGate = gate("mgmtOut")->getNextGate();
+        if (managementGate != nullptr)
+            frameTransmissionCallback = dynamic_cast<IFrameTransmissionCallback *>(managementGate->getOwnerModule());
         if (mib->qos && !hcf)
             throw cRuntimeError("Missing hcf module, required for QoS");
     }
@@ -374,6 +376,15 @@ void Ieee80211Mac::sendDownPendingRadioConfigMsg()
     }
 }
 
+void Ieee80211Mac::notifyFrameTransmission(const Packet *frame, IFrameTransmissionCallback::Status status)
+{
+    Enter_Method("notifyFrameTransmission");
+    if (frameTransmissionCallback != nullptr) {
+        IFrameTransmissionCallback::Result result(frame, status);
+        frameTransmissionCallback->frameTransmissionFinished(result);
+    }
+}
+
 void Ieee80211Mac::processUpperFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& header)
 {
     Enter_Method("processUpperFrame(\"%s\")", packet->getName());
@@ -418,4 +429,3 @@ void Ieee80211Mac::handleCrashOperation(LifecycleOperation *operation)
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.h
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.h
@@ -11,6 +11,7 @@
 #include "inet/common/ModuleRefByPar.h"
 #include "inet/linklayer/base/MacProtocolBase.h"
 #include "inet/linklayer/ieee80211/mac/contract/IDs.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateSelection.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRx.h"
@@ -54,6 +55,7 @@ class INET_API Ieee80211Mac : public MacProtocolBase
     opp_component_ptr<Pcf> pcf;
     opp_component_ptr<Hcf> hcf;
     opp_component_ptr<Mcf> mcf;
+    IFrameTransmissionCallback *frameTransmissionCallback = nullptr;
 
     // The last change channel message received and not yet sent to the physical layer, or nullptr.
     cMessage *pendingRadioConfigMsg = nullptr;
@@ -104,6 +106,12 @@ class INET_API Ieee80211Mac : public MacProtocolBase
     virtual void sendDownFrame(Packet *frame);
     virtual void sendDownPendingRadioConfigMsg();
 
+    /**
+     * Delivers a terminal management-frame transmission outcome while the
+     * frame is still owned by the coordination function.
+     */
+    virtual void notifyFrameTransmission(const Packet *frame, IFrameTransmissionCallback::Status status);
+
     virtual void processUpperFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& header);
     virtual void processLowerFrame(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
 };
@@ -112,4 +120,3 @@ class INET_API Ieee80211Mac : public MacProtocolBase
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/contract/IFrameSequence.h
+++ b/src/inet/linklayer/ieee80211/mac/contract/IFrameSequence.h
@@ -44,6 +44,13 @@ class INET_API ITransmitStep : public IFrameSequenceStep
     virtual Type getType() override { return Type::TRANSMIT; }
 
     virtual Packet *getFrameToTransmit() = 0;
+    // Returns the frame that originated this transmit step. For an ordinary
+    // transmit this is the frame being sent; an RTS step overrides it with
+    // the frame protected by the RTS/CTS exchange.
+    virtual const Packet *getOriginatingFrame() { return getFrameToTransmit(); }
+    // Keep the protected-frame terminology available to existing callers
+    // while exposing the same read-only contract through ITransmitStep.
+    virtual const Packet *getProtectedFrame() { return getOriginatingFrame(); }
     virtual simtime_t getIfs() = 0;
 };
 
@@ -73,4 +80,3 @@ class INET_API IFrameSequence
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/contract/IFrameSequence.h
+++ b/src/inet/linklayer/ieee80211/mac/contract/IFrameSequence.h
@@ -44,13 +44,6 @@ class INET_API ITransmitStep : public IFrameSequenceStep
     virtual Type getType() override { return Type::TRANSMIT; }
 
     virtual Packet *getFrameToTransmit() = 0;
-    // Returns the frame that originated this transmit step. For an ordinary
-    // transmit this is the frame being sent; an RTS step overrides it with
-    // the frame protected by the RTS/CTS exchange.
-    virtual const Packet *getOriginatingFrame() { return getFrameToTransmit(); }
-    // Keep the protected-frame terminology available to existing callers
-    // while exposing the same read-only contract through ITransmitStep.
-    virtual const Packet *getProtectedFrame() { return getOriginatingFrame(); }
     virtual simtime_t getIfs() = 0;
 };
 

--- a/src/inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h
+++ b/src/inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h
@@ -1,0 +1,56 @@
+//
+// Copyright (C) 2026 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+#ifndef __INET_IFRAMETRANSMISSIONCALLBACK_H
+#define __INET_IFRAMETRANSMISSIONCALLBACK_H
+
+#include "inet/common/packet/Packet.h"
+
+namespace inet {
+namespace ieee80211 {
+
+/**
+ * Reports terminal outcomes for locally originated frame transmissions.
+ *
+ * The result is created synchronously by the MAC and is valid only for the
+ * duration of the callback. In particular, the frame pointer must not be
+ * retained by the receiver: the coordination function may release the frame
+ * immediately after the callback returns.
+ */
+class INET_API IFrameTransmissionCallback
+{
+  public:
+    enum class Status {
+        ACKNOWLEDGED,
+        RETRY_LIMIT_REACHED,
+    };
+
+    class INET_API Result final
+    {
+      private:
+        const Packet * const frame;
+        const Status status;
+
+      public:
+        Result(const Packet *frame, Status status) :
+            frame(frame),
+            status(status)
+        {}
+
+        const Packet *getFrame() const { return frame; }
+        Status getStatus() const { return status; }
+    };
+
+  public:
+    virtual ~IFrameTransmissionCallback() {}
+
+    virtual void frameTransmissionFinished(const Result& result) = 0;
+};
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif

--- a/src/inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h
+++ b/src/inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h
@@ -26,6 +26,7 @@ class INET_API IFrameTransmissionCallback
     enum class Status {
         ACKNOWLEDGED,
         RETRY_LIMIT_REACHED,
+        DROPPED_BEFORE_TRANSMISSION,
     };
 
     class INET_API Result final

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
@@ -12,6 +12,7 @@
 #include "inet/linklayer/ieee80211/mac/framesequence/DcfFs.h"
 #include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
 #include "inet/linklayer/ieee80211/mac/recipient/RecipientAckProcedure.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -47,6 +48,10 @@ void Dcf::initialize(int stage)
         originatorProtectionMechanism = check_and_cast<OriginatorProtectionMechanism *>(getSubmodule("originatorProtectionMechanism"));
         WATCH_EXPR("frameSequenceInfo", frameSequenceHandler->isSequenceRunning() ? "Fs: " + frameSequenceHandler->getFrameSequence()->getHistory() : "");
     }
+    else if (stage == INITSTAGE_LAST)
+        // Dcaf resolves its pending queue at the link-layer stage. Install
+        // this callback after all child initialization has completed.
+        channelAccess->getPendingQueue()->setPacketDropCallback(this);
 }
 
 void Dcf::forEachChild(cVisitor *v)
@@ -111,6 +116,13 @@ void Dcf::transmitControlResponseFrame(Packet *responsePacket, const Ptr<const I
 void Dcf::processMgmtFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& mgmtHeader)
 {
     throw cRuntimeError("Unknown management frame");
+}
+
+void Dcf::handlePacketDropped(Packet *packet)
+{
+    Enter_Method("handlePacketDropped");
+    if (packet->findTag<Ieee80211MgmtTransactionTag>() != nullptr)
+        mac->notifyFrameTransmission(packet, IFrameTransmissionCallback::Status::DROPPED_BEFORE_TRANSMISSION);
 }
 
 void Dcf::recipientProcessTransmittedControlResponseFrame(Packet *packet, const Ptr<const Ieee80211MacHeader>& header)

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
@@ -267,6 +267,8 @@ void Dcf::originatorProcessRtsProtectionFailed(Packet *packet)
         details.setLimit(recoveryProcedure->getShortRetryLimit());
         emit(packetDroppedSignal, packet, &details);
         emit(linkBrokenSignal, packet);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(protectedHeader))
+            mac->notifyFrameTransmission(packet, IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED);
     }
 }
 
@@ -311,6 +313,8 @@ void Dcf::originatorProcessReceivedFrame(Packet *receivedPacket, Packet *lastTra
         ackHandler->processReceivedAck(dynamicPtrCast<const Ieee80211AckFrame>(receivedHeader), lastTransmittedDataOrMgmtHeader);
         channelAccess->getInProgressFrames()->dropFrame(lastTransmittedPacket);
         ackHandler->dropFrame(lastTransmittedDataOrMgmtHeader);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(lastTransmittedDataOrMgmtHeader))
+            mac->notifyFrameTransmission(lastTransmittedPacket, IFrameTransmissionCallback::Status::ACKNOWLEDGED);
     }
     else if (receivedHeader->getType() == ST_RTS)
         ; // void
@@ -344,6 +348,8 @@ void Dcf::originatorProcessFailedFrame(Packet *failedPacket)
         details.setLimit(-1); // TODO
         emit(packetDroppedSignal, failedPacket, &details);
         emit(linkBrokenSignal, failedPacket);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(failedHeader))
+            mac->notifyFrameTransmission(failedPacket, IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED);
     }
     else {
         EV_INFO << "Retrying frame " << failedPacket->getName() << ".\n";
@@ -391,4 +397,3 @@ Dcf::~Dcf()
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h
@@ -28,6 +28,7 @@
 #include "inet/linklayer/ieee80211/mac/originator/AckHandler.h"
 #include "inet/linklayer/ieee80211/mac/originator/NonQosRecoveryProcedure.h"
 #include "inet/linklayer/ieee80211/mac/protectionmechanism/OriginatorProtectionMechanism.h"
+#include "inet/queueing/contract/IPacketQueue.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -37,7 +38,7 @@ class Ieee80211Mac;
 /**
  * Implements IEEE 802.11 Distributed Coordination Function.
  */
-class INET_API Dcf : public ICoordinationFunction, public IFrameSequenceHandler::ICallback, public IChannelAccess::ICallback, public ITx::ICallback, public IProcedureCallback, public ModeSetListener
+class INET_API Dcf : public ICoordinationFunction, public IFrameSequenceHandler::ICallback, public IChannelAccess::ICallback, public ITx::ICallback, public IProcedureCallback, public ModeSetListener, public queueing::IPacketQueue::ICallback
 {
   protected:
     Ieee80211Mac *mac = nullptr;
@@ -117,6 +118,9 @@ class INET_API Dcf : public ICoordinationFunction, public IFrameSequenceHandler:
     virtual void transmitControlResponseFrame(Packet *responsePacket, const Ptr<const Ieee80211MacHeader>& responseHeader, Packet *receivedPacket, const Ptr<const Ieee80211MacHeader>& receivedHeader) override;
     virtual void processMgmtFrame(Packet *mgmtPacket, const Ptr<const Ieee80211MgmtHeader>& mgmtHeader) override;
 
+    // queueing::IPacketQueue::ICallback
+    virtual void handlePacketDropped(Packet *packet) override;
+
     virtual bool isSentByUs(const Ptr<const Ieee80211MacHeader>& header) const;
     virtual bool isForUs(const Ptr<const Ieee80211MacHeader>& header) const;
 
@@ -133,4 +137,3 @@ class INET_API Dcf : public ICoordinationFunction, public IFrameSequenceHandler:
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
@@ -30,9 +30,11 @@ module Dcf extends Module like IDcf
     parameters:
         string rxModule;
         string txModule;
+        string mibModule;
 
         *.rateSelectionModule = "^.rateSelection";
         *.rxModule = "^." + this.rxModule;
+        *.mibModule = default(absPath(this.mibModule));
 
         @class(Dcf);
         displayStringTextFormat = default("{frameSequenceInfo}");
@@ -122,4 +124,3 @@ module Dcf extends Module like IDcf
                 @display("p=550,400");
         }
 }
-

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -260,6 +260,8 @@ void Hcf::handleInternalCollision(std::vector<Edcaf *> internallyCollidedEdcafs)
             details.setLimit(-1); // TODO
             emit(packetDroppedSignal, internallyCollidedFrame, &details);
             emit(linkBrokenSignal, internallyCollidedFrame);
+            if (dynamicPtrCast<const Ieee80211MgmtHeader>(internallyCollidedHeader))
+                mac->notifyFrameTransmission(internallyCollidedFrame, IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED);
             if (hasFrameToTransmit(ac))
                 edcaf->requestChannel(this);
         }
@@ -391,7 +393,7 @@ void Hcf::originatorProcessRtsProtectionFailed(Packet *packet)
         }
         else if (auto mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(protectedHeader)) {
             edca->getMgmtAndNonQoSRecoveryProcedure()->rtsFrameTransmissionFailed(mgmtHeader, edcaf->getStationRetryCounters());
-            retryLimitReached = edca->getMgmtAndNonQoSRecoveryProcedure()->isRtsFrameRetryLimitReached(packet, dataHeader);
+            retryLimitReached = edca->getMgmtAndNonQoSRecoveryProcedure()->isRtsFrameRetryLimitReached(packet, mgmtHeader);
         }
         else
             throw cRuntimeError("Unknown frame"); // TODO QoSDataFrame, NonQoSDataFrame
@@ -409,6 +411,8 @@ void Hcf::originatorProcessRtsProtectionFailed(Packet *packet)
             details.setLimit(-1); // TODO
             emit(packetDroppedSignal, packet, &details);
             emit(linkBrokenSignal, packet);
+            if (dynamicPtrCast<const Ieee80211MgmtHeader>(protectedHeader))
+                mac->notifyFrameTransmission(packet, IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED);
         }
     }
     else
@@ -530,6 +534,8 @@ void Hcf::originatorProcessFailedFrame(Packet *failedPacket)
             details.setLimit(-1); // TODO
             emit(packetDroppedSignal, failedPacket, &details);
             emit(linkBrokenSignal, failedPacket);
+            if (dynamicPtrCast<const Ieee80211MgmtHeader>(failedHeader))
+                mac->notifyFrameTransmission(failedPacket, IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED);
         }
         else {
             EV_INFO << "Retrying frame " << failedPacket->getName() << ".\n";
@@ -585,7 +591,7 @@ void Hcf::originatorProcessReceivedControlFrame(Packet *packet, const Ptr<const 
         }
         else if (auto mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(lastTransmittedHeader)) {
             if (dataAndMgmtRateControl) {
-                int retryCount = edca->getMgmtAndNonQoSRecoveryProcedure()->getRetryCount(lastTransmittedPacket, dataHeader);
+                int retryCount = edca->getMgmtAndNonQoSRecoveryProcedure()->getRetryCount(lastTransmittedPacket, mgmtHeader);
                 dataAndMgmtRateControl->frameTransmitted(lastTransmittedPacket, retryCount, true, false);
             }
             edca->getMgmtAndNonQoSRecoveryProcedure()->ackFrameReceived(lastTransmittedPacket, mgmtHeader, edcaf->getStationRetryCounters());
@@ -596,6 +602,8 @@ void Hcf::originatorProcessReceivedControlFrame(Packet *packet, const Ptr<const 
         edcaf->getAckHandler()->processReceivedAck(ackFrame, lastTransmittedDataOrMgmtHeader);
         edcaf->getInProgressFrames()->dropFrame(lastTransmittedPacket);
         edcaf->getAckHandler()->dropFrame(lastTransmittedDataOrMgmtHeader);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(lastTransmittedHeader))
+            mac->notifyFrameTransmission(lastTransmittedPacket, IFrameTransmissionCallback::Status::ACKNOWLEDGED);
     }
     else if (auto blockAck = dynamicPtrCast<const Ieee80211BasicBlockAck>(header)) {
         EV_INFO << "BasicBlockAck has arrived" << std::endl;
@@ -784,4 +792,3 @@ Hcf::~Hcf()
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -14,6 +14,7 @@
 #include "inet/linklayer/ieee80211/mac/blockack/RecipientBlockAckAgreementHandler.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/HcfFs.h"
 #include "inet/linklayer/ieee80211/mac/recipient/RecipientAckProcedure.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
 namespace inet {
@@ -61,6 +62,11 @@ void Hcf::initialize(int stage)
             recipientBlockAckProcedure = new RecipientBlockAckProcedure();
         }
     }
+    else if (stage == INITSTAGE_LAST)
+        // Edca resolves its Edcaf array at the link-layer stage. Install the
+        // queue callbacks after all child initialization has completed.
+        for (int ac = 0; ac < AC_NUMCATEGORIES; ac++)
+            edca->getEdcaf(static_cast<AccessCategory>(ac))->getPendingQueue()->setPacketDropCallback(this);
 }
 
 std::string Hcf::getFrameSequenceInfo() const
@@ -142,6 +148,13 @@ void Hcf::processUpperFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtH
             edca->requestChannelAccess(ac, this);
         }
     }
+}
+
+void Hcf::handlePacketDropped(Packet *packet)
+{
+    Enter_Method("handlePacketDropped");
+    if (packet->findTag<Ieee80211MgmtTransactionTag>() != nullptr)
+        mac->notifyFrameTransmission(packet, IFrameTransmissionCallback::Status::DROPPED_BEFORE_TRANSMISSION);
 }
 
 void Hcf::scheduleStartRxTimer(simtime_t timeout)

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.h
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.h
@@ -35,6 +35,7 @@
 #include "inet/linklayer/ieee80211/mac/originator/TxopProcedure.h"
 #include "inet/linklayer/ieee80211/mac/protectionmechanism/SingleProtectionMechanism.h"
 #include "inet/linklayer/ieee80211/mac/queue/InProgressFrames.h"
+#include "inet/queueing/contract/IPacketQueue.h"
 #include "inet/linklayer/ieee80211/mac/recipient/CtsProcedure.h"
 
 namespace inet {
@@ -45,7 +46,7 @@ class Ieee80211Mac;
 /**
  * Implements IEEE 802.11 Hybrid Coordination Function.
  */
-class INET_API Hcf : public ICoordinationFunction, public IFrameSequenceHandler::ICallback, public IChannelAccess::ICallback, public ITx::ICallback, public IProcedureCallback, public IBlockAckAgreementHandlerCallback, public ModeSetListener
+class INET_API Hcf : public ICoordinationFunction, public IFrameSequenceHandler::ICallback, public IChannelAccess::ICallback, public ITx::ICallback, public IProcedureCallback, public IBlockAckAgreementHandlerCallback, public ModeSetListener, public queueing::IPacketQueue::ICallback
 {
   public:
     static simsignal_t edcaCollisionDetectedSignal;
@@ -156,6 +157,9 @@ class INET_API Hcf : public ICoordinationFunction, public IFrameSequenceHandler:
     virtual void transmitControlResponseFrame(Packet *responsePacket, const Ptr<const Ieee80211MacHeader>& responseHeader, Packet *receivedPacket, const Ptr<const Ieee80211MacHeader>& receivedHeader) override;
     virtual void processMgmtFrame(Packet *mgmtPacket, const Ptr<const Ieee80211MgmtHeader>& mgmtHeader) override;
 
+    // queueing::IPacketQueue::ICallback
+    virtual void handlePacketDropped(Packet *packet) override;
+
     // IProcedureCallback
     virtual void scheduleInactivityTimer(simtime_t timeout) override;
 
@@ -174,4 +178,3 @@ class INET_API Hcf : public ICoordinationFunction, public IFrameSequenceHandler:
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.ned
@@ -32,9 +32,11 @@ module Hcf extends Module like IHcf
 
         string rxModule;
         string txModule;
+        string mibModule;
 
         *.rateSelectionModule = "^.rateSelection";
         *.rxModule = "^." + this.rxModule;
+        *.mibModule = default(absPath(this.mibModule));
         *.*.originatorMacDataServiceModule = "^.^.originatorMacDataService";
 
         @class(Hcf);
@@ -134,4 +136,3 @@ module Hcf extends Module like IHcf
                 @display("p=550,600");
         }
 }
-

--- a/src/inet/linklayer/ieee80211/mac/fragmentation/Fragmentation.cc
+++ b/src/inet/linklayer/ieee80211/mac/fragmentation/Fragmentation.cc
@@ -27,7 +27,8 @@ std::vector<Packet *> *Fragmentation::fragmentFrame(Packet *frame, const std::ve
         auto fragment = new Packet(name.c_str());
         B length = B(fragmentSizes.at(i));
         fragment->insertAtBack(frame->peekDataAt(offset, length));
-        fragment->getRegionTags().copyTags(frame->getRegionTags(), offset, frame->getFrontOffset(), frame->getDataLength());
+        fragment->copyTags(*frame);
+        fragment->getRegionTags().copyTags(frame->getRegionTags(), frame->getFrontOffset() + offset, fragment->getFrontOffset(), length);
         offset += length;
         const auto& fragmentHeader = staticPtrCast<Ieee80211DataOrMgmtHeader>(frameHeader->dupShared());
         fragmentHeader->setSequenceNumber(frameHeader->getSequenceNumber());
@@ -45,4 +46,3 @@ std::vector<Packet *> *Fragmentation::fragmentFrame(Packet *frame, const std::ve
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.cc
+++ b/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.cc
@@ -28,6 +28,17 @@ simtime_t FrameSequenceContext::getIfs() const
     return getNumSteps() == 0 ? 0 : modeSet->getSifsTime(); // TODO pifs
 }
 
+bool FrameSequenceContext::isFramePending(const Packet *frame) const
+{
+    if (frame == nullptr || inProgressFrames == nullptr)
+        return false;
+    for (int i = 0; i < inProgressFrames->getLength(); i++) {
+        if (inProgressFrames->getFrames(i) == frame)
+            return true;
+    }
+    return false;
+}
+
 simtime_t FrameSequenceContext::getAckTimeout(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtframe) const
 {
     return qosContext ? qosContext->ackPolicy->getAckTimeout(packet, dataOrMgmtframe) : nonQoSContext->ackPolicy->getAckTimeout(packet, dataOrMgmtframe);
@@ -78,4 +89,3 @@ void FrameSequenceNumPacketsFilter::receiveSignal(cResultFilter *prev, simtime_t
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.cc
+++ b/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.cc
@@ -28,17 +28,6 @@ simtime_t FrameSequenceContext::getIfs() const
     return getNumSteps() == 0 ? 0 : modeSet->getSifsTime(); // TODO pifs
 }
 
-bool FrameSequenceContext::isFramePending(const Packet *frame) const
-{
-    if (frame == nullptr || inProgressFrames == nullptr)
-        return false;
-    for (int i = 0; i < inProgressFrames->getLength(); i++) {
-        if (inProgressFrames->getFrames(i) == frame)
-            return true;
-    }
-    return false;
-}
-
 simtime_t FrameSequenceContext::getAckTimeout(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtframe) const
 {
     return qosContext ? qosContext->ackPolicy->getAckTimeout(packet, dataOrMgmtframe) : nonQoSContext->ackPolicy->getAckTimeout(packet, dataOrMgmtframe);

--- a/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h
+++ b/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h
@@ -88,6 +88,7 @@ class INET_API FrameSequenceContext : public cObject
     virtual simtime_t getCtsTimeout(Packet *packet, const Ptr<const Ieee80211RtsFrame>& rtsFrame) const;
     virtual simtime_t getIfs() const;
 
+    virtual bool isFramePending(const Packet *frame) const;
     virtual bool isForUs(const Ptr<const Ieee80211MacHeader>& header) const;
     virtual bool isSentByUs(const Ptr<const Ieee80211MacHeader>& header) const;
 };
@@ -110,4 +111,3 @@ class INET_API FrameSequenceNumPacketsFilter : public cObjectResultFilter
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h
+++ b/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h
@@ -88,7 +88,6 @@ class INET_API FrameSequenceContext : public cObject
     virtual simtime_t getCtsTimeout(Packet *packet, const Ptr<const Ieee80211RtsFrame>& rtsFrame) const;
     virtual simtime_t getIfs() const;
 
-    virtual bool isFramePending(const Packet *frame) const;
     virtual bool isForUs(const Ptr<const Ieee80211MacHeader>& header) const;
     virtual bool isSentByUs(const Ptr<const Ieee80211MacHeader>& header) const;
 };

--- a/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h
+++ b/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h
@@ -47,7 +47,8 @@ class INET_API RtsTransmitStep : public TransmitStep
         protectedFrame(protectedFrame)
     {}
 
-    virtual const Packet *getProtectedFrame() { return protectedFrame; }
+    virtual const Packet *getOriginatingFrame() override { return protectedFrame; }
+    virtual const Packet *getProtectedFrame() override { return protectedFrame; }
 };
 
 class INET_API ReceiveStep : public IReceiveStep
@@ -74,4 +75,3 @@ class INET_API ReceiveStep : public IReceiveStep
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h
+++ b/src/inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h
@@ -47,8 +47,7 @@ class INET_API RtsTransmitStep : public TransmitStep
         protectedFrame(protectedFrame)
     {}
 
-    virtual const Packet *getOriginatingFrame() override { return protectedFrame; }
-    virtual const Packet *getProtectedFrame() override { return protectedFrame; }
+    virtual const Packet *getProtectedFrame() { return protectedFrame; }
 };
 
 class INET_API ReceiveStep : public IReceiveStep

--- a/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.cc
+++ b/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.cc
@@ -71,7 +71,7 @@ void TxopProcedure::startTxop(AccessCategory ac)
     if (start != -1)
         throw cRuntimeError("Txop is already running");
     if (limit == -1) {
-        auto referenceMode = modeSet->getSlowestMandatoryMode();
+        auto referenceMode = modeSet->getReferenceMode();
         limit = getTxopLimit(referenceMode, ac).get<s>();
     }
     // The STA selects between single and multiple protection when it transmits the first frame of a TXOP.

--- a/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.cc
+++ b/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.cc
@@ -7,16 +7,11 @@
 
 #include "inet/linklayer/ieee80211/mac/originator/TxopProcedure.h"
 
-#include "inet/linklayer/ieee80211/mac/contract/IRateSelection.h"
-#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211DsssMode.h"
-#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HrDsssMode.h"
-#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
-#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211OfdmMode.h"
-
 namespace inet {
 namespace ieee80211 {
 
 using namespace inet::physicallayer;
+using OperatingPhy = Ieee80211ModeSet::OperatingPhy;
 
 simsignal_t TxopProcedure::txopStartedSignal = cComponent::registerSignal("txopStarted");
 simsignal_t TxopProcedure::txopEndedSignal = cComponent::registerSignal("txopEnded");
@@ -33,19 +28,32 @@ void TxopProcedure::initialize(int stage)
     }
 }
 
-s TxopProcedure::getTxopLimit(const IIeee80211Mode *mode, AccessCategory ac)
+// IEEE Std 802.11-2024, Table 9-194 selects the default TXOP limit by the
+// operating PHY clause. The existing INET values are retained for compatibility;
+// full Table 9-194/9-195 modernization is a separate change.
+s TxopProcedure::getTxopLimit(OperatingPhy operatingPhy, AccessCategory ac)
 {
     switch (ac) {
         case AC_BK: return s(0);
         case AC_BE: return s(0);
         case AC_VI:
-            if (dynamic_cast<const Ieee80211DsssMode *>(mode) || dynamic_cast<const Ieee80211HrDsssMode *>(mode)) return ms(6.016);
-            else if (dynamic_cast<const Ieee80211HtMode *>(mode) || dynamic_cast<const Ieee80211OfdmMode *>(mode)) return ms(3.008);
-            else return s(0);
+            switch (operatingPhy) {
+                case OperatingPhy::HR_DSSS: return ms(6.016);
+                case OperatingPhy::OFDM:
+                case OperatingPhy::ERP:
+                case OperatingPhy::HT:
+                case OperatingPhy::VHT: return ms(3.008);
+                default: throw cRuntimeError("Unknown operating PHY = %d", static_cast<int>(operatingPhy));
+            }
         case AC_VO:
-            if (dynamic_cast<const Ieee80211DsssMode *>(mode) || dynamic_cast<const Ieee80211HrDsssMode *>(mode)) return ms(3.264);
-            else if (dynamic_cast<const Ieee80211HtMode *>(mode) || dynamic_cast<const Ieee80211OfdmMode *>(mode)) return ms(1.504);
-            else return s(0);
+            switch (operatingPhy) {
+                case OperatingPhy::HR_DSSS: return ms(3.264);
+                case OperatingPhy::OFDM:
+                case OperatingPhy::ERP:
+                case OperatingPhy::HT:
+                case OperatingPhy::VHT: return ms(1.504);
+                default: throw cRuntimeError("Unknown operating PHY = %d", static_cast<int>(operatingPhy));
+            }
         default: throw cRuntimeError("Unknown access category = %d", ac);
     }
 }
@@ -71,8 +79,7 @@ void TxopProcedure::startTxop(AccessCategory ac)
     if (start != -1)
         throw cRuntimeError("Txop is already running");
     if (limit == -1) {
-        auto referenceMode = modeSet->getReferenceMode();
-        limit = getTxopLimit(referenceMode, ac).get<s>();
+        limit = getTxopLimit(modeSet->getOperatingPhy(), ac).get<s>();
     }
     // The STA selects between single and multiple protection when it transmits the first frame of a TXOP.
     // All subsequent frames transmitted by the STA in the same TXOP use the same class of duration settings.
@@ -133,4 +140,3 @@ void TxopDurationFilter::receiveSignal(cResultFilter *prev, simtime_t_cref t, cO
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.h
+++ b/src/inet/linklayer/ieee80211/mac/originator/TxopProcedure.h
@@ -11,6 +11,7 @@
 #include "inet/linklayer/ieee80211/mac/common/AccessCategory.h"
 #include "inet/linklayer/ieee80211/mac/common/ModeSetListener.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateSelection.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -39,7 +40,7 @@ class INET_API TxopProcedure : public ModeSetListener
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int stage) override;
 
-    virtual s getTxopLimit(const physicallayer::IIeee80211Mode *mode, AccessCategory ac);
+    virtual s getTxopLimit(physicallayer::Ieee80211ModeSet::OperatingPhy operatingPhy, AccessCategory ac);
     virtual ProtectionMechanism selectProtectionMechanism(AccessCategory ac) const;
 
   public:
@@ -69,4 +70,3 @@ class INET_API TxopDurationFilter : public cObjectResultFilter
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.cc
@@ -1,0 +1,117 @@
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+
+#include <cstring>
+
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
+
+namespace inet {
+namespace ieee80211 {
+
+using namespace inet::physicallayer;
+
+namespace {
+
+static const IIeee80211Mode *getLegacyFallback(const Ieee80211ModeSet *modeSet, const MacAddress& peerAddress)
+{
+    const auto *legacyMode = modeSet->getFastestLegacyOperationalMode();
+    if (legacyMode == nullptr)
+        throw cRuntimeError("No legacy operational mode is available for peer %s", peerAddress.str().c_str());
+    return legacyMode;
+}
+
+// IEEE Std 802.11-2024, 10.6.5.8: an individually addressed frame shall use
+// a receiver-supported MCS/rate and CH_BANDWIDTH permitted by the BSS HT
+// Operation. The directional negotiated state is the model's source of the
+// receiver's capability advertisement.
+static bool isCompatibleHtMode(const IIeee80211Mode *mode, const Ieee80211Mib::PeerHtState *peerHtState)
+{
+    if (mode == nullptr || peerHtState == nullptr || !peerHtState->valid)
+        return false;
+
+    const auto& negotiated = peerHtState->negotiatedCapabilities;
+    const auto& receiverCapabilities = negotiated.localTxPeerRx;
+    if (!receiverCapabilities.valid)
+        return false;
+
+    int mcsIndex = mode->getHtMcsIndex();
+    if (mcsIndex < 0 || mcsIndex >= 77 || !receiverCapabilities.supportedMcs[mcsIndex])
+        return false;
+
+    auto bandwidth = mode->getDataMode()->getBandwidth();
+    if (receiverCapabilities.supportedChannelWidths.count(bandwidth) == 0 ||
+            bandwidth > negotiated.operation.operatingChannelWidth)
+        return false;
+
+    // IEEE Std 802.11-2024, 10.17 and Table 9-224: a short guard interval
+    // is usable only when the receiver advertised it for this channel width.
+    if (mode->isHtShortGuardInterval()) {
+        if (bandwidth == MHz(20))
+            return receiverCapabilities.receiverShortGi20;
+        if (bandwidth == MHz(40))
+            return receiverCapabilities.receiverShortGi40;
+        return false;
+    }
+    return true;
+}
+
+static bool isBetterHtMode(const IIeee80211Mode *candidate, const IIeee80211Mode *current)
+{
+    auto candidateBitrate = candidate->getDataMode()->getNetBitrate();
+    auto currentBitrate = current->getDataMode()->getNetBitrate();
+    if (candidateBitrate != currentBitrate)
+        return candidateBitrate > currentBitrate;
+
+    // The remaining tie-breaks are deliberately based only on the mode
+    // contract, never on pointer identity or allocation order.
+    if (candidate->isHtShortGuardInterval() != current->isHtShortGuardInterval())
+        return !candidate->isHtShortGuardInterval();
+    auto candidateBandwidth = candidate->getDataMode()->getBandwidth();
+    auto currentBandwidth = current->getDataMode()->getBandwidth();
+    if (candidateBandwidth != currentBandwidth)
+        return candidateBandwidth < currentBandwidth;
+    if (candidate->getHtMcsIndex() != current->getHtMcsIndex())
+        return candidate->getHtMcsIndex() < current->getHtMcsIndex();
+    // A mode set normally contains unique MCS/width/GI entries, but keeping a
+    // final value-based key makes the choice total even for custom mode sets.
+    return std::strcmp(candidate->getName(), current->getName()) < 0;
+}
+
+} // namespace
+
+const IIeee80211Mode *selectPeerCompatibleMode(const Ieee80211ModeSet *modeSet,
+        const Ieee80211Mib::PeerHtState *peerHtState, const IIeee80211Mode *mode, const MacAddress& peerAddress)
+{
+    if (mode == nullptr || mode->getHtMcsIndex() < 0)
+        return mode;
+    if (modeSet == nullptr)
+        throw cRuntimeError("Cannot select a peer-compatible HT mode without an IEEE 802.11 mode set");
+    if (!modeSet->containsMode(mode))
+        throw cRuntimeError("HT mode '%s' is not contained in IEEE 802.11 mode set '%s'",
+                mode->getName(), modeSet->getName());
+
+    if (peerHtState == nullptr || !peerHtState->valid || !peerHtState->negotiatedCapabilities.localTxPeerRx.valid)
+        return getLegacyFallback(modeSet, peerAddress);
+    if (isCompatibleHtMode(mode, peerHtState))
+        return mode;
+
+    auto candidateBitrate = mode->getDataMode()->getNetBitrate();
+    const IIeee80211Mode *bestMode = nullptr;
+    for (int i = 0; i < modeSet->getNumModes(); i++) {
+        const auto *candidate = modeSet->getMode(i);
+        if (candidate->getHtMcsIndex() < 0 ||
+                candidate->getDataMode()->getNetBitrate() > candidateBitrate ||
+                !isCompatibleHtMode(candidate, peerHtState))
+            continue;
+        if (bestMode == nullptr || isBetterHtMode(candidate, bestMode))
+            bestMode = candidate;
+    }
+    return bestMode != nullptr ? bestMode : getLegacyFallback(modeSet, peerAddress);
+}
+
+} // namespace ieee80211
+} // namespace inet

--- a/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+
+#ifndef __INET_IEEE80211PEERMODESELECTION_H
+#define __INET_IEEE80211PEERMODESELECTION_H
+
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+
+namespace inet {
+namespace ieee80211 {
+
+/**
+ * Selects a mode that is compatible with the negotiated receive capabilities
+ * of a peer. Non-HT modes are returned unchanged. A null peer state denotes
+ * that HT negotiation is unavailable and selects the mode-set's legacy
+ * operational fallback.
+ */
+INET_API const physicallayer::IIeee80211Mode *selectPeerCompatibleMode(
+        const physicallayer::Ieee80211ModeSet *modeSet,
+        const Ieee80211Mib::PeerHtState *peerHtState,
+        const physicallayer::IIeee80211Mode *mode,
+        const MacAddress& peerAddress);
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -21,6 +21,8 @@ Define_Module(QosRateSelection);
 void QosRateSelection::initialize(int stage)
 {
     ModeSetListener::initialize(stage);
+    if (stage == INITSTAGE_LOCAL)
+        mib.reference(this, "mibModule", true);
     if (stage == INITSTAGE_LINK_LAYER) {
         dataOrMgmtRateControl = dynamic_cast<IRateControl *>(findModuleByPath(par("rateControlModule")));
         double multicastFrameBitrate = par("multicastFrameBitrate");
@@ -74,16 +76,18 @@ const IIeee80211Mode *QosRateSelection::computeResponseAckFrameMode(Packet *pack
     // TODO BSSBasicRateSet, alternate rate
     auto mode = getMode(packet, dataOrMgmtHeader);
     ASSERT(modeSet->containsMode(mode));
+    const IIeee80211Mode *responseMode;
     if (!responseAckFrameMode) {
         if (modeSet->getIsMandatory(mode))
-            return mode;
+            responseMode = mode;
         else if (auto slowerMode = modeSet->getSlowerMandatoryMode(mode))
-            return slowerMode;
+            responseMode = slowerMode;
         else
             throw cRuntimeError("Mandatory mode not found");
     }
     else
-        return responseAckFrameMode;
+        responseMode = responseAckFrameMode;
+    return getPeerCompatibleMode(dataOrMgmtHeader->getTransmitterAddress(), responseMode);
 }
 
 const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *packet, const Ptr<const Ieee80211RtsFrame>& rtsFrame)
@@ -91,16 +95,18 @@ const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *pack
     // TODO BSSBasicRateSet, alternate rate
     auto mode = getMode(packet, rtsFrame);
     ASSERT(modeSet->containsMode(mode));
+    const IIeee80211Mode *responseMode;
     if (!responseCtsFrameMode) {
         if (modeSet->getIsMandatory(mode))
-            return mode;
+            responseMode = mode;
         else if (auto slowerMode = modeSet->getSlowerMandatoryMode(mode))
-            return slowerMode;
+            responseMode = slowerMode;
         else
             throw cRuntimeError("Mandatory mode not found");
     }
     else
-        return responseCtsFrameMode;
+        responseMode = responseCtsFrameMode;
+    return getPeerCompatibleMode(rtsFrame->getTransmitterAddress(), responseMode);
 }
 
 //
@@ -111,8 +117,10 @@ const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *pack
 //
 const IIeee80211Mode *QosRateSelection::computeResponseBlockAckFrameMode(Packet *packet, const Ptr<const Ieee80211BlockAckReq>& blockAckReq)
 {
-    if (dynamicPtrCast<const Ieee80211BasicBlockAckReq>(blockAckReq))
-        return responseBlockAckFrameMode ? responseBlockAckFrameMode : getMode(packet, blockAckReq);
+    if (dynamicPtrCast<const Ieee80211BasicBlockAckReq>(blockAckReq)) {
+        auto mode = responseBlockAckFrameMode ? responseBlockAckFrameMode : getMode(packet, blockAckReq);
+        return getPeerCompatibleMode(blockAckReq->getTransmitterAddress(), mode);
+    }
     else
         throw cRuntimeError("Unknown BlockAckReq frame type");
 }
@@ -120,9 +128,9 @@ const IIeee80211Mode *QosRateSelection::computeResponseBlockAckFrameMode(Packet 
 const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader)
 {
     if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && dataFrameMode)
-        return dataFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataFrameMode);
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)
-        return mgmtFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), mgmtFrameMode);
     // This subclause describes the rate selection rules for group addressed data and management frames, excluding
     // the following:
     //   — Non-STBC Beacon and non-STBC PSMP frames
@@ -141,9 +149,9 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         // that is not yet associated with a BSS), the frame shall be transmitted in a non-HT PPDU using one of the
         // mandatory PHY rates.
         if (dataOrMgmtRateControl)
-            return dataOrMgmtRateControl->getRate();
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataOrMgmtRateControl->getRate());
         else
-            return fastestMandatoryMode;
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), fastestMandatoryMode);
     }
     // A data or management frame not identified in 9.7.5.1 through 9.7.5.5 shall be sent using any data rate or MCS
     // subject to the following constraints:
@@ -159,9 +167,9 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         // TODO Supported Rates element, Extended Supported Rates element
         // TODO OperationalRateSet or the HTOperationalMCSset
         if (dataOrMgmtRateControl)
-            return dataOrMgmtRateControl->getRate();
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataOrMgmtRateControl->getRate());
         else
-            return fastestMandatoryMode;
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), fastestMandatoryMode);
     }
 }
 
@@ -227,7 +235,7 @@ const IIeee80211Mode *QosRateSelection::computeMode(Packet *packet, const Ptr<co
     if (auto dataOrMgmtHeader = dynamicPtrCast<const Ieee80211DataOrMgmtHeader>(header))
         return computeDataOrMgmtFrameMode(dataOrMgmtHeader);
     else
-        return computeControlFrameMode(header, txopProcedure);
+        return getPeerCompatibleMode(header->getReceiverAddress(), computeControlFrameMode(header, txopProcedure));
 }
 
 void QosRateSelection::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
@@ -246,6 +254,17 @@ void QosRateSelection::frameTransmitted(Packet *packet, const Ptr<const Ieee8021
     lastTransmittedFrameMode[receiverAddr] = getMode(packet, header);
 }
 
+const IIeee80211Mode *QosRateSelection::getPeerCompatibleMode(const MacAddress& peerAddress, const IIeee80211Mode *mode) const
+{
+    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0 || mib->findPeerHtState(peerAddress) != nullptr)
+        return mode;
+    const auto *legacyMode = modeSet->getFastestLegacyOperationalMode();
+    if (legacyMode == nullptr)
+        throw cRuntimeError("No legacy operational mode is available for peer %s", peerAddress.str().c_str());
+    // The mode set owns the legal operational legacy fallback. This keeps
+    // unicast control/data traffic legacy until the MIB has a valid HT state.
+    return legacyMode;
+}
+
 } /* namespace ieee80211 */
 } /* namespace inet */
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -9,6 +9,7 @@
 
 #include "inet/common/ModuleAccess.h"
 #include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
 namespace inet {
@@ -256,14 +257,9 @@ void QosRateSelection::frameTransmitted(Packet *packet, const Ptr<const Ieee8021
 
 const IIeee80211Mode *QosRateSelection::getPeerCompatibleMode(const MacAddress& peerAddress, const IIeee80211Mode *mode) const
 {
-    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0 || mib->findPeerHtState(peerAddress) != nullptr)
+    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0)
         return mode;
-    const auto *legacyMode = modeSet->getFastestLegacyOperationalMode();
-    if (legacyMode == nullptr)
-        throw cRuntimeError("No legacy operational mode is available for peer %s", peerAddress.str().c_str());
-    // The mode set owns the legal operational legacy fallback. This keeps
-    // unicast control/data traffic legacy until the MIB has a valid HT state.
-    return legacyMode;
+    return selectPeerCompatibleMode(modeSet, mib->findPeerHtState(peerAddress), mode, peerAddress);
 }
 
 } /* namespace ieee80211 */

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h
@@ -8,9 +8,11 @@
 #ifndef __INET_QOSRATESELECTION_H
 #define __INET_QOSRATESELECTION_H
 
+#include "inet/common/ModuleRefByPar.h"
 #include "inet/linklayer/ieee80211/mac/common/ModeSetListener.h"
 #include "inet/linklayer/ieee80211/mac/contract/IQosRateSelection.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -32,6 +34,7 @@ class INET_API QosRateSelection : public IQosRateSelection, public ModeSetListen
 {
   protected:
     IRateControl *dataOrMgmtRateControl = nullptr;
+    ModuleRefByPar<Ieee80211Mib> mib;
 
     const physicallayer::Ieee80211ModeSet *modeSet = nullptr;
     std::map<MacAddress, const physicallayer::IIeee80211Mode *> lastTransmittedFrameMode;
@@ -56,6 +59,8 @@ class INET_API QosRateSelection : public IQosRateSelection, public ModeSetListen
     virtual const physicallayer::IIeee80211Mode *getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header, TxopProcedure *txopProcedure);
     virtual const physicallayer::IIeee80211Mode *computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader);
+    virtual const physicallayer::IIeee80211Mode *getPeerCompatibleMode(const MacAddress& peerAddress,
+            const physicallayer::IIeee80211Mode *mode) const;
 
     virtual bool isControlResponseFrame(const Ptr<const Ieee80211MacHeader>& header, TxopProcedure *txopProcedure);
 
@@ -78,4 +83,3 @@ class INET_API QosRateSelection : public IQosRateSelection, public ModeSetListen
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -23,6 +23,7 @@ simple QosRateSelection extends SimpleModule
     parameters:
         @class(QosRateSelection);
         string rateControlModule;
+        string mibModule;
 
         double multicastFrameBitrate @unit(bps) = default(-1bps);
 
@@ -38,4 +39,3 @@ simple QosRateSelection extends SimpleModule
         double controlFrameBitrate @unit(bps) = default(-1bps);
         @display("i=block/cogwheel");
 }
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -25,6 +25,7 @@ Define_Module(RateSelection);
 void RateSelection::initialize(int stage)
 {
     if (stage == INITSTAGE_LOCAL) {
+        mib.reference(this, "mibModule", true);
         getContainingNicModule(this)->subscribe(modesetChangedSignal, this);
     }
     else if (stage == INITSTAGE_LINK_LAYER) {
@@ -80,22 +81,24 @@ const IIeee80211Mode *RateSelection::getMode(Packet *packet, const Ptr<const Iee
 const IIeee80211Mode *RateSelection::computeResponseAckFrameMode(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader)
 {
     if (responseAckFrameMode)
-        return responseAckFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getTransmitterAddress(), responseAckFrameMode);
     else {
         auto mode = getMode(packet, dataOrMgmtHeader);
         ASSERT(modeSet->containsMode(mode));
-        return modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        auto responseMode = modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        return getPeerCompatibleMode(dataOrMgmtHeader->getTransmitterAddress(), responseMode);
     }
 }
 
 const IIeee80211Mode *RateSelection::computeResponseCtsFrameMode(Packet *packet, const Ptr<const Ieee80211RtsFrame>& rtsFrame)
 {
     if (responseCtsFrameMode)
-        return responseCtsFrameMode;
+        return getPeerCompatibleMode(rtsFrame->getTransmitterAddress(), responseCtsFrameMode);
     else {
         auto mode = getMode(packet, rtsFrame);
         ASSERT(modeSet->containsMode(mode));
-        return modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        auto responseMode = modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        return getPeerCompatibleMode(rtsFrame->getTransmitterAddress(), responseMode);
     }
 }
 
@@ -115,15 +118,15 @@ const IIeee80211Mode *RateSelection::computeResponseCtsFrameMode(Packet *packet,
 const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader)
 {
     if (dataOrMgmtHeader->getReceiverAddress().isMulticast() && multicastFrameMode)
-        return multicastFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), multicastFrameMode);
     if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && dataFrameMode)
-        return dataFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataFrameMode);
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)
-        return mgmtFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), mgmtFrameMode);
     if (dataOrMgmtRateControl)
-        return dataOrMgmtRateControl->getRate();
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataOrMgmtRateControl->getRate());
     else
-        return fastestMandatoryMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), fastestMandatoryMode);
 }
 
 // 802.11-1999 Std.
@@ -135,7 +138,7 @@ const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const 
 const IIeee80211Mode *RateSelection::computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header)
 {
     // TODO BSSBasicRateSet
-    return fastestMandatoryMode;
+    return getPeerCompatibleMode(header->getReceiverAddress(), fastestMandatoryMode);
 }
 
 const IIeee80211Mode *RateSelection::computeMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header)
@@ -168,6 +171,18 @@ void RateSelection::setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHea
     packet->addTagIfAbsent<Ieee80211ModeReq>()->setMode(mode);
 }
 
+const IIeee80211Mode *RateSelection::getPeerCompatibleMode(const MacAddress& peerAddress, const IIeee80211Mode *mode) const
+{
+    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0 || mib->findPeerHtState(peerAddress) != nullptr)
+        return mode;
+    const auto *legacyMode = modeSet->getFastestLegacyOperationalMode();
+    if (legacyMode == nullptr)
+        throw cRuntimeError("No legacy operational mode is available for peer %s", peerAddress.str().c_str());
+    // Before HT negotiation (and after an invalid negotiation), unicast must
+    // remain legal for a legacy receiver. The mode set owns this operational
+    // legacy fallback and prefers its fastest mandatory mode.
+    return legacyMode;
+}
+
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -10,6 +10,7 @@
 #include "inet/common/ModuleAccess.h"
 #include "inet/common/Simsignals.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
@@ -173,15 +174,9 @@ void RateSelection::setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHea
 
 const IIeee80211Mode *RateSelection::getPeerCompatibleMode(const MacAddress& peerAddress, const IIeee80211Mode *mode) const
 {
-    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0 || mib->findPeerHtState(peerAddress) != nullptr)
+    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0)
         return mode;
-    const auto *legacyMode = modeSet->getFastestLegacyOperationalMode();
-    if (legacyMode == nullptr)
-        throw cRuntimeError("No legacy operational mode is available for peer %s", peerAddress.str().c_str());
-    // Before HT negotiation (and after an invalid negotiation), unicast must
-    // remain legal for a legacy receiver. The mode set owns this operational
-    // legacy fallback and prefers its fastest mandatory mode.
-    return legacyMode;
+    return selectPeerCompatibleMode(modeSet, mib->findPeerHtState(peerAddress), mode, peerAddress);
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
@@ -8,10 +8,12 @@
 #ifndef __INET_RATESELECTION_H
 #define __INET_RATESELECTION_H
 
+#include "inet/common/ModuleRefByPar.h"
 #include "inet/common/SimpleModule.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateSelection.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -33,6 +35,7 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
 {
   protected:
     IRateControl *dataOrMgmtRateControl = nullptr;
+    ModuleRefByPar<Ieee80211Mib> mib;
     const physicallayer::IIeee80211Mode *fastestMandatoryMode = nullptr;
 
     const physicallayer::Ieee80211ModeSet *modeSet = nullptr;
@@ -56,6 +59,8 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
     virtual const physicallayer::IIeee80211Mode *getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader);
+    virtual const physicallayer::IIeee80211Mode *getPeerCompatibleMode(const MacAddress& peerAddress,
+            const physicallayer::IIeee80211Mode *mode) const;
 
   public:
     static void setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header, const physicallayer::IIeee80211Mode *mode);
@@ -77,4 +82,3 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -19,6 +19,7 @@ simple RateSelection extends SimpleModule like IRateSelection
     parameters:
         @class(RateSelection);
         string rateControlModule;
+        string mibModule;
 
         double multicastFrameBitrate @unit(bps) = default(-1bps);
 
@@ -33,4 +34,3 @@ simple RateSelection extends SimpleModule like IRateSelection
         double controlFrameBitrate @unit(bps) = default(-1bps);
         @display("i=block/cogwheel");
 }
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.cc
@@ -98,10 +98,10 @@ void Ieee80211AgentSta::handleResponse(cMessage *msg)
         processScanConfirm(ptr);
     else if (auto ptr = dynamic_cast<Ieee80211Prim_AuthenticateConfirm *>(ctrl))
         processAuthenticateConfirm(ptr);
-    else if (auto ptr = dynamic_cast<Ieee80211Prim_AssociateConfirm *>(ctrl))
-        processAssociateConfirm(ptr);
     else if (auto ptr = dynamic_cast<Ieee80211Prim_ReassociateConfirm *>(ctrl))
         processReassociateConfirm(ptr);
+    else if (auto ptr = dynamic_cast<Ieee80211Prim_AssociateConfirm *>(ctrl))
+        processAssociateConfirm(ptr);
     else if (ctrl)
         throw cRuntimeError("handleResponse(): unrecognized control info class `%s'", ctrl->getClassName());
     else

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h
@@ -1,0 +1,126 @@
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+#ifndef __INET_IEEE80211HTMGMTELEMENTS_H
+#define __INET_IEEE80211HTMGMTELEMENTS_H
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211HtCapabilities.h"
+
+namespace inet {
+namespace ieee80211 {
+
+inline Ieee80211HtCapabilitiesElement makeHtCapabilitiesElement(const Ieee80211HtCapabilities& capabilities)
+{
+    Ieee80211HtCapabilitiesElement element;
+    element.ldpc = capabilities.ldpc;
+    element.supportedChannelWidth40Mhz = capabilities.supportedChannelWidths.count(MHz(40)) != 0;
+    element.greenfield = capabilities.greenfield;
+    element.shortGi20 = capabilities.shortGi20;
+    element.shortGi40 = capabilities.shortGi40;
+    element.maxAmpduLengthExponent = capabilities.maxAmpduLengthExponent;
+    for (int i = 0; i < 77; i++)
+        element.rxMcsSupported[i] = capabilities.rxMcsSupported[i];
+    element.txMcsSetDefined = capabilities.txMcsSetDefined;
+    element.txRxMcsSetNotEqual = capabilities.txRxMcsSetNotEqual;
+    element.txMaxNss = capabilities.txMaxNss;
+    element.txUnequalModulation = capabilities.txUnequalModulation;
+    if (element.txMcsSetDefined && !element.txRxMcsSetNotEqual) {
+        for (int nss = 0; nss < 4; nss++) {
+            int rxMaximum = -1;
+            for (int mcs = 0; mcs < 8; mcs++)
+                if (capabilities.rxMcsSupported[nss * 8 + mcs])
+                    rxMaximum = mcs;
+            if (capabilities.txMcsNss.maxMcsPerNss[nss] != rxMaximum)
+                throw cRuntimeError("Equal HT Tx/Rx MCS Set does not match the Rx MCS bitmap");
+        }
+    }
+    return element;
+}
+
+inline Ieee80211HtCapabilities makeHtCapabilities(const Ieee80211HtCapabilitiesElement& element)
+{
+    if (element.maxAmpduLengthExponent < 0 || element.maxAmpduLengthExponent > 3)
+        throw cRuntimeError("Invalid Maximum A-MPDU Length Exponent: %d", element.maxAmpduLengthExponent);
+    Ieee80211HtCapabilities capabilities;
+    capabilities.supportedChannelWidths.insert(MHz(20));
+    if (element.supportedChannelWidth40Mhz)
+        capabilities.supportedChannelWidths.insert(MHz(40));
+    capabilities.ldpc = element.ldpc;
+    capabilities.greenfield = element.greenfield;
+    capabilities.shortGi20 = element.shortGi20;
+    capabilities.shortGi40 = element.shortGi40;
+    capabilities.maxAmpduLengthExponent = element.maxAmpduLengthExponent;
+    capabilities.txMcsSetDefined = element.txMcsSetDefined;
+    capabilities.txRxMcsSetNotEqual = element.txRxMcsSetNotEqual;
+    capabilities.txMaxNss = element.txMaxNss;
+    capabilities.txUnequalModulation = element.txUnequalModulation;
+    for (int i = 0; i < 77; i++)
+        capabilities.rxMcsSupported[i] = element.rxMcsSupported[i];
+    for (int nss = 0; nss < 4; nss++) {
+        int rxMaximum = -1;
+        for (int mcs = 0; mcs < 8; mcs++)
+            if (element.rxMcsSupported[nss * 8 + mcs])
+                rxMaximum = mcs;
+        capabilities.txMcsNss.maxMcsPerNss[nss] = element.txMcsSetDefined && !element.txRxMcsSetNotEqual ? rxMaximum : -1;
+    }
+    return capabilities;
+}
+
+inline Ieee80211HtOperationElement makeHtOperationElement(const Ieee80211HtOperation& operation)
+{
+    Ieee80211HtOperationElement element;
+    element.primaryChannel = operation.primaryChannel;
+    element.secondaryChannelOffset = operation.secondaryChannelOffset;
+    element.staChannelWidth40Mhz = operation.operatingChannelWidth == MHz(40);
+    element.protectionMode = static_cast<int>(operation.protectionMode);
+    for (int i = 0; i < 77; i++)
+        element.basicMcsSupported[i] = operation.basicMcsSupported[i];
+    return element;
+}
+
+inline Ieee80211HtOperation makeHtOperation(const Ieee80211HtOperationElement& element)
+{
+    if (element.secondaryChannelOffset == 2 || element.secondaryChannelOffset < 0 || element.secondaryChannelOffset > 3)
+        throw cRuntimeError("Invalid HT Secondary Channel Offset: %d", element.secondaryChannelOffset);
+    if (element.protectionMode < 0 || element.protectionMode > 3)
+        throw cRuntimeError("Invalid HT Protection field: %d", element.protectionMode);
+    Ieee80211HtOperation operation;
+    operation.primaryChannel = element.primaryChannel;
+    operation.secondaryChannelOffset = element.secondaryChannelOffset;
+    operation.operatingChannelWidth = element.staChannelWidth40Mhz ? MHz(40) : MHz(20);
+    operation.protectionMode = static_cast<Ieee80211HtProtectionMode>(element.protectionMode);
+    for (int i = 0; i < 77; i++)
+        operation.basicMcsSupported[i] = element.basicMcsSupported[i];
+    return operation;
+}
+
+inline B getHtMgmtElementsLength(const Ptr<const Ieee80211MgmtFrame>& frame)
+{
+    B length(0);
+    if (frame->getHtCapabilitiesPresent())
+        length += B(28);
+    if (frame->getHtOperationPresent())
+        length += B(24);
+    return length;
+}
+
+inline void setHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame, const Ieee80211HtCapabilities& capabilities)
+{
+    frame->setHtCapabilitiesPresent(true);
+    frame->setHtCapabilities(makeHtCapabilitiesElement(capabilities));
+}
+
+inline void setHtOperation(const Ptr<Ieee80211MgmtFrame>& frame, const Ieee80211HtOperation& operation)
+{
+    frame->setHtOperationPresent(true);
+    frame->setHtOperation(makeHtOperationElement(operation));
+}
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -144,10 +144,10 @@ void Ieee80211MgmtAp::sendBeacon()
     EV << "Sending beacon\n";
     const auto& body = makeShared<Ieee80211BeaconFrame>();
     body->setSSID(ssid.c_str());
-    body->setSupportedRates(supportedRates);
+    setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
     body->setChannelNumber(channelNumber);
-    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length()) + (2 + supportedRates.numRates)));
+    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body));
     sendManagementFrame("Beacon", body, ST_BEACON, MacAddress::BROADCAST_ADDRESS);
 }
 
@@ -264,8 +264,8 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
     const auto& body = makeShared<Ieee80211AssociationResponseFrame>();
     body->setStatusCode(SC_SUCCESSFUL);
     body->setAid(mib->allocateAssociationId(sta->address));
-    body->setSupportedRates(supportedRates);
-    body->setChunkLength(B(2 + 2 + 2 + body->getSupportedRates().numRates + 2));
+    setSupportedRateElements(body);
+    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
     sendManagementFrame("AssocResp-OK", body, ST_ASSOCIATIONRESPONSE, sta->address);
 }
 
@@ -295,8 +295,8 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
     const auto& body = makeShared<Ieee80211ReassociationResponseFrame>();
     body->setStatusCode(SC_SUCCESSFUL);
     body->setAid(mib->allocateAssociationId(sta->address));
-    body->setSupportedRates(supportedRates);
-    body->setChunkLength(B(2 + (2 + ssid.length()) + (2 + supportedRates.numRates) + 6));
+    setSupportedRateElements(body);
+    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
     sendManagementFrame("ReassocResp-OK", body, ST_REASSOCIATIONRESPONSE, sta->address);
 }
 
@@ -341,10 +341,10 @@ void Ieee80211MgmtAp::handleProbeRequestFrame(Packet *packet, const Ptr<const Ie
     EV << "Sending ProbeResponse frame\n";
     const auto& body = makeShared<Ieee80211ProbeResponseFrame>();
     body->setSSID(ssid.c_str());
-    body->setSupportedRates(supportedRates);
+    setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
     body->setChannelNumber(channelNumber);
-    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length()) + (2 + supportedRates.numRates)));
+    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body));
     sendManagementFrame("ProbeResp", body, ST_PROBERESPONSE, staAddress);
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -18,7 +18,6 @@
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 #include "inet/networklayer/common/NetworkInterface.h"
-#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
 
 namespace inet {
 
@@ -51,18 +50,12 @@ void Ieee80211MgmtAp::initialize(int stage)
         numAuthSteps = par("numAuthSteps");
         if (numAuthSteps != 2 && numAuthSteps != 4)
             throw cRuntimeError("parameter 'numAuthSteps' (number of frames exchanged during authentication) must be 2 or 4, not %d", numAuthSteps);
-        channelNumber = -1; // value will arrive from physical layer in receiveChangeNotification()
         WATCH(ssid);
-        WATCH(channelNumber);
         WATCH(beaconInterval);
         WATCH(numAuthSteps);
         WATCH(staList);
 
         // TODO fill in supportedRates
-
-        // subscribe for notifications
-        cModule *radioModule = getModuleFromPar<cModule>(par("radioModule"), this);
-        radioModule->subscribe(Ieee80211Radio::radioChannelChangedSignal, this);
 
         // start beacon timer (randomize startup time)
         beaconTimer = new cMessage("beaconTimer");
@@ -83,17 +76,6 @@ void Ieee80211MgmtAp::handleTimer(cMessage *msg)
 void Ieee80211MgmtAp::handleCommand(int msgkind, cObject *ctrl)
 {
     throw cRuntimeError("handleCommand(): no commands supported");
-}
-
-void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details)
-{
-    Enter_Method("%s", cComponent::getSignalName(signalID));
-
-    if (signalID == Ieee80211Radio::radioChannelChangedSignal) {
-        EV << "updating channel number\n";
-        channelNumber = value;
-        mib->htOperation.primaryChannel = channelNumber;
-    }
 }
 
 Ieee80211MgmtAp::AssociationResponseDisposition Ieee80211MgmtAp::getAssociationResponseDisposition(const Packet *responseFrame,
@@ -139,8 +121,10 @@ void Ieee80211MgmtAp::frameTransmissionFinished(const IFrameTransmissionCallback
             mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
             if (sta->second.pendingHtStateAvailable) {
                 // IEEE Std 802.11-2024, 11.3.5.3: association state becomes effective only after the successful response exchange.
-                if (sta->second.pendingHtCapabilitiesValid)
-                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, mib->htOperation);
+                if (sta->second.pendingHtCapabilitiesValid) {
+                    ASSERT(sta->second.pendingHtOperationValid);
+                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, sta->second.pendingHtOperation);
+                }
                 else
                     mib->removePeerHtCapabilities(address);
             }
@@ -196,18 +180,23 @@ void Ieee80211MgmtAp::clearPendingAssociation(StaInfo *sta)
     sta->pendingHtStateAvailable = false;
     sta->pendingHtCapabilitiesValid = false;
     sta->pendingHtCapabilities = Ieee80211HtCapabilities();
+    sta->pendingHtOperationValid = false;
+    sta->pendingHtOperation = Ieee80211HtOperation();
 }
 
 void Ieee80211MgmtAp::sendBeacon()
 {
     EV << "Sending beacon\n";
+    int primaryChannel = mib->requirePrimaryChannel();
+    const auto htOperation = mib->getHtOperation();
     const auto& body = makeShared<Ieee80211BeaconFrame>();
     body->setSSID(ssid.c_str());
     setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
-    body->setChannelNumber(channelNumber);
+    body->setChannelNumber(primaryChannel);
     addHtCapabilities(body);
-    addHtOperation(body);
+    if (mib->isHtOperationSupported())
+        setHtOperation(body, htOperation);
     body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Beacon", body, ST_BEACON, MacAddress::BROADCAST_ADDRESS);
 }
@@ -333,25 +322,37 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
     }
 
     const auto& requestBody = packet->peekData<Ieee80211AssociationRequestFrame>();
-    sta->pendingAssociationSuccessful = false;
-    sta->pendingHtStateAvailable = true;
-    sta->pendingHtCapabilitiesValid = mib->isHtOperationSupported() && requestBody->getHtCapabilitiesPresent();
-    if (sta->pendingHtCapabilitiesValid)
-        sta->pendingHtCapabilities = makeHtCapabilities(requestBody->getHtCapabilities());
-    bool basicHtMcsSupported = !sta->pendingHtCapabilitiesValid ||
-            supportsBasicHtMcsSet(sta->pendingHtCapabilities, mib->htOperation);
+    bool pendingHtOperationValid = mib->isHtOperationSupported();
+    Ieee80211HtOperation pendingHtOperation;
+    if (pendingHtOperationValid)
+        pendingHtOperation = mib->getHtOperation();
+    bool pendingHtCapabilitiesValid = pendingHtOperationValid && requestBody->getHtCapabilitiesPresent();
+    Ieee80211HtCapabilities pendingHtCapabilities;
+    if (pendingHtCapabilitiesValid)
+        pendingHtCapabilities = makeHtCapabilities(requestBody->getHtCapabilities());
+    bool basicHtMcsSupported = !pendingHtCapabilitiesValid ||
+            supportsBasicHtMcsSet(pendingHtCapabilities, pendingHtOperation);
     delete packet;
 
     // IEEE Std 802.11-2024, 11.3.5.3 g): an HT STA must support every Basic HT-MCS.
     const auto& body = makeShared<Ieee80211AssociationResponseFrame>();
+    // Constructing an HT response requires an authoritative primary channel.
+    // Do this before reserving an AID or publishing pending transaction state,
+    // so an unavailable channel cannot leave a half-created association.
+    if (pendingHtOperationValid)
+        setHtOperation(body, pendingHtOperation);
     body->setStatusCode(basicHtMcsSupported ? SC_SUCCESSFUL : SC_DATARATE_UNSUP);
     short associationId = basicHtMcsSupported ? mib->reserveAssociationId(sta->address) : 0;
     body->setAid(associationId);
     sta->pendingAssociationSuccessful = basicHtMcsSupported;
+    sta->pendingHtStateAvailable = true;
+    sta->pendingHtCapabilitiesValid = pendingHtCapabilitiesValid;
+    sta->pendingHtCapabilities = pendingHtCapabilities;
+    sta->pendingHtOperationValid = pendingHtOperationValid;
+    sta->pendingHtOperation = pendingHtOperation;
     sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
     addHtCapabilities(body);
-    addHtOperation(body);
     body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame(basicHtMcsSupported ? "AssocResp-OK" : "AssocResp-UnsupportedHtMcs", body, ST_ASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
@@ -383,25 +384,36 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
     }
 
     const auto& requestBody = packet->peekData<Ieee80211ReassociationRequestFrame>();
-    sta->pendingAssociationSuccessful = false;
-    sta->pendingHtStateAvailable = true;
-    sta->pendingHtCapabilitiesValid = mib->isHtOperationSupported() && requestBody->getHtCapabilitiesPresent();
-    if (sta->pendingHtCapabilitiesValid)
-        sta->pendingHtCapabilities = makeHtCapabilities(requestBody->getHtCapabilities());
-    bool basicHtMcsSupported = !sta->pendingHtCapabilitiesValid ||
-            supportsBasicHtMcsSet(sta->pendingHtCapabilities, mib->htOperation);
+    bool pendingHtOperationValid = mib->isHtOperationSupported();
+    Ieee80211HtOperation pendingHtOperation;
+    if (pendingHtOperationValid)
+        pendingHtOperation = mib->getHtOperation();
+    bool pendingHtCapabilitiesValid = pendingHtOperationValid && requestBody->getHtCapabilitiesPresent();
+    Ieee80211HtCapabilities pendingHtCapabilities;
+    if (pendingHtCapabilitiesValid)
+        pendingHtCapabilities = makeHtCapabilities(requestBody->getHtCapabilities());
+    bool basicHtMcsSupported = !pendingHtCapabilitiesValid ||
+            supportsBasicHtMcsSet(pendingHtCapabilities, pendingHtOperation);
     delete packet;
 
     // send OK response
     const auto& body = makeShared<Ieee80211ReassociationResponseFrame>();
+    // See the association response path above: fail while constructing the
+    // response, before mutating association bookkeeping.
+    if (pendingHtOperationValid)
+        setHtOperation(body, pendingHtOperation);
     body->setStatusCode(basicHtMcsSupported ? SC_SUCCESSFUL : SC_DATARATE_UNSUP);
     short associationId = basicHtMcsSupported ? mib->reserveAssociationId(sta->address) : 0;
     body->setAid(associationId);
     sta->pendingAssociationSuccessful = basicHtMcsSupported;
+    sta->pendingHtStateAvailable = true;
+    sta->pendingHtCapabilitiesValid = pendingHtCapabilitiesValid;
+    sta->pendingHtCapabilities = pendingHtCapabilities;
+    sta->pendingHtOperationValid = pendingHtOperationValid;
+    sta->pendingHtOperation = pendingHtOperation;
     sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
     addHtCapabilities(body);
-    addHtOperation(body);
     body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame(basicHtMcsSupported ? "ReassocResp-OK" : "ReassocResp-UnsupportedHtMcs", body, ST_REASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
@@ -447,13 +459,16 @@ void Ieee80211MgmtAp::handleProbeRequestFrame(Packet *packet, const Ptr<const Ie
     delete packet;
 
     EV << "Sending ProbeResponse frame\n";
+    int primaryChannel = mib->requirePrimaryChannel();
+    const auto htOperation = mib->getHtOperation();
     const auto& body = makeShared<Ieee80211ProbeResponseFrame>();
     body->setSSID(ssid.c_str());
     setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
-    body->setChannelNumber(channelNumber);
+    body->setChannelNumber(primaryChannel);
     addHtCapabilities(body);
-    addHtOperation(body);
+    if (mib->isHtOperationSupported())
+        setHtOperation(body, htOperation);
     body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("ProbeResp", body, ST_PROBERESPONSE, staAddress);
 }

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -17,6 +17,7 @@
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
 
@@ -33,6 +34,61 @@ static std::ostream& operator<<(std::ostream& os, const Ieee80211MgmtAp::StaInfo
 {
     os << "address:" << sta.address;
     return os;
+}
+
+const Packet *Ieee80211MgmtAp::getAssociationResponseFrame(ITransmitStep *transmitStep)
+{
+    return transmitStep == nullptr ? nullptr : transmitStep->getOriginatingFrame();
+}
+
+Ptr<const Ieee80211MacHeader> Ieee80211MgmtAp::getMacHeader(const Packet *frame)
+{
+    if (frame == nullptr)
+        return nullptr;
+    const auto& frontChunk = frame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR);
+    return dynamicPtrCast<const Ieee80211MacHeader>(frontChunk);
+}
+
+Ptr<const Ieee80211MgmtHeader> Ieee80211MgmtAp::getAssociationResponseHeader(const Packet *responseFrame)
+{
+    if (responseFrame == nullptr || responseFrame->findTag<Ieee80211MgmtTransactionTag>() == nullptr)
+        return nullptr;
+    const auto& responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(getMacHeader(responseFrame));
+    if (responseHeader == nullptr || (responseHeader->getType() != ST_ASSOCIATIONRESPONSE && responseHeader->getType() != ST_REASSOCIATIONRESPONSE))
+        return nullptr;
+    return responseHeader;
+}
+
+bool Ieee80211MgmtAp::isAssociationResponseDecisionPoint(ITransmitStep *transmitStep, IReceiveStep *receiveStep)
+{
+    if (transmitStep == nullptr || receiveStep == nullptr)
+        return false;
+    // The originating frame is the transmitted frame for ordinary exchanges,
+    // and the protected management frame for an RTS/CTS exchange. Ordinary
+    // transmissions therefore reach their decision point immediately; RTS
+    // transactions wait until the CTS step has completed.
+    if (transmitStep->getOriginatingFrame() == transmitStep->getFrameToTransmit())
+        return true;
+    const auto& receivedHeader = getMacHeader(receiveStep->getReceivedFrame());
+    return transmitStep->getCompletion() != IFrameSequenceStep::Completion::ACCEPTED ||
+            receiveStep->getCompletion() != IFrameSequenceStep::Completion::ACCEPTED ||
+            receivedHeader == nullptr || receivedHeader->getType() != ST_CTS;
+}
+
+Ieee80211MgmtAp::AssociationResponseDisposition Ieee80211MgmtAp::getAssociationResponseDisposition(const Packet *responseFrame,
+        uint64_t pendingTransactionId, bool exchangeSucceeded, bool retryPending)
+{
+    if (responseFrame == nullptr || pendingTransactionId == 0)
+        return AssociationResponseDisposition::IGNORE;
+    const auto& responseHeader = getAssociationResponseHeader(responseFrame);
+    if (responseHeader == nullptr)
+        return AssociationResponseDisposition::IGNORE;
+    const auto& transactionTag = responseFrame->findTag<Ieee80211MgmtTransactionTag>();
+    if (transactionTag == nullptr || transactionTag->getTransactionId() != pendingTransactionId)
+        return AssociationResponseDisposition::IGNORE;
+    if ((exchangeSucceeded && responseHeader->getMoreFragments()) || (!exchangeSucceeded && retryPending))
+        return AssociationResponseDisposition::RETAIN;
+    return AssociationResponseDisposition::COMPLETE;
 }
 
 Ieee80211MgmtAp::~Ieee80211MgmtAp()
@@ -102,19 +158,46 @@ void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, cO
 
     if (signalID == IFrameSequenceHandler::frameSequenceFinishedSignal) {
         auto context = check_and_cast<FrameSequenceContext *>(obj);
-        if (context->getNumSteps() >= 2) {
-            auto transmitStep = dynamic_cast<ITransmitStep *>(context->getStepBeforeLast());
-            auto receiveStep = dynamic_cast<IReceiveStep *>(context->getLastStep());
-            if (transmitStep && receiveStep &&
-                transmitStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED &&
-                receiveStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED) {
-                auto responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(transmitStep->getFrameToTransmit()->peekAtFront<Ieee80211MacHeader>());
-                if (responseHeader != nullptr && (responseHeader->getType() == ST_ASSOCIATIONRESPONSE || responseHeader->getType() == ST_REASSOCIATIONRESPONSE)) {
-                    auto ackHeader = receiveStep->getReceivedFrame()->peekAtFront<Ieee80211MacHeader>();
-                    if (ackHeader->getType() == ST_ACK) {
-                        if (responseHeader->getType() == ST_ASSOCIATIONRESPONSE && mib->bssAccessPointData.stations[responseHeader->getReceiverAddress()] != Ieee80211Mib::ASSOCIATED)
-                            sendAssocNotification(responseHeader->getReceiverAddress());
-                        mib->bssAccessPointData.stations[responseHeader->getReceiverAddress()] = Ieee80211Mib::ASSOCIATED;
+        for (int stepIndex = 0; stepIndex + 1 < context->getNumSteps(); stepIndex++) {
+            auto transmitStep = dynamic_cast<ITransmitStep *>(context->getStep(stepIndex));
+            auto receiveStep = dynamic_cast<IReceiveStep *>(context->getStep(stepIndex + 1));
+            if (transmitStep && receiveStep) {
+                const Packet *responseFrame = getAssociationResponseFrame(transmitStep);
+                const auto& responseHeader = getAssociationResponseHeader(responseFrame);
+                if (responseHeader != nullptr) {
+                    if (!isAssociationResponseDecisionPoint(transmitStep, receiveStep))
+                        continue;
+                    const auto& receivedHeader = getMacHeader(receiveStep->getReceivedFrame());
+                    const auto& address = responseHeader->getReceiverAddress();
+                    auto sta = staList.find(address);
+                    bool exchangeSucceeded = transmitStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED &&
+                            receiveStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED &&
+                            receivedHeader != nullptr && receivedHeader->getType() == ST_ACK;
+                    bool retryPending = false;
+                    if (!exchangeSucceeded)
+                        retryPending = context->isFramePending(responseFrame);
+                    uint64_t pendingTransactionId = sta == staList.end() ? 0 : sta->second.pendingAssociationTransactionId;
+                    auto disposition = getAssociationResponseDisposition(responseFrame, pendingTransactionId, exchangeSucceeded, retryPending);
+                    if (disposition == AssociationResponseDisposition::COMPLETE) {
+                        if (exchangeSucceeded && sta->second.pendingAssociationSuccessful) {
+                            bool wasAssociated = mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED;
+                            mib->commitAssociationId(address);
+                            mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
+                            // Signal delivery is synchronous; observers must see committed station state.
+                            if (!wasAssociated)
+                                sendAssocNotification(address);
+                        }
+                        else if (exchangeSucceeded && mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED) {
+                            // This model does not implement negotiated management-frame protection.
+                            // IEEE Std 802.11-2024, 11.3.5.3(p) for association and 11.3.5.5(n)
+                            // for same-AP reassociation therefore require the existing association
+                            // state to be cleared after this acknowledged refusal.
+                            mib->releaseAssociationId(address);
+                            mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+                            // Signal delivery is synchronous; observers must see the downgraded state.
+                            sendDisAssocNotification(address);
+                        }
+                        clearPendingAssociation(&sta->second);
                     }
                 }
             }
@@ -130,13 +213,29 @@ Ieee80211MgmtAp::StaInfo *Ieee80211MgmtAp::lookupSenderSTA(const Ptr<const Ieee8
     return it == staList.end() ? nullptr : &(it->second);
 }
 
-void Ieee80211MgmtAp::sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr)
+void Ieee80211MgmtAp::sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr, uint64_t transactionId)
 {
     auto packet = new Packet(name);
     packet->addTag<MacAddressReq>()->setDestAddress(destAddr);
     packet->addTag<Ieee80211SubtypeReq>()->setSubtype(subtype);
     packet->insertAtBack(body);
+    if (transactionId != 0)
+        packet->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
     sendDown(packet);
+}
+
+uint64_t Ieee80211MgmtAp::createAssociationTransactionId()
+{
+    if (++nextAssociationTransactionId == 0)
+        ++nextAssociationTransactionId;
+    return nextAssociationTransactionId;
+}
+
+void Ieee80211MgmtAp::clearPendingAssociation(StaInfo *sta)
+{
+    mib->cancelAssociationIdReservation(sta->address);
+    sta->pendingAssociationSuccessful = false;
+    sta->pendingAssociationTransactionId = 0;
 }
 
 void Ieee80211MgmtAp::sendBeacon()
@@ -166,6 +265,7 @@ void Ieee80211MgmtAp::handleAuthenticationFrame(Packet *packet, const Ptr<const 
         mib->bssAccessPointData.stations[staAddress] = Ieee80211Mib::NOT_AUTHENTICATED;
         sta->authSeqExpected = 1;
     }
+    clearPendingAssociation(sta);
 
     // reset authentication status, when starting a new auth sequence
     // The statements below are added because the L2 handover time was greater than before when
@@ -233,6 +333,7 @@ void Ieee80211MgmtAp::handleDeauthenticationFrame(Packet *packet, const Ptr<cons
     delete packet;
 
     if (sta) {
+        clearPendingAssociation(sta);
         // mark STA as not authenticated; alternatively, it could also be removed from staList
         if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
             sendDisAssocNotification(sta->address);
@@ -249,6 +350,15 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
 
     // "11.3.2 AP association procedures"
     StaInfo *sta = lookupSenderSTA(header);
+    if (sta != nullptr && sta->pendingAssociationTransactionId != 0) {
+        // A response transaction is MAC-owned until its terminal completion.
+        // Coalesce a retransmitted request instead of replacing its response
+        // or allocating another association ID.
+        delete packet;
+        return;
+    }
+    if (sta != nullptr)
+        clearPendingAssociation(sta);
     if (!sta || mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::NOT_AUTHENTICATED) {
         // STA not authenticated: send error and return
         const auto& body = makeShared<Ieee80211DeauthenticationFrame>();
@@ -263,10 +373,12 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
     // send OK response
     const auto& body = makeShared<Ieee80211AssociationResponseFrame>();
     body->setStatusCode(SC_SUCCESSFUL);
-    body->setAid(mib->allocateAssociationId(sta->address));
+    body->setAid(mib->reserveAssociationId(sta->address));
+    sta->pendingAssociationSuccessful = true;
+    sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
     body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
-    sendManagementFrame("AssocResp-OK", body, ST_ASSOCIATIONRESPONSE, sta->address);
+    sendManagementFrame("AssocResp-OK", body, ST_ASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
 
 void Ieee80211MgmtAp::handleAssociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -280,6 +392,12 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
 
     // "11.3.4 AP reassociation procedures" -- almost the same as AssociationRequest processing
     StaInfo *sta = lookupSenderSTA(header);
+    if (sta != nullptr && sta->pendingAssociationTransactionId != 0) {
+        delete packet;
+        return;
+    }
+    if (sta != nullptr)
+        clearPendingAssociation(sta);
     if (!sta || mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::NOT_AUTHENTICATED) {
         // STA not authenticated: send error and return
         const auto& body = makeShared<Ieee80211DeauthenticationFrame>();
@@ -294,10 +412,12 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
     // send OK response
     const auto& body = makeShared<Ieee80211ReassociationResponseFrame>();
     body->setStatusCode(SC_SUCCESSFUL);
-    body->setAid(mib->allocateAssociationId(sta->address));
+    body->setAid(mib->reserveAssociationId(sta->address));
+    sta->pendingAssociationSuccessful = true;
+    sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
     body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
-    sendManagementFrame("ReassocResp-OK", body, ST_REASSOCIATIONRESPONSE, sta->address);
+    sendManagementFrame("ReassocResp-OK", body, ST_REASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
 
 void Ieee80211MgmtAp::handleReassociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -311,6 +431,7 @@ void Ieee80211MgmtAp::handleDisassociationFrame(Packet *packet, const Ptr<const 
     delete packet;
 
     if (sta) {
+        clearPendingAssociation(sta);
         if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
             sendDisAssocNotification(sta->address);
             mib->releaseAssociationId(sta->address);
@@ -379,7 +500,7 @@ void Ieee80211MgmtAp::stop()
 {
     cancelEvent(beaconTimer);
     staList.clear();
-    mib->bssAccessPointData.associationIds.clear();
+    mib->clearAssociationIds();
     Ieee80211MgmtApBase::stop();
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -17,6 +17,7 @@
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
@@ -149,6 +150,7 @@ void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, in
     if (signalID == Ieee80211Radio::radioChannelChangedSignal) {
         EV << "updating channel number\n";
         channelNumber = value;
+        mib->htOperation.primaryChannel = channelNumber;
     }
 }
 
@@ -183,7 +185,14 @@ void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, cO
                             bool wasAssociated = mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED;
                             mib->commitAssociationId(address);
                             mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
-                            // Signal delivery is synchronous; observers must see committed station state.
+                            if (sta->second.pendingHtStateAvailable) {
+                                // IEEE Std 802.11-2024, 11.3.5.3: association state becomes effective only after the successful response exchange.
+                                if (sta->second.pendingHtCapabilitiesValid)
+                                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, mib->htOperation);
+                                else
+                                    mib->removePeerHtCapabilities(address);
+                            }
+                            // Signal delivery is synchronous; observers must see committed station and peer state.
                             if (!wasAssociated)
                                 sendAssocNotification(address);
                         }
@@ -236,6 +245,9 @@ void Ieee80211MgmtAp::clearPendingAssociation(StaInfo *sta)
     mib->cancelAssociationIdReservation(sta->address);
     sta->pendingAssociationSuccessful = false;
     sta->pendingAssociationTransactionId = 0;
+    sta->pendingHtStateAvailable = false;
+    sta->pendingHtCapabilitiesValid = false;
+    sta->pendingHtCapabilities = Ieee80211HtCapabilities();
 }
 
 void Ieee80211MgmtAp::sendBeacon()
@@ -246,7 +258,9 @@ void Ieee80211MgmtAp::sendBeacon()
     setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
     body->setChannelNumber(channelNumber);
-    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    addHtOperation(body);
+    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Beacon", body, ST_BEACON, MacAddress::BROADCAST_ADDRESS);
 }
 
@@ -280,6 +294,7 @@ void Ieee80211MgmtAp::handleAuthenticationFrame(Packet *packet, const Ptr<const 
             mib->releaseAssociationId(sta->address);
         }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::NOT_AUTHENTICATED;
+        mib->removePeerHtCapabilities(sta->address);
         sta->authSeqExpected = 1;
     }
 
@@ -341,6 +356,7 @@ void Ieee80211MgmtAp::handleDeauthenticationFrame(Packet *packet, const Ptr<cons
         }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::NOT_AUTHENTICATED;
         sta->authSeqExpected = 1;
+        mib->removePeerHtCapabilities(sta->address);
     }
 }
 
@@ -368,17 +384,28 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
         return;
     }
 
+    const auto& requestBody = packet->peekData<Ieee80211AssociationRequestFrame>();
+    sta->pendingAssociationSuccessful = false;
+    sta->pendingHtStateAvailable = true;
+    sta->pendingHtCapabilitiesValid = mib->isHtOperationSupported() && requestBody->getHtCapabilitiesPresent();
+    if (sta->pendingHtCapabilitiesValid)
+        sta->pendingHtCapabilities = makeHtCapabilities(requestBody->getHtCapabilities());
+    bool basicHtMcsSupported = !sta->pendingHtCapabilitiesValid ||
+            supportsBasicHtMcsSet(sta->pendingHtCapabilities, mib->htOperation);
     delete packet;
 
-    // send OK response
+    // IEEE Std 802.11-2024, 11.3.5.3 g): an HT STA must support every Basic HT-MCS.
     const auto& body = makeShared<Ieee80211AssociationResponseFrame>();
-    body->setStatusCode(SC_SUCCESSFUL);
-    body->setAid(mib->reserveAssociationId(sta->address));
-    sta->pendingAssociationSuccessful = true;
+    body->setStatusCode(basicHtMcsSupported ? SC_SUCCESSFUL : SC_DATARATE_UNSUP);
+    short associationId = basicHtMcsSupported ? mib->reserveAssociationId(sta->address) : 0;
+    body->setAid(associationId);
+    sta->pendingAssociationSuccessful = basicHtMcsSupported;
     sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
-    sendManagementFrame("AssocResp-OK", body, ST_ASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
+    addHtCapabilities(body);
+    addHtOperation(body);
+    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
+    sendManagementFrame(basicHtMcsSupported ? "AssocResp-OK" : "AssocResp-UnsupportedHtMcs", body, ST_ASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
 
 void Ieee80211MgmtAp::handleAssociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -407,17 +434,28 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
         return;
     }
 
+    const auto& requestBody = packet->peekData<Ieee80211ReassociationRequestFrame>();
+    sta->pendingAssociationSuccessful = false;
+    sta->pendingHtStateAvailable = true;
+    sta->pendingHtCapabilitiesValid = mib->isHtOperationSupported() && requestBody->getHtCapabilitiesPresent();
+    if (sta->pendingHtCapabilitiesValid)
+        sta->pendingHtCapabilities = makeHtCapabilities(requestBody->getHtCapabilities());
+    bool basicHtMcsSupported = !sta->pendingHtCapabilitiesValid ||
+            supportsBasicHtMcsSet(sta->pendingHtCapabilities, mib->htOperation);
     delete packet;
 
     // send OK response
     const auto& body = makeShared<Ieee80211ReassociationResponseFrame>();
-    body->setStatusCode(SC_SUCCESSFUL);
-    body->setAid(mib->reserveAssociationId(sta->address));
-    sta->pendingAssociationSuccessful = true;
+    body->setStatusCode(basicHtMcsSupported ? SC_SUCCESSFUL : SC_DATARATE_UNSUP);
+    short associationId = basicHtMcsSupported ? mib->reserveAssociationId(sta->address) : 0;
+    body->setAid(associationId);
+    sta->pendingAssociationSuccessful = basicHtMcsSupported;
     sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
-    sendManagementFrame("ReassocResp-OK", body, ST_REASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
+    addHtCapabilities(body);
+    addHtOperation(body);
+    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
+    sendManagementFrame(basicHtMcsSupported ? "ReassocResp-OK" : "ReassocResp-UnsupportedHtMcs", body, ST_REASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
 
 void Ieee80211MgmtAp::handleReassociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -437,6 +475,7 @@ void Ieee80211MgmtAp::handleDisassociationFrame(Packet *packet, const Ptr<const 
             mib->releaseAssociationId(sta->address);
         }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::AUTHENTICATED;
+        mib->removePeerHtCapabilities(sta->address);
     }
 }
 
@@ -465,7 +504,9 @@ void Ieee80211MgmtAp::handleProbeRequestFrame(Packet *packet, const Ptr<const Ie
     setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
     body->setChannelNumber(channelNumber);
-    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    addHtOperation(body);
+    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("ProbeResp", body, ST_PROBERESPONSE, staAddress);
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -144,7 +144,7 @@ void Ieee80211MgmtAp::frameTransmissionFinished(const IFrameTransmissionCallback
         }
         clearPendingAssociation(&sta->second);
     }
-    else if (result.getStatus() == IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED)
+    else
         clearPendingAssociation(&sta->second);
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -216,8 +216,6 @@ void Ieee80211MgmtAp::handleAuthenticationFrame(Packet *packet, const Ptr<const 
         mib->bssAccessPointData.stations[staAddress] = Ieee80211Mib::NOT_AUTHENTICATED;
         sta->authSeqExpected = 1;
     }
-    clearPendingAssociation(sta);
-
     // reset authentication status, when starting a new auth sequence
     // The statements below are added because the L2 handover time was greater than before when
     // a STA wants to re-connect to an AP with which it was associated before. When the STA wants to
@@ -226,6 +224,11 @@ void Ieee80211MgmtAp::handleAuthenticationFrame(Packet *packet, const Ptr<const 
     // receives authentication frame number 1 from STA, which will cause the AP to return an Auth-Error
     // making the MN STA to start the handover process all over again.
     if (frameAuthSeq == 1) {
+        // INET policy: an accepted new authentication sequence supersedes any
+        // association response that is still owned by the MAC. IEEE 802.11-2024
+        // 11.3.4 does not require an associated peer to downgrade on frame 1;
+        // keep this cancellation scoped to this existing model transition.
+        clearPendingAssociation(sta);
         if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
             sendDisAssocNotification(sta->address);
             mib->releaseAssociationId(sta->address);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -12,8 +12,6 @@
 #include "inet/linklayer/ethernet/common/EthernetMacHeader_m.h"
 #endif // ifdef INET_WITH_ETHERNET
 
-#include "inet/linklayer/ieee80211/mac/contract/IFrameSequenceHandler.h"
-#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
@@ -35,61 +33,6 @@ static std::ostream& operator<<(std::ostream& os, const Ieee80211MgmtAp::StaInfo
 {
     os << "address:" << sta.address;
     return os;
-}
-
-const Packet *Ieee80211MgmtAp::getAssociationResponseFrame(ITransmitStep *transmitStep)
-{
-    return transmitStep == nullptr ? nullptr : transmitStep->getOriginatingFrame();
-}
-
-Ptr<const Ieee80211MacHeader> Ieee80211MgmtAp::getMacHeader(const Packet *frame)
-{
-    if (frame == nullptr)
-        return nullptr;
-    const auto& frontChunk = frame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR);
-    return dynamicPtrCast<const Ieee80211MacHeader>(frontChunk);
-}
-
-Ptr<const Ieee80211MgmtHeader> Ieee80211MgmtAp::getAssociationResponseHeader(const Packet *responseFrame)
-{
-    if (responseFrame == nullptr || responseFrame->findTag<Ieee80211MgmtTransactionTag>() == nullptr)
-        return nullptr;
-    const auto& responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(getMacHeader(responseFrame));
-    if (responseHeader == nullptr || (responseHeader->getType() != ST_ASSOCIATIONRESPONSE && responseHeader->getType() != ST_REASSOCIATIONRESPONSE))
-        return nullptr;
-    return responseHeader;
-}
-
-bool Ieee80211MgmtAp::isAssociationResponseDecisionPoint(ITransmitStep *transmitStep, IReceiveStep *receiveStep)
-{
-    if (transmitStep == nullptr || receiveStep == nullptr)
-        return false;
-    // The originating frame is the transmitted frame for ordinary exchanges,
-    // and the protected management frame for an RTS/CTS exchange. Ordinary
-    // transmissions therefore reach their decision point immediately; RTS
-    // transactions wait until the CTS step has completed.
-    if (transmitStep->getOriginatingFrame() == transmitStep->getFrameToTransmit())
-        return true;
-    const auto& receivedHeader = getMacHeader(receiveStep->getReceivedFrame());
-    return transmitStep->getCompletion() != IFrameSequenceStep::Completion::ACCEPTED ||
-            receiveStep->getCompletion() != IFrameSequenceStep::Completion::ACCEPTED ||
-            receivedHeader == nullptr || receivedHeader->getType() != ST_CTS;
-}
-
-Ieee80211MgmtAp::AssociationResponseDisposition Ieee80211MgmtAp::getAssociationResponseDisposition(const Packet *responseFrame,
-        uint64_t pendingTransactionId, bool exchangeSucceeded, bool retryPending)
-{
-    if (responseFrame == nullptr || pendingTransactionId == 0)
-        return AssociationResponseDisposition::IGNORE;
-    const auto& responseHeader = getAssociationResponseHeader(responseFrame);
-    if (responseHeader == nullptr)
-        return AssociationResponseDisposition::IGNORE;
-    const auto& transactionTag = responseFrame->findTag<Ieee80211MgmtTransactionTag>();
-    if (transactionTag == nullptr || transactionTag->getTransactionId() != pendingTransactionId)
-        return AssociationResponseDisposition::IGNORE;
-    if ((exchangeSucceeded && responseHeader->getMoreFragments()) || (!exchangeSucceeded && retryPending))
-        return AssociationResponseDisposition::RETAIN;
-    return AssociationResponseDisposition::COMPLETE;
 }
 
 Ieee80211MgmtAp::~Ieee80211MgmtAp()
@@ -120,7 +63,6 @@ void Ieee80211MgmtAp::initialize(int stage)
         // subscribe for notifications
         cModule *radioModule = getModuleFromPar<cModule>(par("radioModule"), this);
         radioModule->subscribe(Ieee80211Radio::radioChannelChangedSignal, this);
-        getContainingNicModule(this)->subscribe(IFrameSequenceHandler::frameSequenceFinishedSignal, this);
 
         // start beacon timer (randomize startup time)
         beaconTimer = new cMessage("beaconTimer");
@@ -154,66 +96,72 @@ void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, in
     }
 }
 
-void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
+Ieee80211MgmtAp::AssociationResponseDisposition Ieee80211MgmtAp::getAssociationResponseDisposition(const Packet *responseFrame,
+        uint64_t pendingTransactionId, IFrameTransmissionCallback::Status status)
 {
-    Enter_Method("%s", cComponent::getSignalName(signalID));
+    if (responseFrame == nullptr || pendingTransactionId == 0)
+        return AssociationResponseDisposition::IGNORE;
+    const auto& transactionTag = responseFrame->findTag<Ieee80211MgmtTransactionTag>();
+    if (transactionTag == nullptr || transactionTag->getTransactionId() != pendingTransactionId)
+        return AssociationResponseDisposition::IGNORE;
+    const auto& frontChunk = responseFrame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR);
+    const auto& responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(frontChunk);
+    if (responseHeader == nullptr || (responseHeader->getType() != ST_ASSOCIATIONRESPONSE && responseHeader->getType() != ST_REASSOCIATIONRESPONSE))
+        return AssociationResponseDisposition::IGNORE;
+    if (status == IFrameTransmissionCallback::Status::ACKNOWLEDGED && responseHeader->getMoreFragments())
+        return AssociationResponseDisposition::RETAIN;
+    return AssociationResponseDisposition::COMPLETE;
+}
 
-    if (signalID == IFrameSequenceHandler::frameSequenceFinishedSignal) {
-        auto context = check_and_cast<FrameSequenceContext *>(obj);
-        for (int stepIndex = 0; stepIndex + 1 < context->getNumSteps(); stepIndex++) {
-            auto transmitStep = dynamic_cast<ITransmitStep *>(context->getStep(stepIndex));
-            auto receiveStep = dynamic_cast<IReceiveStep *>(context->getStep(stepIndex + 1));
-            if (transmitStep && receiveStep) {
-                const Packet *responseFrame = getAssociationResponseFrame(transmitStep);
-                const auto& responseHeader = getAssociationResponseHeader(responseFrame);
-                if (responseHeader != nullptr) {
-                    if (!isAssociationResponseDecisionPoint(transmitStep, receiveStep))
-                        continue;
-                    const auto& receivedHeader = getMacHeader(receiveStep->getReceivedFrame());
-                    const auto& address = responseHeader->getReceiverAddress();
-                    auto sta = staList.find(address);
-                    bool exchangeSucceeded = transmitStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED &&
-                            receiveStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED &&
-                            receivedHeader != nullptr && receivedHeader->getType() == ST_ACK;
-                    bool retryPending = false;
-                    if (!exchangeSucceeded)
-                        retryPending = context->isFramePending(responseFrame);
-                    uint64_t pendingTransactionId = sta == staList.end() ? 0 : sta->second.pendingAssociationTransactionId;
-                    auto disposition = getAssociationResponseDisposition(responseFrame, pendingTransactionId, exchangeSucceeded, retryPending);
-                    if (disposition == AssociationResponseDisposition::COMPLETE) {
-                        if (exchangeSucceeded && sta->second.pendingAssociationSuccessful) {
-                            bool wasAssociated = mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED;
-                            mib->commitAssociationId(address);
-                            mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
-                            if (sta->second.pendingHtStateAvailable) {
-                                // IEEE Std 802.11-2024, 11.3.5.3: association state becomes effective only after the successful response exchange.
-                                if (sta->second.pendingHtCapabilitiesValid)
-                                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, mib->htOperation);
-                                else
-                                    mib->removePeerHtCapabilities(address);
-                            }
-                            // Signal delivery is synchronous; observers must see committed station and peer state.
-                            if (!wasAssociated)
-                                sendAssocNotification(address);
-                        }
-                        else if (exchangeSucceeded && mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED) {
-                            // This model does not implement negotiated management-frame protection.
-                            // IEEE Std 802.11-2024, 11.3.5.3(p) for association and 11.3.5.5(n)
-                            // for same-AP reassociation therefore require the existing association
-                            // state to be cleared after this acknowledged refusal.
-                            mib->releaseAssociationId(address);
-                            mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
-                            // Signal delivery is synchronous; observers must see the downgraded state.
-                            sendDisAssocNotification(address);
-                        }
-                        clearPendingAssociation(&sta->second);
-                    }
-                }
+void Ieee80211MgmtAp::frameTransmissionFinished(const IFrameTransmissionCallback::Result& result)
+{
+    Enter_Method("frameTransmissionFinished");
+    const Packet *responseFrame = result.getFrame();
+    if (responseFrame == nullptr)
+        return;
+    const auto& responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(responseFrame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR));
+    if (responseHeader == nullptr || (responseHeader->getType() != ST_ASSOCIATIONRESPONSE && responseHeader->getType() != ST_REASSOCIATIONRESPONSE))
+        return;
+    auto address = responseHeader->getReceiverAddress();
+    auto sta = staList.find(address);
+    uint64_t pendingTransactionId = sta == staList.end() ? 0 : sta->second.pendingAssociationTransactionId;
+    auto disposition = getAssociationResponseDisposition(responseFrame, pendingTransactionId, result.getStatus());
+    if (disposition == AssociationResponseDisposition::IGNORE)
+        return;
+    ASSERT(sta != staList.end());
+    if (disposition == AssociationResponseDisposition::RETAIN)
+        return;
+
+    if (result.getStatus() == IFrameTransmissionCallback::Status::ACKNOWLEDGED) {
+        if (sta->second.pendingAssociationSuccessful) {
+            bool wasAssociated = mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED;
+            mib->commitAssociationId(address);
+            mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
+            if (sta->second.pendingHtStateAvailable) {
+                // IEEE Std 802.11-2024, 11.3.5.3: association state becomes effective only after the successful response exchange.
+                if (sta->second.pendingHtCapabilitiesValid)
+                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, mib->htOperation);
+                else
+                    mib->removePeerHtCapabilities(address);
             }
+            // Signal delivery is synchronous; observers must see committed station and peer state.
+            if (!wasAssociated)
+                sendAssocNotification(address);
         }
+        else if (mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED) {
+            // This model does not implement negotiated management-frame protection.
+            // IEEE Std 802.11-2024, 11.3.5.3(p) for association and 11.3.5.5(n)
+            // for same-AP reassociation therefore require the existing association
+            // state to be cleared after this acknowledged refusal.
+            mib->releaseAssociationId(address);
+            mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+            // Signal delivery is synchronous; observers must see the downgraded state.
+            sendDisAssocNotification(address);
+        }
+        clearPendingAssociation(&sta->second);
     }
-    else
-        Ieee80211MgmtApBase::receiveSignal(source, signalID, obj, details);
+    else if (result.getStatus() == IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED)
+        clearPendingAssociation(&sta->second);
 }
 
 Ieee80211MgmtAp::StaInfo *Ieee80211MgmtAp::lookupSenderSTA(const Ptr<const Ieee80211MgmtHeader>& header)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
@@ -39,6 +39,9 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
         int authSeqExpected; // when NOT_AUTHENTICATED: transaction sequence number of next expected auth frame
         bool pendingAssociationSuccessful = false;
         uint64_t pendingAssociationTransactionId = 0;
+        bool pendingHtStateAvailable = false;
+        bool pendingHtCapabilitiesValid = false;
+        Ieee80211HtCapabilities pendingHtCapabilities;
 //        int consecFailedTrans; // TODO
 //        double expiry; // TODO association should expire after a while if STA is silent?
     };

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
@@ -10,20 +10,18 @@
 
 #include <map>
 
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h"
 
 namespace inet {
 
 namespace ieee80211 {
 
-class ITransmitStep;
-class IReceiveStep;
-
 /**
  * Used in 802.11 infrastructure mode: handles management frames for
  * an access point (AP). See corresponding NED file for a detailed description.
  */
-class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
+class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase, public IFrameTransmissionCallback
 {
   protected:
     enum class AssociationResponseDisposition {
@@ -83,15 +81,17 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int) override;
 
+    using Ieee80211MgmtApBase::receiveSignal;
+
     /** Implements abstract Ieee80211MgmtBase method */
     virtual void handleTimer(cMessage *msg) override;
 
     /** Implements abstract Ieee80211MgmtBase method -- throws an error (no commands supported) */
     virtual void handleCommand(int msgkind, cObject *ctrl) override;
 
-    /** Called by the signal handler whenever a change occurs we're interested in */
+    /** Called by a signal handler whenever a change occurs we're interested in */
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
-    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
+    virtual void frameTransmissionFinished(const IFrameTransmissionCallback::Result& result) override;
 
     /** Utility function: return sender STA's entry from our STA list, or nullptr if not in there */
     virtual StaInfo *lookupSenderSTA(const Ptr<const Ieee80211MgmtHeader>& header);
@@ -99,13 +99,12 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     /** Utility function: set fields in the given frame and send it out to the address */
     virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr, uint64_t transactionId = 0);
 
-    static const Packet *getAssociationResponseFrame(ITransmitStep *transmitStep);
-    static Ptr<const Ieee80211MacHeader> getMacHeader(const Packet *frame);
-    static Ptr<const Ieee80211MgmtHeader> getAssociationResponseHeader(const Packet *responseFrame);
-    static bool isAssociationResponseDecisionPoint(ITransmitStep *transmitStep, IReceiveStep *receiveStep);
-    static AssociationResponseDisposition getAssociationResponseDisposition(const Packet *responseFrame, uint64_t pendingTransactionId, bool exchangeSucceeded, bool retryPending);
     virtual uint64_t createAssociationTransactionId();
     virtual void clearPendingAssociation(StaInfo *sta);
+
+    /** Classifies a terminal management-MPDU result using its transaction tag and fragment state. */
+    static AssociationResponseDisposition getAssociationResponseDisposition(const Packet *responseFrame,
+            uint64_t pendingTransactionId, IFrameTransmissionCallback::Status status);
 
     /** Utility function: creates and sends a beacon frame */
     virtual void sendBeacon();

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
@@ -16,17 +16,29 @@ namespace inet {
 
 namespace ieee80211 {
 
+class ITransmitStep;
+class IReceiveStep;
+
 /**
  * Used in 802.11 infrastructure mode: handles management frames for
  * an access point (AP). See corresponding NED file for a detailed description.
  */
 class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
 {
+  protected:
+    enum class AssociationResponseDisposition {
+        IGNORE,
+        RETAIN,
+        COMPLETE,
+    };
+
   public:
     /** Describes a STA */
     struct StaInfo {
         MacAddress address;
         int authSeqExpected; // when NOT_AUTHENTICATED: transaction sequence number of next expected auth frame
+        bool pendingAssociationSuccessful = false;
+        uint64_t pendingAssociationTransactionId = 0;
 //        int consecFailedTrans; // TODO
 //        double expiry; // TODO association should expire after a while if STA is silent?
     };
@@ -58,6 +70,7 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     // state
     StaList staList; ///< list of STAs
     cMessage *beaconTimer = nullptr;
+    uint64_t nextAssociationTransactionId = 0;
 
   public:
     Ieee80211MgmtAp() {}
@@ -81,7 +94,15 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     virtual StaInfo *lookupSenderSTA(const Ptr<const Ieee80211MgmtHeader>& header);
 
     /** Utility function: set fields in the given frame and send it out to the address */
-    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr);
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr, uint64_t transactionId = 0);
+
+    static const Packet *getAssociationResponseFrame(ITransmitStep *transmitStep);
+    static Ptr<const Ieee80211MacHeader> getMacHeader(const Packet *frame);
+    static Ptr<const Ieee80211MgmtHeader> getAssociationResponseHeader(const Packet *responseFrame);
+    static bool isAssociationResponseDecisionPoint(ITransmitStep *transmitStep, IReceiveStep *receiveStep);
+    static AssociationResponseDisposition getAssociationResponseDisposition(const Packet *responseFrame, uint64_t pendingTransactionId, bool exchangeSucceeded, bool retryPending);
+    virtual uint64_t createAssociationTransactionId();
+    virtual void clearPendingAssociation(StaInfo *sta);
 
     /** Utility function: creates and sends a beacon frame */
     virtual void sendBeacon();

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
@@ -40,6 +40,8 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase, public IFrameTransm
         bool pendingHtStateAvailable = false;
         bool pendingHtCapabilitiesValid = false;
         Ieee80211HtCapabilities pendingHtCapabilities;
+        bool pendingHtOperationValid = false;
+        Ieee80211HtOperation pendingHtOperation;
 //        int consecFailedTrans; // TODO
 //        double expiry; // TODO association should expire after a while if STA is silent?
     };
@@ -64,7 +66,6 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase, public IFrameTransm
   protected:
     // configuration
     std::string ssid;
-    int channelNumber = -1;
     simtime_t beaconInterval;
     int numAuthSteps = 0;
 
@@ -81,16 +82,12 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase, public IFrameTransm
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int) override;
 
-    using Ieee80211MgmtApBase::receiveSignal;
-
     /** Implements abstract Ieee80211MgmtBase method */
     virtual void handleTimer(cMessage *msg) override;
 
     /** Implements abstract Ieee80211MgmtBase method -- throws an error (no commands supported) */
     virtual void handleCommand(int msgkind, cObject *ctrl) override;
 
-    /** Called by a signal handler whenever a change occurs we're interested in */
-    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
     virtual void frameTransmissionFinished(const IFrameTransmissionCallback::Result& result) override;
 
     /** Utility function: return sender STA's entry from our STA list, or nullptr if not in there */

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.cc
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "inet/common/ProtocolTag_m.h"
+#include "inet/common/ModuleAccess.h"
 #include "inet/linklayer/common/MacAddressTag_m.h"
 
 #ifdef INET_WITH_ETHERNET
@@ -15,6 +16,7 @@
 #endif // ifdef INET_WITH_ETHERNET
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
 
 namespace inet {
 
@@ -27,12 +29,23 @@ void Ieee80211MgmtApBase::initialize(int stage)
         mib->mode = Ieee80211Mib::INFRASTRUCTURE;
         mib->bssStationData.stationType = Ieee80211Mib::ACCESS_POINT;
         mib->bssData.ssid = par("ssid").stdstringValue();
+        auto radioModule = getModuleFromPar<cModule>(par("radioModule"), this);
+        radioModule->subscribe(physicallayer::Ieee80211Radio::radioChannelChangedSignal, this);
     }
     else if (stage == INITSTAGE_LINK_LAYER)
         mib->bssData.bssid = mib->address;
 }
 
+void Ieee80211MgmtApBase::receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details)
+{
+    Enter_Method("%s", cComponent::getSignalName(signalID));
+
+    if (signalID == physicallayer::Ieee80211Radio::radioChannelChangedSignal) {
+        EV << "Updating AP primary channel to " << value << ".\n";
+        mib->setPrimaryChannel(value);
+    }
+}
+
 } // namespace ieee80211
 
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h
@@ -28,6 +28,8 @@ class INET_API Ieee80211MgmtApBase : public Ieee80211MgmtBase
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int) override;
+    using Ieee80211MgmtBase::receiveSignal;
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
 };
 
 } // namespace ieee80211
@@ -35,4 +37,3 @@ class INET_API Ieee80211MgmtApBase : public Ieee80211MgmtBase
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApSimplified.ned
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApSimplified.ned
@@ -22,6 +22,7 @@ simple Ieee80211MgmtApSimplified extends SimpleModule like IIeee80211Mgmt
         string interfaceTableModule;
         string mibModule;
         string macModule;               // The path to the MAC module
+        string radioModule = default("^.radio");
         string ssid = default("SSID");
         @display("i=block/cogwheel");
     gates:

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -45,11 +45,31 @@ void Ieee80211MgmtBase::receiveSignal(cComponent *source, simsignal_t signalID, 
 
     if (signalID == modesetChangedSignal) {
         modeSet = check_and_cast<physicallayer::Ieee80211ModeSet *>(obj);
-        supportedRates.numRates = std::min(8, modeSet->getNumModes());
+        supportedRates = Ieee80211SupportedRatesElement();
+        extendedSupportedRates = Ieee80211ExtendedSupportedRatesElement();
         int rateIndex = 0;
-        for (int i = 0; i < supportedRates.numRates; i++)
-            if (modeSet->isMandatory(i))
-                supportedRates.rate[rateIndex++] = modeSet->getMode(i)->getDataMode()->getNetBitrate().get<Mbps>();
+        int extendedRateIndex = 0;
+        // Supported Rates carries the legacy OperationalRateSet only. HT/VHT
+        // MCS support is advertised through the corresponding capabilities
+        // elements (IEEE Std 802.11-2024, 9.4.2.3, 9.4.2.54.4, 11.1.4.6).
+        for (const auto *mode : modeSet->getLegacyOperationalModes()) {
+            bool isBasicRate = modeSet->getIsMandatory(mode);
+            double rate = mode->getDataMode()->getNetBitrate().get<Mbps>();
+            if (rateIndex < 8) {
+                supportedRates.rate[rateIndex] = rate;
+                supportedRates.basicRate[rateIndex] = isBasicRate;
+                rateIndex++;
+            }
+            else if (extendedRateIndex < 255) {
+                extendedSupportedRates.rate[extendedRateIndex] = rate;
+                extendedSupportedRates.basicRate[extendedRateIndex] = isBasicRate;
+                extendedRateIndex++;
+            }
+            else
+                throw cRuntimeError("Mode set '%s' contains more than 263 legacy operational rates", modeSet->getName());
+        }
+        supportedRates.numRates = rateIndex;
+        extendedSupportedRates.numRates = extendedRateIndex;
     }
 }
 
@@ -163,4 +183,3 @@ void Ieee80211MgmtBase::stop()
 } // namespace ieee80211
 
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -84,7 +84,7 @@ void Ieee80211MgmtBase::addHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame) 
 void Ieee80211MgmtBase::addHtOperation(const Ptr<Ieee80211MgmtFrame>& frame) const
 {
     if (mib->isHtOperationSupported())
-        setHtOperation(frame, mib->htOperation);
+        setHtOperation(frame, mib->getHtOperation());
 }
 
 void Ieee80211MgmtBase::handleMessageWhenUp(cMessage *msg)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -14,6 +14,7 @@
 #include "inet/common/lifecycle/ModuleOperations.h"
 #include "inet/common/lifecycle/NodeStatus.h"
 #include "inet/linklayer/common/InterfaceTag_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
@@ -45,6 +46,7 @@ void Ieee80211MgmtBase::receiveSignal(cComponent *source, simsignal_t signalID, 
 
     if (signalID == modesetChangedSignal) {
         modeSet = check_and_cast<physicallayer::Ieee80211ModeSet *>(obj);
+        mib->updateLocalHtCapabilities(modeSet);
         supportedRates = Ieee80211SupportedRatesElement();
         extendedSupportedRates = Ieee80211ExtendedSupportedRatesElement();
         int rateIndex = 0;
@@ -71,6 +73,18 @@ void Ieee80211MgmtBase::receiveSignal(cComponent *source, simsignal_t signalID, 
         supportedRates.numRates = rateIndex;
         extendedSupportedRates.numRates = extendedRateIndex;
     }
+}
+
+void Ieee80211MgmtBase::addHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame) const
+{
+    if (mib->isHtOperationSupported())
+        setHtCapabilities(frame, mib->localHtCapabilities);
+}
+
+void Ieee80211MgmtBase::addHtOperation(const Ptr<Ieee80211MgmtFrame>& frame) const
+{
+    if (mib->isHtOperationSupported())
+        setHtOperation(frame, mib->htOperation);
 }
 
 void Ieee80211MgmtBase::handleMessageWhenUp(cMessage *msg)
@@ -178,6 +192,7 @@ void Ieee80211MgmtBase::start()
 
 void Ieee80211MgmtBase::stop()
 {
+    mib->clearPeerHtCapabilities();
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h
@@ -36,6 +36,7 @@ class INET_API Ieee80211MgmtBase : public OperationalBase, public cListener
     NetworkInterface *myIface = nullptr;
     physicallayer::Ieee80211ModeSet *modeSet = nullptr;
     Ieee80211SupportedRatesElement supportedRates;
+    Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
 
     // statistics
     long numMgmtFramesReceived;
@@ -60,6 +61,25 @@ class INET_API Ieee80211MgmtBase : public OperationalBase, public cListener
 
     /** Utility method to dispose of an unhandled frame */
     virtual void dropManagementFrame(Packet *frame);
+
+    /** Populates the primary and (when needed) Extended Supported Rates elements. */
+    template<typename Frame>
+    void setSupportedRateElements(const Ptr<Frame>& frame) const
+    {
+        frame->setSupportedRates(supportedRates);
+        frame->setExtendedSupportedRatesPresent(extendedSupportedRates.numRates > 0);
+        frame->setExtendedSupportedRates(extendedSupportedRates);
+    }
+
+    /** Returns the encoded length of the primary and optional Extended Supported Rates elements. */
+    template<typename Frame>
+    B getSupportedRateElementsLength(const Ptr<Frame>& frame) const
+    {
+        B length = B(2 + frame->getSupportedRates().numRates);
+        if (frame->getExtendedSupportedRatesPresent())
+            length += B(2 + frame->getExtendedSupportedRates().numRates);
+        return length;
+    }
 
     /** Dispatch to frame processing methods according to frame type */
     virtual void processFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& header);
@@ -99,4 +119,3 @@ class INET_API Ieee80211MgmtBase : public OperationalBase, public cListener
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h
@@ -81,6 +81,10 @@ class INET_API Ieee80211MgmtBase : public OperationalBase, public cListener
         return length;
     }
 
+    /** Adds the local HT advertisement to a frame when the authoritative PHY profile supports HT operation. */
+    virtual void addHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame) const;
+    virtual void addHtOperation(const Ptr<Ieee80211MgmtFrame>& frame) const;
+
     /** Dispatch to frame processing methods according to frame type */
     virtual void processFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& header);
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame.msg
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame.msg
@@ -127,6 +127,32 @@ struct Ieee80211ExtendedSupportedRatesElement
     bool basicRate[255]; // BSS membership/basic-rate bit
 }
 
+// IEEE Std 802.11-2024, 9.4.2.54: modeled fields in the fixed 26-octet HT Capabilities body.
+struct Ieee80211HtCapabilitiesElement
+{
+    bool ldpc;
+    bool supportedChannelWidth40Mhz;
+    bool greenfield;
+    bool shortGi20;
+    bool shortGi40;
+    short maxAmpduLengthExponent;
+    bool rxMcsSupported[77];
+    bool txMcsSetDefined;
+    bool txRxMcsSetNotEqual;
+    short txMaxNss;
+    bool txUnequalModulation;
+}
+
+// IEEE Std 802.11-2024, 9.4.2.55: modeled fields in the fixed 22-octet HT Operation body.
+struct Ieee80211HtOperationElement
+{
+    short primaryChannel;
+    short secondaryChannelOffset;
+    bool staChannelWidth40Mhz;
+    short protectionMode;
+    bool basicMcsSupported[77];
+}
+
 //
 // Frame body base class used to hide various frame body types
 //
@@ -134,6 +160,10 @@ class Ieee80211MgmtFrame extends FieldsChunk
 {
     bool extendedSupportedRatesPresent;
     Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
+    bool htCapabilitiesPresent;
+    Ieee80211HtCapabilitiesElement htCapabilities;
+    bool htOperationPresent;
+    Ieee80211HtOperationElement htOperation;
 }
 
 //

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame.msg
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame.msg
@@ -114,8 +114,9 @@ enum Ieee80211HwmpCode
 //
 struct Ieee80211SupportedRatesElement
 {
-    short numRates; // number of rates (max 8)
+    short numRates; // number of rates (1..8)
     double rate[8]; // in Mbit/s; should be multiple of 500 kbit/s
+    bool basicRate[8]; // BSS membership/basic-rate bit
 }
 
 //

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame.msg
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame.msg
@@ -119,11 +119,21 @@ struct Ieee80211SupportedRatesElement
     bool basicRate[8]; // BSS membership/basic-rate bit
 }
 
+// IEEE Std 802.11-2024, 9.4.2.11: overflow of Supported Rates.
+struct Ieee80211ExtendedSupportedRatesElement
+{
+    short numRates; // number of rates (1..255)
+    double rate[255]; // in Mbit/s; should be multiple of 500 kbit/s
+    bool basicRate[255]; // BSS membership/basic-rate bit
+}
+
 //
 // Frame body base class used to hide various frame body types
 //
 class Ieee80211MgmtFrame extends FieldsChunk
 {
+    bool extendedSupportedRatesPresent;
+    Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
 }
 
 //

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -28,7 +28,9 @@ Register_Serializer(Ieee80211ReassociationRequestFrame, Ieee80211TypedMgmtFrameS
 Register_Serializer(Ieee80211ReassociationResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationResponseFrame>);
 
 static constexpr uint8_t SUPPORTED_RATES_ELEMENT_ID = 1;
+static constexpr uint8_t EXTENDED_SUPPORTED_RATES_ELEMENT_ID = 50;
 static constexpr uint8_t MAX_SUPPORTED_RATES = 8;
+static constexpr uint16_t MAX_EXTENDED_SUPPORTED_RATES = 255;
 static constexpr double SUPPORTED_RATE_UNIT = 0.5;
 static constexpr double MAX_SUPPORTED_RATE_UNITS = 127;
 
@@ -38,6 +40,14 @@ static void validateSupportedRatesCount(int numRates)
     // one to eight octets.
     if (numRates < 1 || numRates > MAX_SUPPORTED_RATES)
         throw cRuntimeError("Malformed Supported Rates element length: %d", numRates);
+}
+
+static void validateExtendedSupportedRatesCount(int numRates)
+{
+    // IEEE Std 802.11-2024, 9.4.2.11: Extended Supported Rates has one to
+    // 255 octets when it is present.
+    if (numRates < 1 || numRates > MAX_EXTENDED_SUPPORTED_RATES)
+        throw cRuntimeError("Malformed Extended Supported Rates element length: %d", numRates);
 }
 
 static uint8_t encodeSupportedRate(double rate, bool basicRate)
@@ -59,6 +69,26 @@ static void writeSupportedRatesElement(MemoryOutputStream& stream, const Ieee802
     stream.writeByte(supportedRates.numRates);
     for (int i = 0; i < supportedRates.numRates; i++)
         stream.writeByte(encodeSupportedRate(supportedRates.rate[i], supportedRates.basicRate[i]));
+}
+
+static void writeExtendedSupportedRatesElement(MemoryOutputStream& stream, const Ieee80211ExtendedSupportedRatesElement& supportedRates)
+{
+    validateExtendedSupportedRatesCount(supportedRates.numRates);
+    stream.writeByte(EXTENDED_SUPPORTED_RATES_ELEMENT_ID);
+    stream.writeByte(supportedRates.numRates);
+    for (int i = 0; i < supportedRates.numRates; i++)
+        stream.writeByte(encodeSupportedRate(supportedRates.rate[i], supportedRates.basicRate[i]));
+}
+
+template<typename Frame>
+static void writeSupportedRateElements(MemoryOutputStream& stream, const Ptr<const Frame>& frame)
+{
+    writeSupportedRatesElement(stream, frame->getSupportedRates());
+    const auto& extendedSupportedRates = frame->getExtendedSupportedRates();
+    if (frame->getExtendedSupportedRatesPresent())
+        writeExtendedSupportedRatesElement(stream, extendedSupportedRates);
+    else if (extendedSupportedRates.numRates != 0)
+        throw cRuntimeError("Extended Supported Rates value is present without its presence flag");
 }
 
 static Ieee80211SupportedRatesElement readSupportedRatesElement(MemoryInputStream& stream)
@@ -83,6 +113,63 @@ static Ieee80211SupportedRatesElement readSupportedRatesElement(MemoryInputStrea
     return supportedRates;
 }
 
+static Ieee80211ExtendedSupportedRatesElement readExtendedSupportedRatesElement(MemoryInputStream& stream, int length, const Ptr<Ieee80211MgmtFrame>& frame)
+{
+    if (frame->getExtendedSupportedRatesPresent())
+        throw cRuntimeError("Duplicate Extended Supported Rates element");
+    validateExtendedSupportedRatesCount(length);
+    if (stream.getRemainingLength() < B(length))
+        throw cRuntimeError("Malformed Extended Supported Rates element: length=%d remaining=%" PRId64,
+                length, stream.getRemainingLength().get<B>());
+    Ieee80211ExtendedSupportedRatesElement supportedRates;
+    supportedRates.numRates = length;
+    for (int i = 0; i < length; i++) {
+        const uint8_t encodedRate = stream.readByte();
+        if ((encodedRate & 0x7F) == 0)
+            throw cRuntimeError("Malformed Extended Supported Rates element: zero rate at index %d", i);
+        supportedRates.basicRate[i] = (encodedRate & 0x80) != 0;
+        supportedRates.rate[i] = (double)(encodedRate & 0x7F) * SUPPORTED_RATE_UNIT;
+    }
+    frame->setExtendedSupportedRatesPresent(true);
+    frame->setExtendedSupportedRates(supportedRates);
+    return supportedRates;
+}
+
+enum HtElementPresence : unsigned int {
+    HT_ELEMENT_NONE = 0,
+    EXTENDED_SUPPORTED_RATES_ALLOWED = 4,
+};
+
+static void writeHtElements(MemoryOutputStream& stream, const Ptr<const Ieee80211MgmtFrame>& frame, unsigned int allowedElements)
+{
+    if (!(allowedElements & EXTENDED_SUPPORTED_RATES_ALLOWED) && frame->getExtendedSupportedRatesPresent())
+        throw cRuntimeError("Extended Supported Rates element is not allowed in this management frame subtype");
+}
+
+static void readHtElements(MemoryInputStream& stream, const Ptr<Ieee80211MgmtFrame>& frame, unsigned int allowedElements)
+{
+    while (stream.getRemainingLength() != b(0)) {
+        if (stream.getRemainingLength() < B(2))
+            throw cRuntimeError("Malformed IEEE 802.11 management element header");
+        int elementId = stream.readByte();
+        int length = stream.readByte();
+        if (stream.getRemainingLength() < B(length))
+            throw cRuntimeError("Malformed IEEE 802.11 management element: id=%d length=%d remaining=%" PRId64,
+                    elementId, length, stream.getRemainingLength().get<B>());
+        if (elementId == SUPPORTED_RATES_ELEMENT_ID) {
+            throw cRuntimeError("Duplicate Supported Rates element");
+        }
+        else if (elementId == EXTENDED_SUPPORTED_RATES_ELEMENT_ID) {
+            if (!(allowedElements & EXTENDED_SUPPORTED_RATES_ALLOWED))
+                throw cRuntimeError("Extended Supported Rates element is not allowed in this management frame subtype");
+            readExtendedSupportedRatesElement(stream, length, frame);
+        }
+        else
+            for (int i = 0; i < length; i++)
+                stream.readByte();
+    }
+}
+
 void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const
 {
     if (auto authenticationFrame = dynamicPtrCast<const Ieee80211AuthenticationFrame>(chunk)) {
@@ -93,16 +180,19 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeUint16Be(authenticationFrame->getSequenceNumber());
         // 3    Status code                                 The status code information is reserved in certain Authentication frames as defined in Table 7-17.
         stream.writeUint16Be(authenticationFrame->getStatusCode());
+        writeHtElements(stream, authenticationFrame, HT_ELEMENT_NONE);
         // 4    Challenge text                              The challenge text information is present only in certain Authentication frames as defined in Table 7-17.
         // Last Vendor Specific                             One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
     }
     else if (auto deauthenticationFrame = dynamicPtrCast<const Ieee80211DeauthenticationFrame>(chunk)) {
 //        type = ST_DEAUTHENTICATION;
         stream.writeUint16Be(deauthenticationFrame->getReasonCode());
+        writeHtElements(stream, deauthenticationFrame, HT_ELEMENT_NONE);
     }
     else if (auto disassociationFrame = dynamicPtrCast<const Ieee80211DisassociationFrame>(chunk)) {
 //        type = ST_DISASSOCIATION;
         stream.writeUint16Be(disassociationFrame->getReasonCode());
+        writeHtElements(stream, disassociationFrame, HT_ELEMENT_NONE);
     }
     else if (auto probeRequestFrame = dynamicPtrCast<const Ieee80211ProbeRequestFrame>(chunk)) {
 //        type = ST_PROBEREQUEST;
@@ -113,7 +203,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 2    Supported rates
-        writeSupportedRatesElement(stream, probeRequestFrame->getSupportedRates());
+        writeSupportedRateElements(stream, probeRequestFrame);
+        writeHtElements(stream, probeRequestFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 3    Request information         May be included if dot11MultiDomainCapabilityEnabled is true.
         // 4    Extended Supported Rates    The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // Last Vendor Specific             One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -131,7 +222,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 4    Supported rates
-        writeSupportedRatesElement(stream, associationRequestFrame->getSupportedRates());
+        writeSupportedRateElements(stream, associationRequestFrame);
+        writeHtElements(stream, associationRequestFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    Power Capability           The Power Capability element shall be present if dot11SpectrumManagementRequired is true.
         // 7    Supported Channel          The Supported Channels element shall be present if dot11SpectrumManagementRequired is true.
@@ -155,7 +247,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5    Supported rates
-        writeSupportedRatesElement(stream, reassociationRequestFrame->getSupportedRates());
+        writeSupportedRateElements(stream, reassociationRequestFrame);
+        writeHtElements(stream, reassociationRequestFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 6    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 7    Power Capability           The Power Capability element shall be present if dot11SpectrumManagementRequired is true.
         // 8    Supported Channels         The Supported Channels element shall be present if dot11SpectrumManagementRequired is true.
@@ -172,7 +265,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 3    AID
         stream.writeUint16Be(associationResponseFrame->getAid());
         // 4    Supported rates
-        writeSupportedRatesElement(stream, associationResponseFrame->getSupportedRates());
+        writeSupportedRateElements(stream, associationResponseFrame);
+        writeHtElements(stream, associationResponseFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -186,7 +280,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 3    AID
         stream.writeUint16Be(reassociationResponseFrame->getAid());
         // 4    Supported rates
-        writeSupportedRatesElement(stream, reassociationResponseFrame->getSupportedRates());
+        writeSupportedRateElements(stream, reassociationResponseFrame);
+        writeHtElements(stream, reassociationResponseFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -206,7 +301,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5    Supported rates
-        writeSupportedRatesElement(stream, beaconFrame->getSupportedRates());
+        writeSupportedRateElements(stream, beaconFrame);
+        writeHtElements(stream, beaconFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 6    Frequency-Hopping (FH) Parameter Set   The FH Parameter Set information element is present within Beacon frames generated by STAs using FH PHYs.
         // 7    DS Parameter Set                       The DS Parameter Set information element is present within Beacon frames generated by STAs using Clause 15, Clause 18, and Clause 19 PHYs.
         // 8    CF Parameter Set                       The CF Parameter Set information element is present only within Beacon frames generated by APs supporting a PCF.
@@ -243,7 +339,8 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5      Supported rates
-        writeSupportedRatesElement(stream, probeResponseFrame->getSupportedRates());
+        writeSupportedRateElements(stream, probeResponseFrame);
+        writeHtElements(stream, probeResponseFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 6      FH Parameter Set                The FH Parameter Set information element is present within Probe Response frames generated by STAs using FH PHYs.
         // 7      DS Parameter Set                The DS Parameter Set information element is present within Probe Response frames generated by STAs using Clause 15, Clause 18, and Clause 19 PHYs.
         // 8      CF Parameter Set                The CF Parameter Set information element is present only within Probe Response frames generated by APs supporting a PCF.
@@ -290,6 +387,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             stream.readUint16Be();
             frame->setSequenceNumber(stream.readUint16Be());
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
+            readHtElements(stream, frame, HT_ELEMENT_NONE);
             return frame;
         }
 
@@ -297,6 +395,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
         {
             auto frame = makeShared<Ieee80211DeauthenticationFrame>();
             frame->setReasonCode((Ieee80211ReasonCode)stream.readUint16Be());
+            readHtElements(stream, frame, HT_ELEMENT_NONE);
             return frame;
         }
 
@@ -304,6 +403,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
         {
             auto frame = makeShared<Ieee80211DisassociationFrame>();
             frame->setReasonCode((Ieee80211ReasonCode)stream.readUint16Be());
+            readHtElements(stream, frame, HT_ELEMENT_NONE);
             return frame;
         }
 
@@ -319,6 +419,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -337,6 +438,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -356,6 +458,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -367,6 +470,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setAid(stream.readUint16Be());
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -378,6 +482,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setAid(stream.readUint16Be());
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -399,6 +504,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -420,6 +526,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
+            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -14,16 +14,16 @@ namespace inet {
 
 namespace ieee80211 {
 
-Register_Serializer(Ieee80211AssociationRequestFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211AssociationResponseFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211AuthenticationFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211BeaconFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211DeauthenticationFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211DisassociationFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211ProbeRequestFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211ProbeResponseFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211ReassociationRequestFrame, Ieee80211MgmtFrameSerializer);
-Register_Serializer(Ieee80211ReassociationResponseFrame, Ieee80211MgmtFrameSerializer);
+Register_Serializer(Ieee80211AssociationRequestFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211AssociationRequestFrame>);
+Register_Serializer(Ieee80211AssociationResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211AssociationResponseFrame>);
+Register_Serializer(Ieee80211AuthenticationFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211AuthenticationFrame>);
+Register_Serializer(Ieee80211BeaconFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211BeaconFrame>);
+Register_Serializer(Ieee80211DeauthenticationFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211DeauthenticationFrame>);
+Register_Serializer(Ieee80211DisassociationFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211DisassociationFrame>);
+Register_Serializer(Ieee80211ProbeRequestFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ProbeRequestFrame>);
+Register_Serializer(Ieee80211ProbeResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ProbeResponseFrame>);
+Register_Serializer(Ieee80211ReassociationRequestFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationRequestFrame>);
+Register_Serializer(Ieee80211ReassociationResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationResponseFrame>);
 
 void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const
 {
@@ -67,7 +67,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 4    Extended Supported Rates    The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // Last Vendor Specific             One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
     }
-    else if (auto associationRequestFrame = dynamicPtrCast<const Ieee80211AssociationRequestFrame>(chunk)) {
+    else if (auto associationRequestFrame = dynamicPtrCast<const Ieee80211AssociationRequestFrame>(chunk); associationRequestFrame && !dynamicPtrCast<const Ieee80211ReassociationRequestFrame>(chunk)) {
 //        type = ST_ASSOCIATIONREQUEST;
         // 1    Capability
         stream.writeUint16Be(0); // FIXME
@@ -126,7 +126,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 10   QoS Capability             The QoS Capability element is present when dot11QosOption- Implemented is true.
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
     }
-    else if (auto associationResponseFrame = dynamicPtrCast<const Ieee80211AssociationResponseFrame>(chunk)) {
+    else if (auto associationResponseFrame = dynamicPtrCast<const Ieee80211AssociationResponseFrame>(chunk); associationResponseFrame && !dynamicPtrCast<const Ieee80211ReassociationResponseFrame>(chunk)) {
 //        type = ST_ASSOCIATIONRESPONSE;
         // 1    Capability
         stream.writeUint16Be(0); // FIXME
@@ -166,7 +166,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
     }
-    else if (auto beaconFrame = dynamicPtrCast<const Ieee80211BeaconFrame>(chunk)) {
+    else if (auto beaconFrame = dynamicPtrCast<const Ieee80211BeaconFrame>(chunk); beaconFrame && !dynamicPtrCast<const Ieee80211ProbeResponseFrame>(chunk)) {
 //        type = ST_BEACON;
         // 1    Timestamp
         stream.writeUint64Be(simTime().raw()); // FIXME
@@ -255,9 +255,22 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         throw cRuntimeError("Cannot serialize frame");
 }
 
-const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserialize(MemoryInputStream& stream) const
+const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStream& stream, const std::type_info& typeInfo)
 {
-    switch (0) { // TODO receive and dispatch on type_info parameter
+    int frameType = -1;
+    if (typeInfo == typeid(Ieee80211AuthenticationFrame)) frameType = 0xB0;
+    else if (typeInfo == typeid(Ieee80211DeauthenticationFrame)) frameType = 0xC0;
+    else if (typeInfo == typeid(Ieee80211DisassociationFrame)) frameType = 0xA0;
+    else if (typeInfo == typeid(Ieee80211ProbeRequestFrame)) frameType = 0x40;
+    else if (typeInfo == typeid(Ieee80211AssociationRequestFrame)) frameType = 0x00;
+    else if (typeInfo == typeid(Ieee80211ReassociationRequestFrame)) frameType = 0x02;
+    else if (typeInfo == typeid(Ieee80211AssociationResponseFrame)) frameType = 0x01;
+    else if (typeInfo == typeid(Ieee80211ReassociationResponseFrame)) frameType = 0x03;
+    else if (typeInfo == typeid(Ieee80211BeaconFrame)) frameType = 0x80;
+    else if (typeInfo == typeid(Ieee80211ProbeResponseFrame)) frameType = 0x50;
+    else throw cRuntimeError("Unsupported IEEE 802.11 management frame type: %s", typeInfo.name());
+
+    switch (frameType) {
         case 0xB0: // ST_AUTHENTICATION
         {
             auto frame = makeShared<Ieee80211AuthenticationFrame>();
@@ -304,6 +317,9 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserialize(MemoryInputStream& st
         case 0x00: // ST_ASSOCIATIONREQUEST
         {
             auto frame = makeShared<Ieee80211AssociationRequestFrame>();
+
+            stream.readUint16Be();
+            stream.readUint16Be();
 
             char SSID[256];
             stream.readByte();
@@ -437,4 +453,3 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserialize(MemoryInputStream& st
 } // namespace ieee80211
 
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -37,6 +37,9 @@ static constexpr uint8_t MAX_SUPPORTED_RATES = 8;
 static constexpr uint16_t MAX_EXTENDED_SUPPORTED_RATES = 255;
 static constexpr double SUPPORTED_RATE_UNIT = 0.5;
 static constexpr double MAX_SUPPORTED_RATE_UNITS = 127;
+static constexpr uint16_t ASSOCIATION_ID_MARKER = 0xC000;
+static constexpr uint16_t ASSOCIATION_ID_MASK = 0x3FFF;
+static constexpr int MAX_LOGICAL_ASSOCIATION_ID = 2007;
 
 static void validateSupportedRatesCount(int numRates)
 {
@@ -336,6 +339,35 @@ static void readHtElements(MemoryInputStream& stream, const Ptr<Ieee80211MgmtFra
     }
 }
 
+static uint16_t encodeAssociationId(Ieee80211StatusCode statusCode, int aid)
+{
+    if (statusCode == SC_SUCCESSFUL) {
+        if (aid < 1 || aid > MAX_LOGICAL_ASSOCIATION_ID)
+            throw cRuntimeError("Malformed successful Association Response AID: %d", aid);
+        return ASSOCIATION_ID_MARKER | static_cast<uint16_t>(aid);
+    }
+    // This model uses zero for unsuccessful response AIDs. Keep that
+    // policy explicit at the wire boundary instead of accepting a stale ID.
+    if (aid != 0)
+        throw cRuntimeError("Malformed unsuccessful Association Response AID: %d", aid);
+    return 0;
+}
+
+static int decodeAssociationId(Ieee80211StatusCode statusCode, uint16_t wireAid)
+{
+    if (statusCode == SC_SUCCESSFUL) {
+        if ((wireAid & ASSOCIATION_ID_MARKER) != ASSOCIATION_ID_MARKER)
+            throw cRuntimeError("Malformed successful Association Response AID: missing marker 0xC000");
+        const int aid = wireAid & ASSOCIATION_ID_MASK;
+        if (aid < 1 || aid > MAX_LOGICAL_ASSOCIATION_ID)
+            throw cRuntimeError("Malformed successful Association Response AID: %d", aid);
+        return aid;
+    }
+    if (wireAid != 0)
+        throw cRuntimeError("Malformed unsuccessful Association Response AID: expected zero, got 0x%04x", wireAid);
+    return 0;
+}
+
 void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const
 {
     if (auto authenticationFrame = dynamicPtrCast<const Ieee80211AuthenticationFrame>(chunk)) {
@@ -429,7 +461,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 2    Status code
         stream.writeUint16Be(associationResponseFrame->getStatusCode());
         // 3    AID
-        stream.writeUint16Be(associationResponseFrame->getAid());
+        stream.writeUint16Be(encodeAssociationId(associationResponseFrame->getStatusCode(), associationResponseFrame->getAid()));
         // 4    Supported rates
         writeSupportedRateElements(stream, associationResponseFrame);
         writeHtElements(stream, associationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -444,7 +476,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 2    Status code
         stream.writeUint16Be(reassociationResponseFrame->getStatusCode());
         // 3    AID
-        stream.writeUint16Be(reassociationResponseFrame->getAid());
+        stream.writeUint16Be(encodeAssociationId(reassociationResponseFrame->getStatusCode(), reassociationResponseFrame->getAid()));
         // 4    Supported rates
         writeSupportedRateElements(stream, reassociationResponseFrame);
         writeHtElements(stream, reassociationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -633,7 +665,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             auto frame = makeShared<Ieee80211AssociationResponseFrame>();
             stream.readUint16Be();
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
-            frame->setAid(stream.readUint16Be());
+            frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Be()));
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
             readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -645,7 +677,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             auto frame = makeShared<Ieee80211ReassociationResponseFrame>();
             stream.readUint16Be();
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
-            frame->setAid(stream.readUint16Be());
+            frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Be()));
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
             readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -7,6 +7,8 @@
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.h"
 
+#include <cmath>
+
 #include "inet/common/packet/serializer/ChunkSerializerRegistry.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
 
@@ -24,6 +26,62 @@ Register_Serializer(Ieee80211ProbeRequestFrame, Ieee80211TypedMgmtFrameSerialize
 Register_Serializer(Ieee80211ProbeResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ProbeResponseFrame>);
 Register_Serializer(Ieee80211ReassociationRequestFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationRequestFrame>);
 Register_Serializer(Ieee80211ReassociationResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationResponseFrame>);
+
+static constexpr uint8_t SUPPORTED_RATES_ELEMENT_ID = 1;
+static constexpr uint8_t MAX_SUPPORTED_RATES = 8;
+static constexpr double SUPPORTED_RATE_UNIT = 0.5;
+static constexpr double MAX_SUPPORTED_RATE_UNITS = 127;
+
+static void validateSupportedRatesCount(int numRates)
+{
+    // IEEE Std 802.11-2024, 9.4.2.3: the Supported Rates field contains
+    // one to eight octets.
+    if (numRates < 1 || numRates > MAX_SUPPORTED_RATES)
+        throw cRuntimeError("Malformed Supported Rates element length: %d", numRates);
+}
+
+static uint8_t encodeSupportedRate(double rate, bool basicRate)
+{
+    const double rateUnits = std::ceil(rate / SUPPORTED_RATE_UNIT);
+    // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6: a legacy rate is
+    // represented in 500 kb/s units, rounded up when necessary, up to
+    // 63.5 Mb/s. Bit 7 identifies a basic rate.
+    if (!std::isfinite(rate) || rate <= 0 || !std::isfinite(rateUnits) ||
+            rateUnits < 1 || rateUnits > MAX_SUPPORTED_RATE_UNITS)
+        throw cRuntimeError("Unsupported Supported Rate value: %g Mb/s", rate);
+    return static_cast<uint8_t>(rateUnits) | (basicRate ? 0x80 : 0);
+}
+
+static void writeSupportedRatesElement(MemoryOutputStream& stream, const Ieee80211SupportedRatesElement& supportedRates)
+{
+    validateSupportedRatesCount(supportedRates.numRates);
+    stream.writeByte(SUPPORTED_RATES_ELEMENT_ID);
+    stream.writeByte(supportedRates.numRates);
+    for (int i = 0; i < supportedRates.numRates; i++)
+        stream.writeByte(encodeSupportedRate(supportedRates.rate[i], supportedRates.basicRate[i]));
+}
+
+static Ieee80211SupportedRatesElement readSupportedRatesElement(MemoryInputStream& stream)
+{
+    Ieee80211SupportedRatesElement supportedRates;
+    const uint8_t elementId = stream.readByte();
+    if (elementId != SUPPORTED_RATES_ELEMENT_ID)
+        throw cRuntimeError("Expected Supported Rates element, got element ID %d", elementId);
+    const uint8_t numRates = stream.readByte();
+    validateSupportedRatesCount(numRates);
+    if (stream.getRemainingLength() < B(numRates))
+        throw cRuntimeError("Malformed Supported Rates element: length=%d remaining=%" PRId64,
+                numRates, stream.getRemainingLength().get<B>());
+    supportedRates.numRates = numRates;
+    for (int i = 0; i < supportedRates.numRates; i++) {
+        const uint8_t encodedRate = stream.readByte();
+        if ((encodedRate & 0x7F) == 0)
+            throw cRuntimeError("Malformed Supported Rates element: zero rate at index %d", i);
+        supportedRates.basicRate[i] = (encodedRate & 0x80) != 0;
+        supportedRates.rate[i] = (double)(encodedRate & 0x7F) * SUPPORTED_RATE_UNIT;
+    }
+    return supportedRates;
+}
 
 void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const
 {
@@ -55,14 +113,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 2    Supported rates
-        const Ieee80211SupportedRatesElement& supportedRates = probeRequestFrame->getSupportedRates();
-        stream.writeByte(1);
-        stream.writeByte(supportedRates.numRates);
-        for (int i = 0; i < supportedRates.numRates; i++) {
-            uint8_t rate = ceil(supportedRates.rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, probeRequestFrame->getSupportedRates());
         // 3    Request information         May be included if dot11MultiDomainCapabilityEnabled is true.
         // 4    Extended Supported Rates    The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // Last Vendor Specific             One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -80,14 +131,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 4    Supported rates
-        const Ieee80211SupportedRatesElement& supportedRates = associationRequestFrame->getSupportedRates();
-        stream.writeByte(1);
-        stream.writeByte(supportedRates.numRates);
-        for (int i = 0; i < supportedRates.numRates; i++) {
-            uint8_t rate = ceil(supportedRates.rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, associationRequestFrame->getSupportedRates());
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    Power Capability           The Power Capability element shall be present if dot11SpectrumManagementRequired is true.
         // 7    Supported Channel          The Supported Channels element shall be present if dot11SpectrumManagementRequired is true.
@@ -111,14 +155,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5    Supported rates
-        const Ieee80211SupportedRatesElement& supportedRates = reassociationRequestFrame->getSupportedRates();
-        stream.writeByte(1);
-        stream.writeByte(supportedRates.numRates);
-        for (int i = 0; i < supportedRates.numRates; i++) {
-            uint8_t rate = ceil(supportedRates.rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, reassociationRequestFrame->getSupportedRates());
         // 6    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 7    Power Capability           The Power Capability element shall be present if dot11SpectrumManagementRequired is true.
         // 8    Supported Channels         The Supported Channels element shall be present if dot11SpectrumManagementRequired is true.
@@ -135,13 +172,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 3    AID
         stream.writeUint16Be(associationResponseFrame->getAid());
         // 4    Supported rates
-        stream.writeByte(1);
-        stream.writeByte(associationResponseFrame->getSupportedRates().numRates);
-        for (int i = 0; i < associationResponseFrame->getSupportedRates().numRates; i++) {
-            uint8_t rate = ceil(associationResponseFrame->getSupportedRates().rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, associationResponseFrame->getSupportedRates());
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -155,13 +186,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 3    AID
         stream.writeUint16Be(reassociationResponseFrame->getAid());
         // 4    Supported rates
-        stream.writeByte(1);
-        stream.writeByte(reassociationResponseFrame->getSupportedRates().numRates);
-        for (int i = 0; i < reassociationResponseFrame->getSupportedRates().numRates; i++) {
-            uint8_t rate = ceil(reassociationResponseFrame->getSupportedRates().rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, reassociationResponseFrame->getSupportedRates());
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -181,13 +206,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5    Supported rates
-        stream.writeByte(1);
-        stream.writeByte(beaconFrame->getSupportedRates().numRates);
-        for (int i = 0; i < beaconFrame->getSupportedRates().numRates; i++) {
-            uint8_t rate = ceil(beaconFrame->getSupportedRates().rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, beaconFrame->getSupportedRates());
         // 6    Frequency-Hopping (FH) Parameter Set   The FH Parameter Set information element is present within Beacon frames generated by STAs using FH PHYs.
         // 7    DS Parameter Set                       The DS Parameter Set information element is present within Beacon frames generated by STAs using Clause 15, Clause 18, and Clause 19 PHYs.
         // 8    CF Parameter Set                       The CF Parameter Set information element is present only within Beacon frames generated by APs supporting a PCF.
@@ -224,13 +243,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeByte(length);
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5      Supported rates
-        stream.writeByte(1);
-        stream.writeByte(probeResponseFrame->getSupportedRates().numRates);
-        for (int i = 0; i < probeResponseFrame->getSupportedRates().numRates; i++) {
-            uint8_t rate = ceil(probeResponseFrame->getSupportedRates().rate[i] / 0.5);
-            // rate |= 0x80 if rate contained in the BSSBasicRateSet parameter
-            stream.writeByte(rate);
-        }
+        writeSupportedRatesElement(stream, probeResponseFrame->getSupportedRates());
         // 6      FH Parameter Set                The FH Parameter Set information element is present within Probe Response frames generated by STAs using FH PHYs.
         // 7      DS Parameter Set                The DS Parameter Set information element is present within Probe Response frames generated by STAs using Clause 15, Clause 18, and Clause 19 PHYs.
         // 8      CF Parameter Set                The CF Parameter Set information element is present only within Probe Response frames generated by APs supporting a PCF.
@@ -305,12 +318,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             SSID[length] = '\0';
             frame->setSSID(SSID);
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 
@@ -328,12 +336,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             SSID[length] = '\0';
             frame->setSSID(SSID);
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 
@@ -352,12 +355,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             SSID[length] = '\0';
             frame->setSSID(SSID);
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 
@@ -368,12 +366,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
             frame->setAid(stream.readUint16Be());
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 
@@ -384,12 +377,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
             frame->setAid(stream.readUint16Be());
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 
@@ -410,12 +398,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             SSID[length] = '\0';
             frame->setSSID(SSID);
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 
@@ -436,12 +419,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             SSID[length] = '\0';
             frame->setSSID(SSID);
 
-            Ieee80211SupportedRatesElement supRat;
-            stream.readByte();
-            supRat.numRates = stream.readByte();
-            for (int i = 0; i < supRat.numRates; i++)
-                supRat.rate[i] = (double)(stream.readByte() & 0x7F) * 0.5;
-            frame->setSupportedRates(supRat);
+            frame->setSupportedRates(readSupportedRatesElement(stream));
             return frame;
         }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -461,7 +461,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 2    Status code
         stream.writeUint16Be(associationResponseFrame->getStatusCode());
         // 3    AID
-        stream.writeUint16Be(encodeAssociationId(associationResponseFrame->getStatusCode(), associationResponseFrame->getAid()));
+        stream.writeUint16Le(encodeAssociationId(associationResponseFrame->getStatusCode(), associationResponseFrame->getAid()));
         // 4    Supported rates
         writeSupportedRateElements(stream, associationResponseFrame);
         writeHtElements(stream, associationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -476,7 +476,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         // 2    Status code
         stream.writeUint16Be(reassociationResponseFrame->getStatusCode());
         // 3    AID
-        stream.writeUint16Be(encodeAssociationId(reassociationResponseFrame->getStatusCode(), reassociationResponseFrame->getAid()));
+        stream.writeUint16Le(encodeAssociationId(reassociationResponseFrame->getStatusCode(), reassociationResponseFrame->getAid()));
         // 4    Supported rates
         writeSupportedRateElements(stream, reassociationResponseFrame);
         writeHtElements(stream, reassociationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -665,7 +665,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             auto frame = makeShared<Ieee80211AssociationResponseFrame>();
             stream.readUint16Be();
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
-            frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Be()));
+            frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Le()));
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
             readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -677,7 +677,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             auto frame = makeShared<Ieee80211ReassociationResponseFrame>();
             stream.readUint16Be();
             frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Be());
-            frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Be()));
+            frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Le()));
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
             readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -7,7 +7,9 @@
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.h"
 
+#include <algorithm>
 #include <cmath>
+#include <vector>
 
 #include "inet/common/packet/serializer/ChunkSerializerRegistry.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
@@ -27,6 +29,8 @@ Register_Serializer(Ieee80211ProbeResponseFrame, Ieee80211TypedMgmtFrameSerializ
 Register_Serializer(Ieee80211ReassociationRequestFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationRequestFrame>);
 Register_Serializer(Ieee80211ReassociationResponseFrame, Ieee80211TypedMgmtFrameSerializer<Ieee80211ReassociationResponseFrame>);
 
+static constexpr uint8_t HT_CAPABILITIES_ELEMENT_ID = 45;
+static constexpr uint8_t HT_OPERATION_ELEMENT_ID = 61;
 static constexpr uint8_t SUPPORTED_RATES_ELEMENT_ID = 1;
 static constexpr uint8_t EXTENDED_SUPPORTED_RATES_ELEMENT_ID = 50;
 static constexpr uint8_t MAX_SUPPORTED_RATES = 8;
@@ -135,8 +139,91 @@ static Ieee80211ExtendedSupportedRatesElement readExtendedSupportedRatesElement(
     return supportedRates;
 }
 
+static bool getBit(const std::vector<uint8_t>& bytes, int bit)
+{
+    return (bytes[bit / 8] & (1 << (bit % 8))) != 0;
+}
+
+static void setBit(std::vector<uint8_t>& bytes, int bit)
+{
+    bytes[bit / 8] |= 1 << (bit % 8);
+}
+
+static void writeHtCapabilitiesElement(MemoryOutputStream& stream, const Ieee80211HtCapabilitiesElement& capabilities)
+{
+    // IEEE Std 802.11-2024, 9.4.2.54 and Tables 9-224 to 9-226.
+    if (capabilities.maxAmpduLengthExponent < 0 || capabilities.maxAmpduLengthExponent > 3)
+        throw cRuntimeError("Malformed Maximum A-MPDU Length Exponent: %d", capabilities.maxAmpduLengthExponent);
+    if (!capabilities.txMcsSetDefined && (capabilities.txRxMcsSetNotEqual || capabilities.txMaxNss != 0 || capabilities.txUnequalModulation))
+        throw cRuntimeError("Malformed undefined HT Tx MCS Set");
+    if (capabilities.txMcsSetDefined && !capabilities.txRxMcsSetNotEqual &&
+            (capabilities.txMaxNss != 0 || capabilities.txUnequalModulation))
+        throw cRuntimeError("Malformed equal HT Tx/Rx MCS Set");
+    if (capabilities.txMcsSetDefined && capabilities.txRxMcsSetNotEqual &&
+            (capabilities.txMaxNss < 1 || capabilities.txMaxNss > 4))
+        throw cRuntimeError("Malformed HT Tx Maximum Number of Spatial Streams: %d", capabilities.txMaxNss);
+
+    stream.writeByte(HT_CAPABILITIES_ELEMENT_ID);
+    stream.writeByte(26);
+    // SM Power Save is unmodeled: Table 9-224 requires value 3 for disabled/not supported.
+    uint16_t information = (capabilities.ldpc ? 1 : 0) |
+            (capabilities.supportedChannelWidth40Mhz ? 1 << 1 : 0) |
+            (3 << 2) |
+            (capabilities.greenfield ? 1 << 4 : 0) |
+            (capabilities.shortGi20 ? 1 << 5 : 0) |
+            (capabilities.shortGi40 ? 1 << 6 : 0);
+    stream.writeUint16Le(information);
+    stream.writeByte(capabilities.maxAmpduLengthExponent);
+
+    std::vector<uint8_t> mcs(16, 0);
+    for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++)
+        if (capabilities.rxMcsSupported[mcsIndex])
+            setBit(mcs, mcsIndex);
+    if (capabilities.txMcsSetDefined)
+        setBit(mcs, 96);
+    if (capabilities.txMcsSetDefined && capabilities.txRxMcsSetNotEqual) {
+        setBit(mcs, 97);
+        if ((capabilities.txMaxNss - 1) & 1)
+            setBit(mcs, 98);
+        if ((capabilities.txMaxNss - 1) & 2)
+            setBit(mcs, 99);
+        if (capabilities.txUnequalModulation)
+            setBit(mcs, 100);
+    }
+    for (auto byte : mcs)
+        stream.writeByte(byte);
+    stream.writeUint16Le(0); // HT Extended Capabilities: modeled subset advertises none.
+    stream.writeUint32Le(0); // Transmit Beamforming Capabilities: unmodeled.
+    stream.writeByte(0); // ASEL Capabilities: unmodeled.
+}
+
+static void writeHtOperationElement(MemoryOutputStream& stream, const Ieee80211HtOperationElement& operation)
+{
+    // IEEE Std 802.11-2024, 9.4.2.55 and Table 9-230.
+    if (operation.primaryChannel < 0 || operation.primaryChannel > 255 ||
+            operation.secondaryChannelOffset < 0 || operation.secondaryChannelOffset > 3 || operation.secondaryChannelOffset == 2 ||
+            operation.protectionMode < 0 || operation.protectionMode > 3)
+        throw cRuntimeError("Malformed HT Operation element fields");
+    stream.writeByte(HT_OPERATION_ELEMENT_ID);
+    stream.writeByte(22);
+    stream.writeByte(operation.primaryChannel);
+    uint64_t information = (operation.secondaryChannelOffset & 3) |
+            (operation.staChannelWidth40Mhz ? uint64_t(1) << 2 : 0) |
+            (uint64_t(operation.protectionMode) << 8);
+    for (int i = 0; i < 5; i++)
+        stream.writeByte((information >> (i * 8)) & 0xff);
+    std::vector<uint8_t> basicMcs(16, 0);
+    for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++)
+        if (operation.basicMcsSupported[mcsIndex])
+            setBit(basicMcs, mcsIndex);
+    for (auto byte : basicMcs)
+        stream.writeByte(byte);
+}
+
 enum HtElementPresence : unsigned int {
     HT_ELEMENT_NONE = 0,
+    HT_CAPABILITIES_ALLOWED = 1,
+    HT_OPERATION_ALLOWED = 2,
     EXTENDED_SUPPORTED_RATES_ALLOWED = 4,
 };
 
@@ -144,6 +231,75 @@ static void writeHtElements(MemoryOutputStream& stream, const Ptr<const Ieee8021
 {
     if (!(allowedElements & EXTENDED_SUPPORTED_RATES_ALLOWED) && frame->getExtendedSupportedRatesPresent())
         throw cRuntimeError("Extended Supported Rates element is not allowed in this management frame subtype");
+    if (!(allowedElements & HT_CAPABILITIES_ALLOWED) && frame->getHtCapabilitiesPresent())
+        throw cRuntimeError("HT Capabilities element is not allowed in this management frame subtype");
+    if (!(allowedElements & HT_OPERATION_ALLOWED) && frame->getHtOperationPresent())
+        throw cRuntimeError("HT Operation element is not allowed in this management frame subtype");
+    if (frame->getHtCapabilitiesPresent())
+        writeHtCapabilitiesElement(stream, frame->getHtCapabilities());
+    if (frame->getHtOperationPresent())
+        writeHtOperationElement(stream, frame->getHtOperation());
+}
+
+static void readHtCapabilitiesElement(MemoryInputStream& stream, int length, const Ptr<Ieee80211MgmtFrame>& frame)
+{
+    if (length != 26)
+        throw cRuntimeError("Malformed HT Capabilities element length: %d", length);
+    if (frame->getHtCapabilitiesPresent())
+        throw cRuntimeError("Duplicate HT Capabilities element");
+    Ieee80211HtCapabilitiesElement capabilities;
+    uint16_t information = stream.readUint16Le();
+    capabilities.ldpc = information & 1;
+    capabilities.supportedChannelWidth40Mhz = information & (1 << 1);
+    capabilities.greenfield = information & (1 << 4);
+    capabilities.shortGi20 = information & (1 << 5);
+    capabilities.shortGi40 = information & (1 << 6);
+    capabilities.maxAmpduLengthExponent = stream.readByte() & 3;
+    std::vector<uint8_t> mcs(16);
+    for (auto& byte : mcs)
+        byte = stream.readByte();
+    for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++)
+        capabilities.rxMcsSupported[mcsIndex] = getBit(mcs, mcsIndex);
+    capabilities.txMcsSetDefined = getBit(mcs, 96);
+    capabilities.txRxMcsSetNotEqual = getBit(mcs, 97);
+    bool txNssBitsSet = getBit(mcs, 98) || getBit(mcs, 99);
+    bool txUnequalModulation = getBit(mcs, 100);
+    if (!capabilities.txMcsSetDefined && (capabilities.txRxMcsSetNotEqual || txNssBitsSet || txUnequalModulation))
+        throw cRuntimeError("Malformed undefined HT Tx MCS Set");
+    if (capabilities.txMcsSetDefined && !capabilities.txRxMcsSetNotEqual && (txNssBitsSet || txUnequalModulation))
+        throw cRuntimeError("Malformed equal HT Tx/Rx MCS Set");
+    capabilities.txMaxNss = capabilities.txRxMcsSetNotEqual ?
+            (getBit(mcs, 98) ? 1 : 0) + (getBit(mcs, 99) ? 2 : 0) + 1 : 0;
+    capabilities.txUnequalModulation = txUnequalModulation;
+    for (int i = 0; i < 7; i++)
+        stream.readByte();
+    frame->setHtCapabilitiesPresent(true);
+    frame->setHtCapabilities(capabilities);
+}
+
+static void readHtOperationElement(MemoryInputStream& stream, int length, const Ptr<Ieee80211MgmtFrame>& frame)
+{
+    if (length != 22)
+        throw cRuntimeError("Malformed HT Operation element length: %d", length);
+    if (frame->getHtOperationPresent())
+        throw cRuntimeError("Duplicate HT Operation element");
+    Ieee80211HtOperationElement operation;
+    operation.primaryChannel = stream.readByte();
+    uint64_t information = 0;
+    for (int i = 0; i < 5; i++)
+        information |= uint64_t(stream.readByte()) << (i * 8);
+    operation.secondaryChannelOffset = information & 3;
+    operation.staChannelWidth40Mhz = information & (1 << 2);
+    operation.protectionMode = (information >> 8) & 3;
+    std::vector<uint8_t> basicMcs(16);
+    for (auto& byte : basicMcs)
+        byte = stream.readByte();
+    for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++)
+        operation.basicMcsSupported[mcsIndex] = getBit(basicMcs, mcsIndex);
+    if (operation.secondaryChannelOffset == 2)
+        throw cRuntimeError("Malformed HT Operation element: reserved Secondary Channel Offset");
+    frame->setHtOperationPresent(true);
+    frame->setHtOperation(operation);
 }
 
 static void readHtElements(MemoryInputStream& stream, const Ptr<Ieee80211MgmtFrame>& frame, unsigned int allowedElements)
@@ -164,6 +320,16 @@ static void readHtElements(MemoryInputStream& stream, const Ptr<Ieee80211MgmtFra
                 throw cRuntimeError("Extended Supported Rates element is not allowed in this management frame subtype");
             readExtendedSupportedRatesElement(stream, length, frame);
         }
+        else if (elementId == HT_CAPABILITIES_ELEMENT_ID) {
+            if (!(allowedElements & HT_CAPABILITIES_ALLOWED))
+                throw cRuntimeError("HT Capabilities element is not allowed in this management frame subtype");
+            readHtCapabilitiesElement(stream, length, frame);
+        }
+        else if (elementId == HT_OPERATION_ELEMENT_ID) {
+            if (!(allowedElements & HT_OPERATION_ALLOWED))
+                throw cRuntimeError("HT Operation element is not allowed in this management frame subtype");
+            readHtOperationElement(stream, length, frame);
+        }
         else
             for (int i = 0; i < length; i++)
                 stream.readByte();
@@ -180,9 +346,9 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeUint16Be(authenticationFrame->getSequenceNumber());
         // 3    Status code                                 The status code information is reserved in certain Authentication frames as defined in Table 7-17.
         stream.writeUint16Be(authenticationFrame->getStatusCode());
-        writeHtElements(stream, authenticationFrame, HT_ELEMENT_NONE);
         // 4    Challenge text                              The challenge text information is present only in certain Authentication frames as defined in Table 7-17.
         // Last Vendor Specific                             One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
+        writeHtElements(stream, authenticationFrame, HT_ELEMENT_NONE);
     }
     else if (auto deauthenticationFrame = dynamicPtrCast<const Ieee80211DeauthenticationFrame>(chunk)) {
 //        type = ST_DEAUTHENTICATION;
@@ -204,7 +370,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 2    Supported rates
         writeSupportedRateElements(stream, probeRequestFrame);
-        writeHtElements(stream, probeRequestFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, probeRequestFrame, HT_CAPABILITIES_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 3    Request information         May be included if dot11MultiDomainCapabilityEnabled is true.
         // 4    Extended Supported Rates    The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // Last Vendor Specific             One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -223,7 +389,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 4    Supported rates
         writeSupportedRateElements(stream, associationRequestFrame);
-        writeHtElements(stream, associationRequestFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, associationRequestFrame, HT_CAPABILITIES_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    Power Capability           The Power Capability element shall be present if dot11SpectrumManagementRequired is true.
         // 7    Supported Channel          The Supported Channels element shall be present if dot11SpectrumManagementRequired is true.
@@ -248,7 +414,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5    Supported rates
         writeSupportedRateElements(stream, reassociationRequestFrame);
-        writeHtElements(stream, reassociationRequestFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, reassociationRequestFrame, HT_CAPABILITIES_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 6    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 7    Power Capability           The Power Capability element shall be present if dot11SpectrumManagementRequired is true.
         // 8    Supported Channels         The Supported Channels element shall be present if dot11SpectrumManagementRequired is true.
@@ -266,7 +432,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeUint16Be(associationResponseFrame->getAid());
         // 4    Supported rates
         writeSupportedRateElements(stream, associationResponseFrame);
-        writeHtElements(stream, associationResponseFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, associationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -281,7 +447,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeUint16Be(reassociationResponseFrame->getAid());
         // 4    Supported rates
         writeSupportedRateElements(stream, reassociationResponseFrame);
-        writeHtElements(stream, reassociationResponseFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, reassociationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 5    Extended Supported Rates   The Extended Supported Rates element is present whenever there are more than eight supported rates, and it is optional otherwise.
         // 6    EDCA Parameter Set
         // Last Vendor Specific            One or more vendor-specific information elements may appear in this frame. This information element follows all other information elements.
@@ -302,7 +468,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5    Supported rates
         writeSupportedRateElements(stream, beaconFrame);
-        writeHtElements(stream, beaconFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, beaconFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 6    Frequency-Hopping (FH) Parameter Set   The FH Parameter Set information element is present within Beacon frames generated by STAs using FH PHYs.
         // 7    DS Parameter Set                       The DS Parameter Set information element is present within Beacon frames generated by STAs using Clause 15, Clause 18, and Clause 19 PHYs.
         // 8    CF Parameter Set                       The CF Parameter Set information element is present only within Beacon frames generated by APs supporting a PCF.
@@ -340,7 +506,7 @@ void Ieee80211MgmtFrameSerializer::serialize(MemoryOutputStream& stream, const P
         stream.writeBytes((uint8_t *)SSID, B(length));
         // 5      Supported rates
         writeSupportedRateElements(stream, probeResponseFrame);
-        writeHtElements(stream, probeResponseFrame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+        writeHtElements(stream, probeResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
         // 6      FH Parameter Set                The FH Parameter Set information element is present within Probe Response frames generated by STAs using FH PHYs.
         // 7      DS Parameter Set                The DS Parameter Set information element is present within Probe Response frames generated by STAs using Clause 15, Clause 18, and Clause 19 PHYs.
         // 8      CF Parameter Set                The CF Parameter Set information element is present only within Probe Response frames generated by APs supporting a PCF.
@@ -419,7 +585,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -438,7 +604,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -458,7 +624,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -470,7 +636,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setAid(stream.readUint16Be());
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -482,7 +648,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setAid(stream.readUint16Be());
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -504,7 +670,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 
@@ -526,7 +692,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFrame(MemoryInputStrea
             frame->setSSID(SSID);
 
             frame->setSupportedRates(readSupportedRatesElement(stream));
-            readHtElements(stream, frame, EXTENDED_SUPPORTED_RATES_ALLOWED);
+            readHtElements(stream, frame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
             return frame;
         }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.h
@@ -8,6 +8,8 @@
 #ifndef __INET_IEEE80211MGMTFRAMESERIALIZER_H
 #define __INET_IEEE80211MGMTFRAMESERIALIZER_H
 
+#include <typeinfo>
+
 #include "inet/common/packet/serializer/FieldsChunkSerializer.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 
@@ -17,15 +19,27 @@ namespace ieee80211 {
 
 /**
  * Converts between Ieee80211MgmtFrame and binary network byte order IEEE 802.11 mgmt frame.
+ * The input stream passed to deserialize() must be bounded to the exact management-frame body;
+ * all bytes remaining after the fixed fields are interpreted as management elements.
  */
 class INET_API Ieee80211MgmtFrameSerializer : public FieldsChunkSerializer
 {
   protected:
     virtual void serialize(MemoryOutputStream& stream, const Ptr<const Chunk>& chunk) const override;
-    virtual const Ptr<Chunk> deserialize(MemoryInputStream& stream) const override;
+    static const Ptr<Chunk> deserializeFrame(MemoryInputStream& stream, const std::type_info& typeInfo);
 
   public:
     Ieee80211MgmtFrameSerializer() : FieldsChunkSerializer() {}
+};
+
+template<typename Frame>
+class Ieee80211TypedMgmtFrameSerializer : public Ieee80211MgmtFrameSerializer
+{
+  protected:
+    virtual const Ptr<Chunk> deserialize(MemoryInputStream& stream) const override
+    {
+        return deserializeFrame(stream, typeid(Frame));
+    }
 };
 
 } // namespace ieee80211
@@ -33,4 +47,3 @@ class INET_API Ieee80211MgmtFrameSerializer : public FieldsChunkSerializer
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtProtocolPrinter.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtProtocolPrinter.cc
@@ -19,8 +19,27 @@ Register_Protocol_Printer(&Protocol::ieee80211Mgmt, Ieee80211MgmtProtocolPrinter
 void Ieee80211MgmtProtocolPrinter::print(const Ptr<const Chunk>& chunk, const Protocol *protocol, const cMessagePrinter::Options *options, Context& context) const
 {
     context.infoColumn << "(IEEE 802.11 Mgmt) " << chunk;
+    auto frame = dynamicPtrCast<const Ieee80211MgmtFrame>(chunk);
+    if (frame != nullptr && frame->getHtCapabilitiesPresent()) {
+        const auto& capabilities = frame->getHtCapabilities();
+        int maximumRxMcs = -1;
+        for (int mcs = 0; mcs < 77; mcs++)
+            if (capabilities.rxMcsSupported[mcs])
+                maximumRxMcs = mcs;
+        context.infoColumn << " HT-Cap(width=" << (capabilities.supportedChannelWidth40Mhz ? "20/40" : "20")
+                << "MHz,rxMcs=0.." << maximumRxMcs << ",tx="
+                << (capabilities.txMcsSetDefined ? "defined" : "undefined") << ")";
+    }
+    if (frame != nullptr && frame->getHtOperationPresent()) {
+        const auto& operation = frame->getHtOperation();
+        int maximumBasicMcs = -1;
+        for (int mcs = 0; mcs < 77; mcs++)
+            if (operation.basicMcsSupported[mcs])
+                maximumBasicMcs = mcs;
+        context.infoColumn << " HT-Op(primary=" << operation.primaryChannel << ",width="
+                << (operation.staChannelWidth40Mhz ? 40 : 20) << "MHz,basicMcs=0.." << maximumBasicMcs << ")";
+    }
 }
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtProtocolPrinter.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtProtocolPrinter.cc
@@ -5,6 +5,8 @@
 //
 
 
+#include <sstream>
+
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtProtocolPrinter.h"
 
 #include "inet/common/packet/printer/PacketPrinter.h"
@@ -16,28 +18,45 @@ namespace ieee80211 {
 
 Register_Protocol_Printer(&Protocol::ieee80211Mgmt, Ieee80211MgmtProtocolPrinter);
 
+static std::string formatMcsBitmap(const bool (&mcsSupported)[77])
+{
+    std::ostringstream stream;
+    stream << "{";
+    bool first = true;
+    for (int mcs = 0; mcs < 77; ) {
+        if (!mcsSupported[mcs]) {
+            mcs++;
+            continue;
+        }
+        int firstMcs = mcs;
+        while (mcs + 1 < 77 && mcsSupported[mcs + 1])
+            mcs++;
+        if (!first)
+            stream << ",";
+        stream << firstMcs;
+        if (firstMcs != mcs)
+            stream << ".." << mcs;
+        first = false;
+        mcs++;
+    }
+    stream << "}";
+    return stream.str();
+}
+
 void Ieee80211MgmtProtocolPrinter::print(const Ptr<const Chunk>& chunk, const Protocol *protocol, const cMessagePrinter::Options *options, Context& context) const
 {
     context.infoColumn << "(IEEE 802.11 Mgmt) " << chunk;
     auto frame = dynamicPtrCast<const Ieee80211MgmtFrame>(chunk);
     if (frame != nullptr && frame->getHtCapabilitiesPresent()) {
         const auto& capabilities = frame->getHtCapabilities();
-        int maximumRxMcs = -1;
-        for (int mcs = 0; mcs < 77; mcs++)
-            if (capabilities.rxMcsSupported[mcs])
-                maximumRxMcs = mcs;
         context.infoColumn << " HT-Cap(width=" << (capabilities.supportedChannelWidth40Mhz ? "20/40" : "20")
-                << "MHz,rxMcs=0.." << maximumRxMcs << ",tx="
+                << "MHz,rxMcs=" << formatMcsBitmap(capabilities.rxMcsSupported) << ",tx="
                 << (capabilities.txMcsSetDefined ? "defined" : "undefined") << ")";
     }
     if (frame != nullptr && frame->getHtOperationPresent()) {
         const auto& operation = frame->getHtOperation();
-        int maximumBasicMcs = -1;
-        for (int mcs = 0; mcs < 77; mcs++)
-            if (operation.basicMcsSupported[mcs])
-                maximumBasicMcs = mcs;
         context.infoColumn << " HT-Op(primary=" << operation.primaryChannel << ",width="
-                << (operation.staChannelWidth40Mhz ? 40 : 20) << "MHz,basicMcs=0.." << maximumBasicMcs << ")";
+                << (operation.staChannelWidth40Mhz ? 40 : 20) << "MHz,basicMcs=" << formatMcsBitmap(operation.basicMcsSupported) << ")";
     }
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -267,12 +267,9 @@ void Ieee80211MgmtSta::startAssociation(ApInfo *ap, simtime_t timeout)
 
     // create and send association request
     const auto& body = makeShared<Ieee80211AssociationRequestFrame>();
-
-    // TODO set the following too?
-    // string SSID
-//    Ieee80211SupportedRatesElement supportedRates;
-
-    body->setChunkLength(B(2 + 2 + strlen(body->getSSID()) + 2 + body->getSupportedRates().numRates + 2));
+    body->setSSID(ap->ssid.c_str());
+    setSupportedRateElements(body);
+    body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
     sendManagementFrame("Assoc", body, ST_ASSOCIATIONREQUEST, ap->address);
 
     // schedule timeout
@@ -375,8 +372,8 @@ void Ieee80211MgmtSta::sendProbeRequest()
     EV << "Sending Probe Request, BSSID=" << scanning.bssid << ", SSID=\"" << scanning.ssid << "\"\n";
     const auto& body = makeShared<Ieee80211ProbeRequestFrame>();
     body->setSSID(scanning.ssid.c_str());
-    body->setSupportedRates(supportedRates);
-    body->setChunkLength(B((2 + scanning.ssid.length()) + (2 + body->getSupportedRates().numRates)));
+    setSupportedRateElements(body);
+    body->setChunkLength(B(2 + scanning.ssid.length()) + getSupportedRateElementsLength(body));
     sendManagementFrame("ProbeReq", body, ST_PROBEREQUEST, scanning.bssid);
 }
 
@@ -397,6 +394,8 @@ void Ieee80211MgmtSta::sendScanConfirm()
         bss.setBSSID(ap->address);
         bss.setSSID(ap->ssid.c_str());
         bss.setSupportedRates(ap->supportedRates);
+        bss.setExtendedSupportedRatesPresent(ap->extendedSupportedRatesPresent);
+        bss.setExtendedSupportedRates(ap->extendedSupportedRates);
         bss.setBeaconInterval(ap->beaconInterval);
         bss.setRxPower(ap->rxPower);
     }
@@ -747,6 +746,8 @@ void Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211Mgmt
     ap->address = address;
     ap->ssid = body->getSSID();
     ap->supportedRates = body->getSupportedRates();
+    ap->extendedSupportedRatesPresent = body->getExtendedSupportedRatesPresent();
+    ap->extendedSupportedRates = body->getExtendedSupportedRates();
     ap->beaconInterval = body->getBeaconInterval();
     auto signalPowerInd = packet->getTag<SignalPowerInd>();
     if (signalPowerInd != nullptr) {
@@ -758,4 +759,3 @@ void Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211Mgmt
 
 } // namespace ieee80211
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -32,6 +32,9 @@ using namespace physicallayer;
 // TODO mac should be able to signal when msg got transmitted
 
 Define_Module(Ieee80211MgmtSta);
+Register_Class(Ieee80211MgmtSta::HtNegotiationFailure);
+
+simsignal_t Ieee80211MgmtSta::htNegotiationFailedSignal = cComponent::registerSignal("htNegotiationFailed");
 
 // message kind values for timers
 #define MK_AUTH_TIMEOUT           1
@@ -754,23 +757,12 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
     const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
     int statusCode = responseBody->getStatusCode();
 
-    bool responseHtValid = false;
+    HtAssociationResponseStatus responseHtStatus = HtAssociationResponseStatus::LEGACY;
     Ieee80211HtCapabilities responseHtCapabilities;
     Ieee80211HtOperation responseHtOperation;
-    if (statusCode == SC_SUCCESSFUL && mib->isHtOperationSupported()) {
-        bool responseHtCapabilitiesPresent = responseBody->getHtCapabilitiesPresent();
-        bool responseHtOperationPresent = responseBody->getHtOperationPresent();
-        if (responseHtCapabilitiesPresent && responseHtOperationPresent) {
-            responseHtCapabilities = makeHtCapabilities(responseBody->getHtCapabilities());
-            responseHtOperation = makeHtOperation(responseBody->getHtOperation());
-            auto negotiated = negotiateHtCapabilities(mib->localHtCapabilities, responseHtCapabilities, responseHtOperation);
-            responseHtValid = negotiated.localTxPeerRx.valid && negotiated.localRxPeerTx.valid;
-        }
-        // The response has already been acknowledged by the MAC. Never rewrite
-        // an on-air SUCCESS into local failure: doing so would leave the AP and
-        // STA in different association states. Invalid/absent peer HT data is
-        // retained conservatively as no negotiated HT state.
-    }
+    std::string responseHtReason;
+    if (statusCode == SC_SUCCESSFUL)
+        responseHtStatus = classifyAssociationResponse(responseBody, responseHtCapabilities, responseHtOperation, responseHtReason);
     delete packet;
 
     cancelPendingAssociation();
@@ -799,10 +791,21 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         mib->bssData.bssid = ap->address;
         mib->bssStationData.isAssociated = true;
         (ApInfo&)assocAP = (*ap);
-        if (responseHtValid)
+        if (responseHtStatus == HtAssociationResponseStatus::VALID_HT)
             mib->setPeerHtCapabilities(ap->address, responseHtCapabilities, responseHtOperation);
-        else
+        else {
             mib->removePeerHtCapabilities(ap->address);
+            if (responseHtStatus == HtAssociationResponseStatus::INVALID_HT) {
+                EV_WARN << "Association succeeded without usable HT negotiation with AP address=" << ap->address
+                        << ": " << responseHtReason << "\n";
+                HtNegotiationFailure notification;
+                notification.setPeerAddress(ap->address);
+                notification.setReassociation(reassociation);
+                notification.setStatus(responseHtStatus);
+                notification.setReason(responseHtReason);
+                emit(htNegotiationFailedSignal, &notification);
+            }
+        }
 
         emit(l2AssociatedSignal, myIface, ap);
 
@@ -815,6 +818,47 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         sendReassociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
     else
         sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
+}
+
+Ieee80211MgmtSta::HtAssociationResponseStatus Ieee80211MgmtSta::classifyAssociationResponse(
+        const Ptr<const Ieee80211AssociationResponseFrame>& responseBody,
+        Ieee80211HtCapabilities& responseHtCapabilities, Ieee80211HtOperation& responseHtOperation,
+        std::string& reason) const
+{
+    bool responseHtCapabilitiesPresent = responseBody->getHtCapabilitiesPresent();
+    bool responseHtOperationPresent = responseBody->getHtOperationPresent();
+    // A non-HT station deliberately ignores HT elements. This preserves the
+    // genuine legacy association path even when an HT-capable AP includes its
+    // normal response elements.
+    if (!mib->isHtOperationSupported())
+        return HtAssociationResponseStatus::LEGACY;
+    if (!responseHtCapabilitiesPresent && !responseHtOperationPresent)
+        return HtAssociationResponseStatus::LEGACY;
+    if (responseHtCapabilitiesPresent != responseHtOperationPresent) {
+        reason = "association response contains only one of the HT Capabilities and HT Operation elements";
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    // Keep the existing deserialization behavior: malformed received HT
+    // elements are rejected by makeHtCapabilities/makeHtOperation.
+    responseHtCapabilities = makeHtCapabilities(responseBody->getHtCapabilities());
+    responseHtOperation = makeHtOperation(responseBody->getHtOperation());
+    auto negotiated = negotiateHtCapabilities(mib->localHtCapabilities, responseHtCapabilities, responseHtOperation);
+    if (!supportsBasicHtMcsSet(mib->localHtCapabilities, responseHtOperation) ||
+            !negotiated.localTxPeerRx.valid || !negotiated.localRxPeerTx.valid) {
+        reason = "HT capabilities and operation have no bidirectionally usable common mode";
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    return HtAssociationResponseStatus::VALID_HT;
+}
+
+const char *Ieee80211MgmtSta::getHtAssociationResponseStatusName(HtAssociationResponseStatus status)
+{
+    switch (status) {
+        case HtAssociationResponseStatus::LEGACY: return "LEGACY";
+        case HtAssociationResponseStatus::VALID_HT: return "VALID_HT";
+        case HtAssociationResponseStatus::INVALID_HT: return "INVALID_HT";
+        default: return "UNKNOWN";
+    }
 }
 
 void Ieee80211MgmtSta::handleReassociationFailure(ApInfo *ap)
@@ -922,7 +966,7 @@ void Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211Mgmt
         ap = &apList.back();
     }
 
-    ap->channel = body->getChannelNumber();
+    int legacyChannel = body->getChannelNumber();
     ap->address = address;
     ap->ssid = body->getSSID();
     ap->supportedRates = body->getSupportedRates();
@@ -932,8 +976,16 @@ void Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211Mgmt
     if (ap->htCapabilitiesPresent)
         ap->htCapabilities = makeHtCapabilities(body->getHtCapabilities());
     ap->htOperationPresent = body->getHtOperationPresent();
-    if (ap->htOperationPresent)
+    if (ap->htOperationPresent) {
         ap->htOperation = makeHtOperation(body->getHtOperation());
+        // IEEE Std 802.11-2024, Table 9-230 and 11.14: the HT Operation
+        // element is the authoritative advertisement of the BSS primary
+        // channel. The fixed channelNumber field is not serialized by the
+        // management-body serializer and may therefore be its default value.
+        ap->channel = ap->htOperation.primaryChannel;
+    }
+    else
+        ap->channel = legacyChannel;
     ap->beaconInterval = body->getBeaconInterval();
     auto signalPowerInd = packet->getTag<SignalPowerInd>();
     if (signalPowerInd != nullptr) {

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -6,6 +6,7 @@
 
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 
 #include "inet/common/INETUtils.h"
 #include "inet/common/ModuleAccess.h"
@@ -289,7 +290,8 @@ void Ieee80211MgmtSta::startAssociation(ApInfo *ap, simtime_t timeout)
     const auto& body = makeShared<Ieee80211AssociationRequestFrame>();
     body->setSSID(ap->ssid.c_str());
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Assoc", body, ST_ASSOCIATIONREQUEST, ap->address);
     reassociationInProgress = false;
 
@@ -311,7 +313,8 @@ void Ieee80211MgmtSta::startReassociation(ApInfo *ap, simtime_t timeout)
     body->setCurrentAP(assocAP.address);
     body->setSSID(ap->ssid.c_str());
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + 6 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + 2 + 6 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Reassoc", body, ST_REASSOCIATIONREQUEST, ap->address);
     reassociationInProgress = true;
     assocTimeoutMsg = new cMessage("assocTimeout", MK_ASSOC_TIMEOUT);
@@ -407,7 +410,8 @@ void Ieee80211MgmtSta::sendProbeRequest()
     const auto& body = makeShared<Ieee80211ProbeRequestFrame>();
     body->setSSID(scanning.ssid.c_str());
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + scanning.ssid.length()) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + scanning.ssid.length()) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("ProbeReq", body, ST_PROBEREQUEST, scanning.bssid);
 }
 
@@ -518,6 +522,7 @@ void Ieee80211MgmtSta::disassociate()
     ASSERT(mib->bssStationData.isAssociated);
     cancelPendingAssociation();
     mib->bssStationData.isAssociated = false;
+    mib->removePeerHtCapabilities(assocAP.address);
     cancelAndDelete(assocAP.beaconTimeoutMsg);
     assocAP.beaconTimeoutMsg = nullptr;
     assocAP = AssociatedApInfo(); // clear it
@@ -651,6 +656,7 @@ void Ieee80211MgmtSta::handleDeauthenticationFrame(Packet *packet, const Ptr<con
 
     EV << "Setting isAuthenticated flag for that AP to false\n";
     ap->isAuthenticated = false;
+    mib->removePeerHtCapabilities(address);
     delete packet;
 }
 
@@ -696,6 +702,23 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
     const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
     int statusCode = responseBody->getStatusCode();
 
+    bool responseHtValid = false;
+    Ieee80211HtCapabilities responseHtCapabilities;
+    Ieee80211HtOperation responseHtOperation;
+    if (statusCode == SC_SUCCESSFUL && mib->isHtOperationSupported()) {
+        bool responseHtCapabilitiesPresent = responseBody->getHtCapabilitiesPresent();
+        bool responseHtOperationPresent = responseBody->getHtOperationPresent();
+        if (responseHtCapabilitiesPresent && responseHtOperationPresent) {
+            responseHtCapabilities = makeHtCapabilities(responseBody->getHtCapabilities());
+            responseHtOperation = makeHtOperation(responseBody->getHtOperation());
+            auto negotiated = negotiateHtCapabilities(mib->localHtCapabilities, responseHtCapabilities, responseHtOperation);
+            responseHtValid = negotiated.localTxPeerRx.valid && negotiated.localRxPeerTx.valid;
+        }
+        // The response has already been acknowledged by the MAC. Never rewrite
+        // an on-air SUCCESS into local failure: doing so would leave the AP and
+        // STA in different association states. Invalid/absent peer HT data is
+        // retained conservatively as no negotiated HT state.
+    }
     delete packet;
 
     cancelPendingAssociation();
@@ -704,6 +727,8 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         EV << "Association failed with AP address=" << ap->address << "\n";
         if (reassociation)
             handleReassociationFailure(ap);
+        else if (!mib->bssStationData.isAssociated || assocAP.address != ap->address)
+            mib->removePeerHtCapabilities(ap->address);
     }
     else {
         EV << "Association successful, AP address=" << ap->address << "\n";
@@ -711,6 +736,7 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         if (mib->bssStationData.isAssociated) {
             EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
             mib->bssStationData.isAssociated = false;
+            mib->removePeerHtCapabilities(assocAP.address);
             cancelAndDelete(assocAP.beaconTimeoutMsg);
             assocAP.beaconTimeoutMsg = nullptr;
             assocAP = AssociatedApInfo();
@@ -721,6 +747,10 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         mib->bssData.bssid = ap->address;
         mib->bssStationData.isAssociated = true;
         (ApInfo&)assocAP = (*ap);
+        if (responseHtValid)
+            mib->setPeerHtCapabilities(ap->address, responseHtCapabilities, responseHtOperation);
+        else
+            mib->removePeerHtCapabilities(ap->address);
 
         emit(l2AssociatedSignal, myIface, ap);
 
@@ -741,6 +771,8 @@ void Ieee80211MgmtSta::handleReassociationFailure(ApInfo *ap)
     // disassociates the STA only when the target is its current AP.
     if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address))
         disassociate();
+    else
+        mib->removePeerHtCapabilities(ap->address);
 }
 
 bool Ieee80211MgmtSta::shouldDisassociateOnReassociationFailure(bool isAssociated,
@@ -773,6 +805,7 @@ void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const
 
     EV << "Setting isAssociated flag to false\n";
     mib->bssStationData.isAssociated = false;
+    mib->removePeerHtCapabilities(address);
     cancelAndDelete(assocAP.beaconTimeoutMsg);
     assocAP.beaconTimeoutMsg = nullptr;
 }
@@ -828,6 +861,12 @@ void Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211Mgmt
     ap->supportedRates = body->getSupportedRates();
     ap->extendedSupportedRatesPresent = body->getExtendedSupportedRatesPresent();
     ap->extendedSupportedRates = body->getExtendedSupportedRates();
+    ap->htCapabilitiesPresent = body->getHtCapabilitiesPresent();
+    if (ap->htCapabilitiesPresent)
+        ap->htCapabilities = makeHtCapabilities(body->getHtCapabilities());
+    ap->htOperationPresent = body->getHtOperationPresent();
+    if (ap->htOperationPresent)
+        ap->htOperation = makeHtOperation(body->getHtOperation());
     ap->beaconInterval = body->getBeaconInterval();
     auto signalPowerInd = packet->getTag<SignalPowerInd>();
     if (signalPowerInd != nullptr) {

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -120,15 +120,22 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
     }
     else if (msg->getKind() == MK_ASSOC_TIMEOUT) {
         // association timed out
+        ASSERT(msg == assocTimeoutMsg);
         ApInfo *ap = (ApInfo *)msg->getContextPointer();
+        bool reassociation = reassociationInProgress;
         EV << "Association timed out, AP address = " << ap->address << "\n";
 
+        assocTimeoutMsg = nullptr;
+        reassociationInProgress = false;
+        delete msg;
+
         // send back failure report to agent
-        if (reassociationInProgress)
+        if (reassociation) {
+            handleReassociationFailure(ap);
             sendReassociationConfirm(ap, PRC_TIMEOUT);
+        }
         else
             sendAssociationConfirm(ap, PRC_TIMEOUT);
-        reassociationInProgress = false;
     }
     else if (msg->getKind() == MK_SCAN_MAXCHANNELTIME) {
         // go to next channel during scanning
@@ -200,11 +207,20 @@ Ieee80211MgmtSta::ApInfo *Ieee80211MgmtSta::lookupAP(const MacAddress& address)
 
 void Ieee80211MgmtSta::clearAPList()
 {
+    cancelPendingAssociation();
+
     for (auto& elem : apList)
         if (elem.authTimeoutMsg)
             cancelAndDelete(elem.authTimeoutMsg);
 
     apList.clear();
+}
+
+void Ieee80211MgmtSta::cancelPendingAssociation()
+{
+    cancelAndDelete(assocTimeoutMsg);
+    assocTimeoutMsg = nullptr;
+    reassociationInProgress = false;
 }
 
 void Ieee80211MgmtSta::changeChannel(int channelNum)
@@ -323,14 +339,8 @@ void Ieee80211MgmtSta::processScanCommand(Ieee80211Prim_ScanRequest *ctrl)
 
     if (isScanning)
         throw cRuntimeError("processScanCommand: scanning already in progress");
-    if (mib->bssStationData.isAssociated) {
+    if (mib->bssStationData.isAssociated)
         disassociate();
-    }
-    else if (assocTimeoutMsg) {
-        EV << "Cancelling ongoing association process\n";
-        cancelAndDelete(assocTimeoutMsg);
-        assocTimeoutMsg = nullptr;
-    }
 
     // clear existing AP list (and cancel any pending authentications) -- we want to start with a clean page
     clearAPList();
@@ -444,6 +454,8 @@ void Ieee80211MgmtSta::processDeauthenticateCommand(Ieee80211Prim_Deauthenticate
 
     if (mib->bssStationData.isAssociated && assocAP.address == address)
         disassociate();
+    else if (assocTimeoutMsg && assocTimeoutMsg->getContextPointer() == ap)
+        cancelPendingAssociation();
 
     if (ap->isAuthenticated)
         ap->isAuthenticated = false;
@@ -491,11 +503,8 @@ void Ieee80211MgmtSta::processDisassociateCommand(Ieee80211Prim_DisassociateRequ
     if (mib->bssStationData.isAssociated && address == assocAP.address) {
         disassociate();
     }
-    else if (assocTimeoutMsg) {
-        // pending association
-        cancelAndDelete(assocTimeoutMsg);
-        assocTimeoutMsg = nullptr;
-    }
+    else
+        cancelPendingAssociation();
 
     // create and send disassociation request
     const auto& body = makeShared<Ieee80211DisassociationFrame>();
@@ -507,6 +516,7 @@ void Ieee80211MgmtSta::disassociate()
 {
     EV << "Disassociating from AP address=" << assocAP.address << "\n";
     ASSERT(mib->bssStationData.isAssociated);
+    cancelPendingAssociation();
     mib->bssStationData.isAssociated = false;
     cancelAndDelete(assocAP.beaconTimeoutMsg);
     assocAP.beaconTimeoutMsg = nullptr;
@@ -664,35 +674,47 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         return;
     }
 
+    // IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4: process only the response
+    // corresponding to the association or reassociation procedure in progress.
+    if (reassociation != reassociationInProgress) {
+        EV_INFO << "Association response subtype does not match the pending "
+                << (reassociationInProgress ? "reassociation" : "association")
+                << " attempt, ignoring frame\n";
+        delete packet;
+        return;
+    }
+
+    MacAddress address = header->getTransmitterAddress();
+    ApInfo *ap = static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer());
+    if (ap == nullptr || ap->address != address) {
+        EV << "Association response is not from the pending AP, ignoring frame\n";
+        delete packet;
+        return;
+    }
+
     // extract frame contents
     const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
-    MacAddress address = header->getTransmitterAddress();
     int statusCode = responseBody->getStatusCode();
-
-    // look up AP data structure
-    ApInfo *ap = lookupAP(address);
-    if (!ap)
-        throw cRuntimeError("handleAssociationResponseFrame: AP not known: address=%s", address.str().c_str());
 
     delete packet;
 
-    if (mib->bssStationData.isAssociated) {
-        EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
-        mib->bssStationData.isAssociated = false;
-        cancelAndDelete(assocAP.beaconTimeoutMsg);
-        assocAP.beaconTimeoutMsg = nullptr;
-        assocAP = AssociatedApInfo();
-    }
-
-    cancelAndDelete(assocTimeoutMsg);
-    assocTimeoutMsg = nullptr;
-    reassociationInProgress = false;
+    cancelPendingAssociation();
 
     if (statusCode != SC_SUCCESSFUL) {
         EV << "Association failed with AP address=" << ap->address << "\n";
+        if (reassociation)
+            handleReassociationFailure(ap);
     }
     else {
         EV << "Association successful, AP address=" << ap->address << "\n";
+
+        if (mib->bssStationData.isAssociated) {
+            EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
+            mib->bssStationData.isAssociated = false;
+            cancelAndDelete(assocAP.beaconTimeoutMsg);
+            assocAP.beaconTimeoutMsg = nullptr;
+            assocAP = AssociatedApInfo();
+        }
 
         // change our state to "associated"
         mib->bssData.ssid = ap->ssid;
@@ -713,6 +735,20 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
 }
 
+void Ieee80211MgmtSta::handleReassociationFailure(ApInfo *ap)
+{
+    // IEEE Std 802.11-2024, 11.3.5.4(f): failed or timed-out reassociation
+    // disassociates the STA only when the target is its current AP.
+    if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address))
+        disassociate();
+}
+
+bool Ieee80211MgmtSta::shouldDisassociateOnReassociationFailure(bool isAssociated,
+        const MacAddress& associatedApAddress, const MacAddress& targetApAddress)
+{
+    return isAssociated && associatedApAddress == targetApAddress;
+}
+
 void Ieee80211MgmtSta::handleReassociationRequestFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
     dropManagementFrame(packet);
@@ -728,11 +764,7 @@ void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const
     EV << "Received Disassociation frame\n";
     const MacAddress& address = header->getAddress3(); // source address
 
-    if (assocTimeoutMsg) {
-        // pending association
-        cancelAndDelete(assocTimeoutMsg);
-        assocTimeoutMsg = nullptr;
-    }
+    cancelPendingAssociation();
     if (!mib->bssStationData.isAssociated || address != assocAP.address) {
         EV << "Not associated with that AP -- ignoring frame\n";
         delete packet;

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -124,7 +124,11 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
         EV << "Association timed out, AP address = " << ap->address << "\n";
 
         // send back failure report to agent
-        sendAssociationConfirm(ap, PRC_TIMEOUT);
+        if (reassociationInProgress)
+            sendReassociationConfirm(ap, PRC_TIMEOUT);
+        else
+            sendAssociationConfirm(ap, PRC_TIMEOUT);
+        reassociationInProgress = false;
     }
     else if (msg->getKind() == MK_SCAN_MAXCHANNELTIME) {
         // go to next channel during scanning
@@ -172,10 +176,10 @@ void Ieee80211MgmtSta::handleCommand(int msgkind, cObject *ctrl)
         processAuthenticateCommand(cmd);
     else if (auto cmd = dynamic_cast<Ieee80211Prim_DeauthenticateRequest *>(ctrl))
         processDeauthenticateCommand(cmd);
-    else if (auto cmd = dynamic_cast<Ieee80211Prim_AssociateRequest *>(ctrl))
-        processAssociateCommand(cmd);
     else if (auto cmd = dynamic_cast<Ieee80211Prim_ReassociateRequest *>(ctrl))
         processReassociateCommand(cmd);
+    else if (auto cmd = dynamic_cast<Ieee80211Prim_AssociateRequest *>(ctrl))
+        processAssociateCommand(cmd);
     else if (auto cmd = dynamic_cast<Ieee80211Prim_DisassociateRequest *>(ctrl))
         processDisassociateCommand(cmd);
     else if (ctrl)
@@ -271,9 +275,29 @@ void Ieee80211MgmtSta::startAssociation(ApInfo *ap, simtime_t timeout)
     setSupportedRateElements(body);
     body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
     sendManagementFrame("Assoc", body, ST_ASSOCIATIONREQUEST, ap->address);
+    reassociationInProgress = false;
 
     // schedule timeout
     ASSERT(assocTimeoutMsg == nullptr);
+    assocTimeoutMsg = new cMessage("assocTimeout", MK_ASSOC_TIMEOUT);
+    assocTimeoutMsg->setContextPointer(ap);
+    scheduleAfter(timeout, assocTimeoutMsg);
+}
+
+void Ieee80211MgmtSta::startReassociation(ApInfo *ap, simtime_t timeout)
+{
+    if (!mib->bssStationData.isAssociated || assocTimeoutMsg)
+        throw cRuntimeError("startReassociation: not associated or association currently in progress");
+    if (!ap->isAuthenticated)
+        throw cRuntimeError("startReassociation: not authenticated with AP address='%s'", ap->address.str().c_str());
+    changeChannel(ap->channel);
+    const auto& body = makeShared<Ieee80211ReassociationRequestFrame>();
+    body->setCurrentAP(assocAP.address);
+    body->setSSID(ap->ssid.c_str());
+    setSupportedRateElements(body);
+    body->setChunkLength(B(2 + 2 + 6 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
+    sendManagementFrame("Reassoc", body, ST_REASSOCIATIONREQUEST, ap->address);
+    reassociationInProgress = true;
     assocTimeoutMsg = new cMessage("assocTimeout", MK_ASSOC_TIMEOUT);
     assocTimeoutMsg->setContextPointer(ap);
     scheduleAfter(timeout, assocTimeoutMsg);
@@ -447,9 +471,17 @@ void Ieee80211MgmtSta::processAssociateCommand(Ieee80211Prim_AssociateRequest *c
 
 void Ieee80211MgmtSta::processReassociateCommand(Ieee80211Prim_ReassociateRequest *ctrl)
 {
-    // treat the same way as association
-    // TODO refine
-    processAssociateCommand(ctrl);
+    const MacAddress& address = ctrl->getAddress();
+    if (!mib->bssStationData.isAssociated) {
+        auto confirm = new Ieee80211Prim_ReassociateConfirm();
+        confirm->setAddress(address);
+        sendConfirm(confirm, PRC_REFUSED);
+        return;
+    }
+    ApInfo *ap = lookupAP(address);
+    if (!ap)
+        throw cRuntimeError("processReassociateCommand: AP not known: address = %s", address.str().c_str());
+    startReassociation(ap, ctrl->getTimeout());
 }
 
 void Ieee80211MgmtSta::processDisassociateCommand(Ieee80211Prim_DisassociateRequest *ctrl)
@@ -490,7 +522,16 @@ void Ieee80211MgmtSta::sendAuthenticationConfirm(ApInfo *ap, Ieee80211PrimResult
 
 void Ieee80211MgmtSta::sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode)
 {
-    sendConfirm(new Ieee80211Prim_AssociateConfirm(), resultCode);
+    auto confirm = new Ieee80211Prim_AssociateConfirm();
+    confirm->setAddress(ap->address);
+    sendConfirm(confirm, resultCode);
+}
+
+void Ieee80211MgmtSta::sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode)
+{
+    auto confirm = new Ieee80211Prim_ReassociateConfirm();
+    confirm->setAddress(ap->address);
+    sendConfirm(confirm, resultCode);
 }
 
 void Ieee80211MgmtSta::sendConfirm(Ieee80211PrimConfirm *confirm, Ieee80211PrimResultCode resultCode)
@@ -610,7 +651,12 @@ void Ieee80211MgmtSta::handleAssociationRequestFrame(Packet *packet, const Ptr<c
 
 void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
-    EV << "Received Association Response frame\n";
+    processAssociationResponse(packet, header, false);
+}
+
+void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation)
+{
+    EV << "Received Association or Reassociation Response frame\n";
 
     if (!assocTimeoutMsg) {
         EV << "No association in progress, ignoring frame\n";
@@ -622,14 +668,13 @@ void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<
     const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
     MacAddress address = header->getTransmitterAddress();
     int statusCode = responseBody->getStatusCode();
-    // TODO short aid;
-    // TODO Ieee80211SupportedRatesElement supportedRates;
-    delete packet;
 
     // look up AP data structure
     ApInfo *ap = lookupAP(address);
     if (!ap)
         throw cRuntimeError("handleAssociationResponseFrame: AP not known: address=%s", address.str().c_str());
+
+    delete packet;
 
     if (mib->bssStationData.isAssociated) {
         EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
@@ -641,6 +686,7 @@ void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<
 
     cancelAndDelete(assocTimeoutMsg);
     assocTimeoutMsg = nullptr;
+    reassociationInProgress = false;
 
     if (statusCode != SC_SUCCESSFUL) {
         EV << "Association failed with AP address=" << ap->address << "\n";
@@ -661,7 +707,10 @@ void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<
     }
 
     // report back to agent
-    sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
+    if (reassociation)
+        sendReassociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
+    else
+        sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
 }
 
 void Ieee80211MgmtSta::handleReassociationRequestFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -671,8 +720,7 @@ void Ieee80211MgmtSta::handleReassociationRequestFrame(Packet *packet, const Ptr
 
 void Ieee80211MgmtSta::handleReassociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
-    EV << "Received Reassociation Response frame\n";
-    // TODO handle with the same code as Association Response?
+    processAssociationResponse(packet, header, true);
 }
 
 void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -725,6 +725,8 @@ void Ieee80211MgmtSta::handleDeauthenticationFrame(Packet *packet, const Ptr<con
     // address used to identify the peer that sent this frame.
     const MacAddress& address = header->getTransmitterAddress();
     ApInfo *ap = lookupAP(address);
+    ApInfo *pendingAp = assocTimeoutMsg ? static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer()) : nullptr;
+    bool isPendingAp = pendingAp != nullptr && pendingAp->address == address;
     bool isCurrentAp = mib->bssStationData.isAssociated && address == assocAP.address;
 
     // IEEE Std 802.11-2024, 11.3.4.5: deauthentication from the current AP
@@ -742,6 +744,27 @@ void Ieee80211MgmtSta::handleDeauthenticationFrame(Packet *packet, const Ptr<con
             }
         }
         ASSERT(terminateCurrentAssociationFromPeer(address));
+        delete packet;
+        return;
+    }
+
+    // IEEE Std 802.11-2024, 11.3.5.1, 11.3.5.2 and 11.3.5.4: a
+    // deauthentication from the target AP terminates the pending association
+    // or reassociation, even when that AP is not the current AP.
+    if (isPendingAp) {
+        bool pendingReassociation = reassociationInProgress;
+        EV << "Cancelling pending association with deauthenticated AP\n";
+        pendingAp->isAuthenticated = false;
+        if (pendingAp->authTimeoutMsg) {
+            cancelAndDelete(pendingAp->authTimeoutMsg);
+            pendingAp->authTimeoutMsg = nullptr;
+        }
+        mib->removePeerHtCapabilities(address);
+        cancelPendingAssociation();
+        if (pendingReassociation)
+            sendReassociationConfirm(pendingAp, PRC_REFUSED);
+        else
+            sendAssociationConfirm(pendingAp, PRC_REFUSED);
         delete packet;
         return;
     }

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -562,6 +562,33 @@ void Ieee80211MgmtSta::clearCurrentAssociation()
     assocAP = AssociatedApInfo(); // clear it
 }
 
+bool Ieee80211MgmtSta::terminateCurrentAssociationFromPeer(const MacAddress& address)
+{
+    if (!mib->bssStationData.isAssociated || address != assocAP.address)
+        return false;
+
+    // Keep a stable AP-list object for the primitive confirmation while the
+    // association snapshot is cleared. A pending transaction for a different
+    // AP remains valid after the current association is terminated.
+    ApInfo *pendingAp = assocTimeoutMsg ? static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer()) : nullptr;
+    bool pendingReassociation = reassociationInProgress;
+    bool terminatesPendingRequest = pendingAp != nullptr && pendingAp->address == address;
+    if (terminatesPendingRequest)
+        cancelPendingAssociation();
+
+    EV << "Setting isAssociated flag to false\n";
+    clearCurrentAssociation();
+    if (terminatesPendingRequest) {
+        // The primitive API has no peer-aborted result; a termination of a
+        // same-peer pending request is reported as a refusal after teardown.
+        if (pendingReassociation)
+            sendReassociationConfirm(pendingAp, PRC_REFUSED);
+        else
+            sendAssociationConfirm(pendingAp, PRC_REFUSED);
+    }
+    return true;
+}
+
 void Ieee80211MgmtSta::stop()
 {
     if (host != nullptr && isScanning && scanning.activeScan)
@@ -694,8 +721,31 @@ void Ieee80211MgmtSta::handleAuthenticationFrame(Packet *packet, const Ptr<const
 void Ieee80211MgmtSta::handleDeauthenticationFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
     EV << "Received Deauthentication frame\n";
-    const MacAddress& address = header->getAddress3(); // source address
+    // IEEE Std 802.11-2024, 9.3.3.1: Address 2 is the transmitter/source
+    // address used to identify the peer that sent this frame.
+    const MacAddress& address = header->getTransmitterAddress();
     ApInfo *ap = lookupAP(address);
+    bool isCurrentAp = mib->bssStationData.isAssociated && address == assocAP.address;
+
+    // IEEE Std 802.11-2024, 11.3.4.5: deauthentication from the current AP
+    // returns the STA to State 1. Do this before consulting the discovery
+    // cache: association state itself is authoritative for this transition.
+    if (isCurrentAp) {
+        // Clear the cached authentication state before the shared helper emits
+        // a possible same-peer transaction refusal, so observers see the
+        // complete State-1 transition in that callback as well.
+        if (ap != nullptr) {
+            ap->isAuthenticated = false;
+            if (ap->authTimeoutMsg) {
+                cancelAndDelete(ap->authTimeoutMsg);
+                ap->authTimeoutMsg = nullptr;
+            }
+        }
+        ASSERT(terminateCurrentAssociationFromPeer(address));
+        delete packet;
+        return;
+    }
+
     if (!ap || !ap->isAuthenticated) {
         EV << "Unknown AP, or not authenticated with that AP -- ignoring frame\n";
         delete packet;
@@ -896,27 +946,10 @@ void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const
     // IEEE Std 802.11-2024, 11.3.5.7: process a Disassociation only from the
     // AP whose peer state is State 3/4. In particular, a pending association
     // to another AP must survive an unrelated frame.
-    if (!mib->bssStationData.isAssociated || address != assocAP.address) {
+    if (!terminateCurrentAssociationFromPeer(address)) {
         EV << "Not associated with that AP -- ignoring frame\n";
         delete packet;
         return;
-    }
-
-    ApInfo *pendingAp = assocTimeoutMsg ? static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer()) : nullptr;
-    bool pendingReassociation = reassociationInProgress;
-    bool terminatesPendingRequest = pendingAp != nullptr && pendingAp->address == address;
-    if (terminatesPendingRequest)
-        cancelPendingAssociation();
-
-    EV << "Setting isAssociated flag to false\n";
-    clearCurrentAssociation();
-    if (terminatesPendingRequest) {
-        // INET primitive policy: the current API has no peer-aborted result,
-        // so a same-peer terminated association/reassociation maps to refusal.
-        if (pendingReassociation)
-            sendReassociationConfirm(pendingAp, PRC_REFUSED);
-        else
-            sendAssociationConfirm(pendingAp, PRC_REFUSED);
     }
     delete packet;
 }

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -43,6 +43,15 @@ Define_Module(Ieee80211MgmtSta);
 
 #define MAX_BEACONS_MISSED        3.5  // beacon lost timeout, in beacon intervals (doesn't need to be integer)
 
+Ieee80211MgmtSta::~Ieee80211MgmtSta()
+{
+    cancelAndDelete(scanTimer);
+    cancelAndDelete(assocTimeoutMsg);
+    for (auto& ap : apList)
+        cancelAndDelete(ap.authTimeoutMsg);
+    cancelAndDelete(assocAP.beaconTimeoutMsg);
+}
+
 std::ostream& operator<<(std::ostream& os, const Ieee80211MgmtSta::ScanningInfo& scanning)
 {
     os << "activeScan=" << scanning.activeScan
@@ -139,6 +148,8 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
             sendAssociationConfirm(ap, PRC_TIMEOUT);
     }
     else if (msg->getKind() == MK_SCAN_MAXCHANNELTIME) {
+        ASSERT(msg == scanTimer);
+        scanTimer = nullptr;
         // go to next channel during scanning
         bool done = scanNextChannel();
         if (done)
@@ -146,19 +157,25 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
         delete msg;
     }
     else if (msg->getKind() == MK_SCAN_SENDPROBE) {
+        ASSERT(msg == scanTimer);
+        scanTimer = nullptr;
         // Active Scan: send a probe request, then wait for minChannelTime (11.1.3.2.2)
         delete msg;
         sendProbeRequest();
-        cMessage *timerMsg = new cMessage("minChannelTime", MK_SCAN_MINCHANNELTIME);
-        scheduleAfter(scanning.minChannelTime, timerMsg); // TODO actually, we should start waiting after ProbeReq actually got transmitted
+        ASSERT(scanTimer == nullptr);
+        scanTimer = new cMessage("minChannelTime", MK_SCAN_MINCHANNELTIME);
+        scheduleAfter(scanning.minChannelTime, scanTimer); // TODO actually, we should start waiting after ProbeReq actually got transmitted
     }
     else if (msg->getKind() == MK_SCAN_MINCHANNELTIME) {
+        ASSERT(msg == scanTimer);
+        scanTimer = nullptr;
         // Active Scan: after minChannelTime, possibly listen for the remaining time until maxChannelTime
         delete msg;
         if (scanning.busyChannelDetected) {
             EV << "Busy channel detected during minChannelTime, continuing listening until maxChannelTime elapses\n";
-            cMessage *timerMsg = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
-            scheduleAfter(scanning.maxChannelTime - scanning.minChannelTime, timerMsg);
+            ASSERT(scanTimer == nullptr);
+            scanTimer = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
+            scheduleAfter(scanning.maxChannelTime - scanning.minChannelTime, scanTimer);
         }
         else {
             EV << "Channel was empty during minChannelTime, going to next channel\n";
@@ -222,6 +239,12 @@ void Ieee80211MgmtSta::cancelPendingAssociation()
     cancelAndDelete(assocTimeoutMsg);
     assocTimeoutMsg = nullptr;
     reassociationInProgress = false;
+}
+
+void Ieee80211MgmtSta::cancelScanTimer()
+{
+    cancelAndDelete(scanTimer);
+    scanTimer = nullptr;
 }
 
 void Ieee80211MgmtSta::changeChannel(int channelNum)
@@ -390,15 +413,17 @@ bool Ieee80211MgmtSta::scanNextChannel()
     changeChannel(newChannel);
     scanning.busyChannelDetected = false;
 
+    ASSERT(scanTimer == nullptr);
     if (scanning.activeScan) {
         // Active Scan: first wait probeDelay, then send a probe. Listening
         // for minChannelTime or maxChannelTime takes place after that. (11.1.3.2)
-        scheduleAfter(scanning.probeDelay, new cMessage("sendProbe", MK_SCAN_SENDPROBE));
+        scanTimer = new cMessage("sendProbe", MK_SCAN_SENDPROBE);
+        scheduleAfter(scanning.probeDelay, scanTimer);
     }
     else {
         // Passive Scan: spend maxChannelTime on the channel (11.1.3.1)
-        cMessage *timerMsg = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
-        scheduleAfter(scanning.maxChannelTime, timerMsg);
+        scanTimer = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
+        scheduleAfter(scanning.maxChannelTime, scanTimer);
     }
 
     return false;
@@ -532,6 +557,27 @@ void Ieee80211MgmtSta::clearCurrentAssociation()
     cancelAndDelete(assocAP.beaconTimeoutMsg);
     assocAP.beaconTimeoutMsg = nullptr;
     assocAP = AssociatedApInfo(); // clear it
+}
+
+void Ieee80211MgmtSta::stop()
+{
+    if (host != nullptr && isScanning && scanning.activeScan)
+        host->unsubscribe(IRadio::receptionStateChangedSignal, this);
+    isScanning = false;
+    cancelScanTimer();
+    scanning = ScanningInfo();
+
+    clearAPList();
+
+    if (mib->bssStationData.isAssociated)
+        clearCurrentAssociation();
+    else {
+        cancelAndDelete(assocAP.beaconTimeoutMsg);
+        assocAP.beaconTimeoutMsg = nullptr;
+        assocAP = AssociatedApInfo();
+    }
+
+    Ieee80211MgmtBase::stop();
 }
 
 void Ieee80211MgmtSta::sendAuthenticationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -521,6 +521,12 @@ void Ieee80211MgmtSta::disassociate()
     EV << "Disassociating from AP address=" << assocAP.address << "\n";
     ASSERT(mib->bssStationData.isAssociated);
     cancelPendingAssociation();
+    clearCurrentAssociation();
+}
+
+void Ieee80211MgmtSta::clearCurrentAssociation()
+{
+    ASSERT(mib->bssStationData.isAssociated);
     mib->bssStationData.isAssociated = false;
     mib->removePeerHtCapabilities(assocAP.address);
     cancelAndDelete(assocAP.beaconTimeoutMsg);
@@ -794,20 +800,35 @@ void Ieee80211MgmtSta::handleReassociationResponseFrame(Packet *packet, const Pt
 void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
     EV << "Received Disassociation frame\n";
-    const MacAddress& address = header->getAddress3(); // source address
+    // IEEE Std 802.11-2024, 9.3.3.1: Address 2 carries the transmitter (TA/SA).
+    const MacAddress& address = header->getTransmitterAddress();
 
-    cancelPendingAssociation();
+    // IEEE Std 802.11-2024, 11.3.5.7: process a Disassociation only from the
+    // AP whose peer state is State 3/4. In particular, a pending association
+    // to another AP must survive an unrelated frame.
     if (!mib->bssStationData.isAssociated || address != assocAP.address) {
         EV << "Not associated with that AP -- ignoring frame\n";
         delete packet;
         return;
     }
 
+    ApInfo *pendingAp = assocTimeoutMsg ? static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer()) : nullptr;
+    bool pendingReassociation = reassociationInProgress;
+    bool terminatesPendingRequest = pendingAp != nullptr && pendingAp->address == address;
+    if (terminatesPendingRequest)
+        cancelPendingAssociation();
+
     EV << "Setting isAssociated flag to false\n";
-    mib->bssStationData.isAssociated = false;
-    mib->removePeerHtCapabilities(address);
-    cancelAndDelete(assocAP.beaconTimeoutMsg);
-    assocAP.beaconTimeoutMsg = nullptr;
+    clearCurrentAssociation();
+    if (terminatesPendingRequest) {
+        // INET primitive policy: the current API has no peer-aborted result,
+        // so a same-peer terminated association/reassociation maps to refusal.
+        if (pendingReassociation)
+            sendReassociationConfirm(pendingAp, PRC_REFUSED);
+        else
+            sendAssociationConfirm(pendingAp, PRC_REFUSED);
+    }
+    delete packet;
 }
 
 void Ieee80211MgmtSta::handleBeaconFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -48,6 +48,8 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
         MacAddress address; // alias bssid
         std::string ssid;
         Ieee80211SupportedRatesElement supportedRates;
+        bool extendedSupportedRatesPresent = false;
+        Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
         simtime_t beaconInterval;
         double rxPower;
 
@@ -190,4 +192,3 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -25,6 +25,33 @@ namespace ieee80211 {
 class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 {
   public:
+    enum class HtAssociationResponseStatus {
+        LEGACY,
+        VALID_HT,
+        INVALID_HT,
+    };
+
+    /** Describes a successful association response whose HT negotiation could not be used. */
+    class INET_API HtNegotiationFailure : public cObject {
+      private:
+        MacAddress peerAddress;
+        bool reassociation = false;
+        HtAssociationResponseStatus status = HtAssociationResponseStatus::INVALID_HT;
+        std::string reason;
+
+      public:
+        void setPeerAddress(const MacAddress& address) { peerAddress = address; }
+        void setReassociation(bool value) { reassociation = value; }
+        void setStatus(HtAssociationResponseStatus value) { status = value; }
+        void setReason(const std::string& value) { reason = value; }
+        const MacAddress& getPeerAddress() const { return peerAddress; }
+        bool isReassociation() const { return reassociation; }
+        HtAssociationResponseStatus getStatus() const { return status; }
+        const std::string& getReason() const { return reason; }
+    };
+
+    static simsignal_t htNegotiationFailedSignal;
+
     //
     // Encapsulates information about the ongoing scanning process
     //
@@ -142,6 +169,14 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Processes Association and Reassociation Responses without using cached Beacon capabilities. */
     virtual void processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation);
+
+    /** Classifies the HT elements in a successful association response. */
+    virtual HtAssociationResponseStatus classifyAssociationResponse(
+            const Ptr<const Ieee80211AssociationResponseFrame>& responseBody,
+            Ieee80211HtCapabilities& responseHtCapabilities, Ieee80211HtOperation& responseHtOperation,
+            std::string& reason) const;
+
+    static const char *getHtAssociationResponseStatusName(HtAssociationResponseStatus status);
 
     /** Applies the failed-reassociation state transition for the target AP. */
     virtual void handleReassociationFailure(ApInfo *ap);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -122,8 +122,11 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     /** Utility function: looks up AP in our AP list. Returns nullptr if not found. */
     virtual ApInfo *lookupAP(const MacAddress& address);
 
-    /** Utility function: clear the AP list, and cancel any pending authentications. */
+    /** Utility function: clear the AP list and cancel pending association and authentication transactions. */
     virtual void clearAPList();
+
+    /** Utility function: cancel any pending association or reassociation. */
+    virtual void cancelPendingAssociation();
 
     /** Utility function: switches to the given radio channel. */
     virtual void changeChannel(int channelNum);
@@ -133,6 +136,11 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Processes Association and Reassociation Responses without using cached Beacon capabilities. */
     virtual void processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation);
+
+    /** Applies the failed-reassociation state transition for the target AP. */
+    virtual void handleReassociationFailure(ApInfo *ap);
+    static bool shouldDisassociateOnReassociationFailure(bool isAssociated,
+            const MacAddress& associatedApAddress, const MacAddress& targetApAddress);
 
     /** Switches to the next channel to scan; returns true if done (there wasn't any more channel to scan). */
     virtual bool scanNextChannel();

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -168,6 +168,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     /** Utility function: Cancel the existing association */
     virtual void disassociate();
 
+    /** Utility function: clear the existing association without touching a pending transition. */
+    virtual void clearCurrentAssociation();
+
     /** Utility function: sends a confirmation to the agent */
     virtual void sendConfirm(Ieee80211PrimConfirm *confirm, Ieee80211PrimResultCode resultCode);
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -211,6 +211,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     /** Utility function: clear the existing association without touching a pending transition. */
     virtual void clearCurrentAssociation();
 
+    /** Processes a peer-initiated termination of the current association. */
+    virtual bool terminateCurrentAssociationFromPeer(const MacAddress& address);
+
     /** Utility function: sends a confirmation to the agent */
     virtual void sendConfirm(Ieee80211PrimConfirm *confirm, Ieee80211PrimResultCode resultCode);
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -89,6 +89,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     // scanning status
     bool isScanning;
+    cMessage *scanTimer;
     ScanningInfo scanning;
 
     // ApInfo list: we collect scanning results and keep track of ongoing authentications here
@@ -102,7 +103,8 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     AssociatedApInfo assocAP;
 
   public:
-    Ieee80211MgmtSta() : host(nullptr), numChannels(-1), isScanning(false), assocTimeoutMsg(nullptr) {}
+    Ieee80211MgmtSta() : host(nullptr), numChannels(-1), isScanning(false), scanTimer(nullptr), assocTimeoutMsg(nullptr) {}
+    virtual ~Ieee80211MgmtSta();
 
     virtual const ApInfo *getAssociatedAp() { return &assocAP; }
 
@@ -149,6 +151,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     /** Switches to the next channel to scan; returns true if done (there wasn't any more channel to scan). */
     virtual bool scanNextChannel();
 
+    /** Utility function: cancels and deletes the outstanding scan timer, if any. */
+    virtual void cancelScanTimer();
+
     /** Broadcasts a Probe Request */
     virtual void sendProbeRequest();
 
@@ -179,6 +184,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Called by the signal handler whenever a change occurs we're interested in */
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
+
+    /** lifecycle support */
+    virtual void stop() override;
 
     /** Utility function: converts Ieee80211StatusCode (->frame) to Ieee80211PrimResultCode (->primitive) */
     virtual Ieee80211PrimResultCode statusCodeToPrimResultCode(int statusCode);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -50,6 +50,10 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
         Ieee80211SupportedRatesElement supportedRates;
         bool extendedSupportedRatesPresent = false;
         Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
+        bool htCapabilitiesPresent = false;
+        Ieee80211HtCapabilities htCapabilities;
+        bool htOperationPresent = false;
+        Ieee80211HtOperation htOperation;
         simtime_t beaconInterval;
         double rxPower;
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -94,6 +94,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     // associated Access Point
     cMessage *assocTimeoutMsg; // if non-nullptr: association is in progress
+    bool reassociationInProgress = false;
     AssociatedApInfo assocAP;
 
   public:
@@ -116,6 +117,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Utility function: sends association request */
     virtual void startAssociation(ApInfo *ap, simtime_t timeout);
+    virtual void startReassociation(ApInfo *ap, simtime_t timeout);
 
     /** Utility function: looks up AP in our AP list. Returns nullptr if not found. */
     virtual ApInfo *lookupAP(const MacAddress& address);
@@ -128,6 +130,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Stores AP info received in a beacon or probe response */
     virtual void storeAPInfo(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, const Ptr<const Ieee80211BeaconFrame>& body);
+
+    /** Processes Association and Reassociation Responses without using cached Beacon capabilities. */
+    virtual void processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation);
 
     /** Switches to the next channel to scan; returns true if done (there wasn't any more channel to scan). */
     virtual bool scanNextChannel();
@@ -146,6 +151,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Sends back result of association to the agent */
     virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode);
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode);
 
     /** Utility function: Cancel the existing association */
     virtual void disassociate();

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.ned
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.ned
@@ -35,10 +35,10 @@ simple Ieee80211MgmtSta extends SimpleModule like IIeee80211Mgmt
         @display("i=block/cogwheel");
         @signal[l2Associated](type=inet::NetworkInterface);
         @signal[l2BeaconLost](type=inet::NetworkInterface);
+        @signal[htNegotiationFailed](type="inet::ieee80211::Ieee80211MgmtSta::HtNegotiationFailure");
     gates:
         input macIn @labels(Ieee80211MacHeader);
         output macOut @labels(Ieee80211MacHeader);
         input agentIn;   // Used for attaching an agent algorithm
         output agentOut; // Used for attaching an agent algorithm
 }
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.cc
@@ -15,6 +15,33 @@ namespace ieee80211 {
 
 Define_Module(Ieee80211MgmtStaSimplified);
 
+static Ieee80211Mib *findAccessPointMib(const MacAddress& accessPointAddress, bool required = true)
+{
+    L3AddressResolver addressResolver;
+    auto host = addressResolver.findHostWithAddress(accessPointAddress);
+    if (host == nullptr) {
+        if (required)
+            throw cRuntimeError("Access point with address %s not found", accessPointAddress.str().c_str());
+        return nullptr;
+    }
+    auto interfaceTable = addressResolver.findInterfaceTableOf(host);
+    if (interfaceTable == nullptr) {
+        if (required)
+            throw cRuntimeError("Access point interface table with address %s not found", accessPointAddress.str().c_str());
+        return nullptr;
+    }
+    auto networkInterface = interfaceTable->findInterfaceByAddress(accessPointAddress);
+    if (networkInterface == nullptr) {
+        if (required)
+            throw cRuntimeError("Access point interface with address %s not found", accessPointAddress.str().c_str());
+        return nullptr;
+    }
+    auto apMib = dynamic_cast<Ieee80211Mib *>(networkInterface->getSubmodule("mib"));
+    if (apMib == nullptr && required)
+        throw cRuntimeError("Access point MIB with address %s not found", accessPointAddress.str().c_str());
+    return apMib;
+}
+
 void Ieee80211MgmtStaSimplified::initialize(int stage)
 {
     Ieee80211MgmtBase::initialize(stage);
@@ -24,18 +51,45 @@ void Ieee80211MgmtStaSimplified::initialize(int stage)
         mib->bssStationData.isAssociated = true;
     }
     else if (stage == INITSTAGE_LINK_LAYER) {
-        L3AddressResolver addressResolver;
-        auto accessPointAddress = addressResolver.resolve(par("accessPointAddress"), L3AddressResolver::ADDR_MAC).toMac();
-        mib->bssData.bssid = accessPointAddress;
-        auto host = addressResolver.findHostWithAddress(mib->bssData.bssid);
-        if (host == nullptr)
-            throw cRuntimeError("Access point with address %s not found", mib->bssData.bssid.str().c_str());
-        auto interfaceTable = addressResolver.findInterfaceTableOf(host);
-        auto networkInterface = interfaceTable->findInterfaceByAddress(mib->bssData.bssid);
-        auto apMib = dynamic_cast<Ieee80211Mib *>(networkInterface->getSubmodule("mib"));
-        apMib->bssAccessPointData.stations[mib->address] = Ieee80211Mib::ASSOCIATED;
-        mib->bssData.ssid = apMib->bssData.ssid;
+        configureAssociation();
     }
+    else if (stage == INITSTAGE_LAST)
+        configureAssociation();
+}
+
+void Ieee80211MgmtStaSimplified::handleStartOperation(LifecycleOperation *operation)
+{
+    Ieee80211MgmtBase::handleStartOperation(operation);
+    if (operation != nullptr)
+        configureAssociation();
+}
+
+void Ieee80211MgmtStaSimplified::configureAssociation()
+{
+    L3AddressResolver addressResolver;
+    auto accessPointAddress = addressResolver.resolve(par("accessPointAddress"), L3AddressResolver::ADDR_MAC).toMac();
+    mib->bssData.bssid = accessPointAddress;
+    auto apMib = findAccessPointMib(accessPointAddress);
+    apMib->bssAccessPointData.stations[mib->address] = Ieee80211Mib::ASSOCIATED;
+    mib->bssData.ssid = apMib->bssData.ssid;
+    mib->bssStationData.isAssociated = true;
+    // Simplified management is an explicit no-air abstraction: install the state that the
+    // Association Request/Response exchange would have committed in detailed management.
+    if (mib->isHtOperationSupported() && apMib->isHtOperationSupported()) {
+        mib->setPeerHtCapabilities(apMib->address, apMib->localHtCapabilities, apMib->htOperation);
+        apMib->setPeerHtCapabilities(mib->address, mib->localHtCapabilities, apMib->htOperation);
+    }
+}
+
+void Ieee80211MgmtStaSimplified::stop()
+{
+    mib->bssStationData.isAssociated = false;
+    auto apMib = findAccessPointMib(mib->bssData.bssid, false);
+    if (apMib != nullptr) {
+        apMib->bssAccessPointData.stations.erase(mib->address);
+        apMib->removePeerHtCapabilities(mib->address);
+    }
+    Ieee80211MgmtBase::stop();
 }
 
 void Ieee80211MgmtStaSimplified::handleTimer(cMessage *msg)
@@ -101,4 +155,3 @@ void Ieee80211MgmtStaSimplified::handleProbeResponseFrame(Packet *packet, const 
 } // namespace ieee80211
 
 } // namespace inet
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.cc
@@ -76,8 +76,8 @@ void Ieee80211MgmtStaSimplified::configureAssociation()
     // Simplified management is an explicit no-air abstraction: install the state that the
     // Association Request/Response exchange would have committed in detailed management.
     if (mib->isHtOperationSupported() && apMib->isHtOperationSupported()) {
-        mib->setPeerHtCapabilities(apMib->address, apMib->localHtCapabilities, apMib->htOperation);
-        apMib->setPeerHtCapabilities(mib->address, mib->localHtCapabilities, apMib->htOperation);
+        mib->setPeerHtCapabilities(apMib->address, apMib->localHtCapabilities, apMib->getHtOperation());
+        apMib->setPeerHtCapabilities(mib->address, mib->localHtCapabilities, apMib->getHtOperation());
     }
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.h
@@ -25,6 +25,9 @@ class INET_API Ieee80211MgmtStaSimplified : public Ieee80211MgmtBase
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int) override;
+    virtual void handleStartOperation(LifecycleOperation *operation) override;
+    virtual void configureAssociation();
+    virtual void stop() override;
 
     /** Implements abstract Ieee80211MgmtBase method */
     virtual void handleTimer(cMessage *msg) override;
@@ -52,4 +55,3 @@ class INET_API Ieee80211MgmtStaSimplified : public Ieee80211MgmtBase
 } // namespace inet
 
 #endif
-

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag.msg
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag.msg
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2026 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+import inet.common.INETDefs;
+import inet.common.TagBase;
+
+namespace inet::ieee80211;
+
+//
+// Identifies a local management transaction across packet replacement and
+// fragmentation. The physical layer removes this sender-local metadata.
+//
+class Ieee80211MgmtTransactionTag extends TagBase
+{
+    uint64_t transactionId = 0;
+}

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211Primitives.msg
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211Primitives.msg
@@ -108,6 +108,8 @@ class Ieee80211Prim_BssDescription extends cObject
     MacAddress BSSID;
     string SSID;
     Ieee80211SupportedRatesElement supportedRates;
+    bool extendedSupportedRatesPresent;
+    Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
     simtime_t beaconInterval;
 
     double rxPower; // received power from AP; not part of the standard

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211HtCapabilities.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211HtCapabilities.h
@@ -1,0 +1,152 @@
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+#ifndef __INET_IEEE80211HTCAPABILITIES_H
+#define __INET_IEEE80211HTCAPABILITIES_H
+
+#include <algorithm>
+#include <array>
+#include <set>
+
+#include "inet/common/Units.h"
+
+namespace inet {
+namespace ieee80211 {
+
+using namespace units::values;
+
+// IEEE Std 802.11-2024, Table 9-230.
+enum class Ieee80211HtProtectionMode : uint8_t {
+    NO_PROTECTION = 0,
+    NONMEMBER_PROTECTION = 1,
+    TWENTY_MHZ_PROTECTION = 2,
+    NON_HT_MIXED = 3,
+};
+
+struct Ieee80211HtMcsNssMap
+{
+    std::array<int, 4> maxMcsPerNss;
+
+    Ieee80211HtMcsNssMap() { maxMcsPerNss.fill(-1); }
+};
+
+/**
+ * Model-backed subset of the HT Capabilities element (IEEE Std 802.11-2024, 9.4.2.54).
+ * Unrepresented optional capabilities are encoded as unsupported or reserved.
+ */
+struct Ieee80211HtCapabilities
+{
+    std::set<Hz> supportedChannelWidths;
+    std::array<bool, 77> rxMcsSupported = {};
+    bool txMcsSetDefined = true;
+    bool txRxMcsSetNotEqual = false;
+    int txMaxNss = 0;
+    bool txUnequalModulation = false;
+    // Modeled per-NSS local Tx ceiling. It is deliberately left unknown when a
+    // received unequal Tx/Rx advertisement supplies only Table 9-226's summary fields.
+    Ieee80211HtMcsNssMap txMcsNss;
+    bool ldpc = false;
+    bool greenfield = false;
+    bool shortGi20 = false;
+    bool shortGi40 = false;
+    int maxAmpduLengthExponent = 0;
+};
+
+/** Model-backed subset of the HT Operation element (IEEE Std 802.11-2024, 9.4.2.55). */
+struct Ieee80211HtOperation
+{
+    Hz operatingChannelWidth = MHz(20);
+    int primaryChannel = 0;
+    int secondaryChannelOffset = 0;
+    Ieee80211HtProtectionMode protectionMode = Ieee80211HtProtectionMode::NO_PROTECTION;
+    std::array<bool, 77> basicMcsSupported = {};
+};
+
+struct Ieee80211HtDirectionalCapabilities
+{
+    bool valid = false;
+    std::set<Hz> supportedChannelWidths;
+    Ieee80211HtMcsNssMap mcsNss;
+    std::array<bool, 77> supportedMcs = {};
+    bool receiverLdpc = false;
+    bool receiverShortGi20 = false;
+    bool receiverShortGi40 = false;
+    int receiverMaxAmpduLengthExponent = 0;
+};
+
+struct Ieee80211NegotiatedHtCapabilities
+{
+    Ieee80211HtCapabilities localAdvertisement;
+    Ieee80211HtCapabilities peerAdvertisement;
+    Ieee80211HtDirectionalCapabilities localTxPeerRx;
+    Ieee80211HtDirectionalCapabilities localRxPeerTx;
+    Ieee80211HtOperation operation;
+};
+
+inline Ieee80211NegotiatedHtCapabilities negotiateHtCapabilities(const Ieee80211HtCapabilities& local,
+        const Ieee80211HtCapabilities& peer, const Ieee80211HtOperation& operation)
+{
+    Ieee80211NegotiatedHtCapabilities negotiated;
+    negotiated.localAdvertisement = local;
+    negotiated.peerAdvertisement = peer;
+    negotiated.operation = operation;
+    for (const auto& width : local.supportedChannelWidths)
+        if (peer.supportedChannelWidths.count(width)) {
+            negotiated.localTxPeerRx.supportedChannelWidths.insert(width);
+            negotiated.localRxPeerTx.supportedChannelWidths.insert(width);
+    }
+    for (int mcs = 0; mcs < 77; mcs++) {
+        int nss = mcs / 8;
+        bool localTx = local.txMcsSetDefined && !local.txRxMcsSetNotEqual ? local.rxMcsSupported[mcs] :
+                nss < 4 && local.txMcsNss.maxMcsPerNss[nss] >= mcs % 8;
+        // Table 9-226 defines the equal case as the exact Rx MCS bitmap, not
+        // a contiguous range ending at the highest advertised MCS.
+        bool peerTx = peer.txMcsSetDefined && !peer.txRxMcsSetNotEqual && peer.rxMcsSupported[mcs];
+        negotiated.localTxPeerRx.supportedMcs[mcs] = localTx && peer.rxMcsSupported[mcs];
+        negotiated.localRxPeerTx.supportedMcs[mcs] = local.rxMcsSupported[mcs] && peerTx;
+    }
+    for (int nss = 0; nss < 4; nss++) {
+        for (int mcs = 0; mcs < 8; mcs++) {
+            if (negotiated.localTxPeerRx.supportedMcs[nss * 8 + mcs])
+                negotiated.localTxPeerRx.mcsNss.maxMcsPerNss[nss] = mcs;
+            if (negotiated.localRxPeerTx.supportedMcs[nss * 8 + mcs])
+                negotiated.localRxPeerTx.mcsNss.maxMcsPerNss[nss] = mcs;
+        }
+    }
+    // LDPC and short-GI bits advertise receiver capability, so they are directional.
+    negotiated.localTxPeerRx.receiverLdpc = peer.ldpc;
+    negotiated.localRxPeerTx.receiverLdpc = local.ldpc;
+    negotiated.localTxPeerRx.receiverShortGi20 = peer.shortGi20;
+    negotiated.localRxPeerTx.receiverShortGi20 = local.shortGi20;
+    negotiated.localTxPeerRx.receiverShortGi40 = peer.shortGi40;
+    negotiated.localRxPeerTx.receiverShortGi40 = local.shortGi40;
+    negotiated.localTxPeerRx.receiverMaxAmpduLengthExponent = peer.maxAmpduLengthExponent;
+    negotiated.localRxPeerTx.receiverMaxAmpduLengthExponent = local.maxAmpduLengthExponent;
+    // The HT Operation width is the BSS maximum. A 20 MHz-only STA may join a
+    // 20/40 MHz BSS, so validity requires a common usable width, not equality
+    // with the advertised BSS width (IEEE Std 802.11-2024, 11.15.2).
+    negotiated.localTxPeerRx.valid = !negotiated.localTxPeerRx.supportedChannelWidths.empty() &&
+            negotiated.localTxPeerRx.supportedMcs[0];
+    // An undefined peer Tx MCS set is permitted by Table 9-226. It is unknown,
+    // rather than an advertisement that the peer cannot transmit.
+    bool peerTxMcsUnknown = !peer.txMcsSetDefined || peer.txRxMcsSetNotEqual;
+    negotiated.localRxPeerTx.valid = !negotiated.localRxPeerTx.supportedChannelWidths.empty() &&
+            (peerTxMcsUnknown || negotiated.localRxPeerTx.supportedMcs[0]);
+    return negotiated;
+}
+
+inline bool supportsBasicHtMcsSet(const Ieee80211HtCapabilities& capabilities, const Ieee80211HtOperation& operation)
+{
+    for (int mcs = 0; mcs < 77; mcs++)
+        if (operation.basicMcsSupported[mcs] && !capabilities.rxMcsSupported[mcs])
+            return false;
+    return true;
+}
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -86,6 +86,8 @@ void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeS
     const auto& supportedMcs = modeSet->getHtMcsSupported();
     const auto& mandatoryMcs = modeSet->getHtMcsMandatory();
     localHtCapabilities.supportedChannelWidths = modeSet->getHtSupportedChannelWidths();
+    localHtCapabilities.shortGi20 = modeSet->isHtShortGuardIntervalSupported(MHz(20));
+    localHtCapabilities.shortGi40 = modeSet->isHtShortGuardIntervalSupported(MHz(40));
     for (int mcs = 0; mcs < 77; mcs++) {
         localHtCapabilities.rxMcsSupported[mcs] = supportedMcs[mcs];
         if (mcs < 32 && supportedMcs[mcs]) {

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -7,6 +7,10 @@
 
 #include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 
+#include <algorithm>
+
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+
 namespace inet {
 
 namespace ieee80211 {
@@ -19,6 +23,7 @@ void Ieee80211Mib::initialize(int stage)
         WATCH(address);
         WATCH(mode);
         WATCH(qos);
+        WATCH(localHtCapabilitiesValid);
         WATCH(bssData.bssid);
         WATCH(bssStationData.stationType);
         WATCH(bssStationData.isAssociated);
@@ -31,6 +36,91 @@ void Ieee80211Mib::initialize(int stage)
         WATCH_EXPR("ssid", bssData.ssid.empty() ? std::string("-") : bssData.ssid); // associated SSID ("-" if none), for node display strings
         WATCH_EXPR("associatedStr", bssStationData.stationType == STATION ? (bssStationData.isAssociated ? "\nAssociated" : "\nNot associated") : "");
     }
+}
+
+void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet)
+{
+    // The radio publishes its initial channel at PHYSICAL_LAYER before the MAC
+    // publishes its mode set at LINK_LAYER. Preserve that independent BSS
+    // operation input when rebuilding the mode-derived capability subset.
+    int primaryChannel = htOperation.primaryChannel;
+    localHtCapabilities = Ieee80211HtCapabilities();
+    htOperation = Ieee80211HtOperation();
+    htOperation.primaryChannel = primaryChannel;
+    localHtCapabilitiesValid = modeSet != nullptr && modeSet->isHtOperationSupported();
+    if (!localHtCapabilitiesValid) {
+        clearPeerHtCapabilities();
+        return;
+    }
+
+    // IEEE Std 802.11-2024, 9.4.2.54.4 and 9.4.2.55: advertise exactly the
+    // HT modes and HT-only channel widths present in the authoritative mode
+    // set. In particular, do not infer dense MCS blocks or HT widths from
+    // legacy/VHT modes that happen to share the set.
+    const auto& supportedMcs = modeSet->getHtMcsSupported();
+    const auto& mandatoryMcs = modeSet->getHtMcsMandatory();
+    localHtCapabilities.supportedChannelWidths = modeSet->getHtSupportedChannelWidths();
+    for (int mcs = 0; mcs < 77; mcs++) {
+        localHtCapabilities.rxMcsSupported[mcs] = supportedMcs[mcs];
+        if (mcs < 32 && supportedMcs[mcs]) {
+            int nss = mcs / 8;
+            localHtCapabilities.txMcsNss.maxMcsPerNss[nss] = std::max(localHtCapabilities.txMcsNss.maxMcsPerNss[nss], mcs % 8);
+        }
+        htOperation.basicMcsSupported[mcs] = mandatoryMcs[mcs];
+    }
+    if (localHtCapabilities.supportedChannelWidths.empty())
+        throw cRuntimeError("HT operation mode set '%s' does not provide an HT channel width", modeSet->getName());
+    localHtCapabilities.maxAmpduLengthExponent = par("htMaxAmpduLengthExponent");
+    if (localHtCapabilities.maxAmpduLengthExponent < 0 || localHtCapabilities.maxAmpduLengthExponent > 3)
+        throw cRuntimeError("htMaxAmpduLengthExponent must be between 0 and 3");
+
+    htOperation.secondaryChannelOffset = par("htSecondaryChannelOffset");
+    if (htOperation.secondaryChannelOffset != 0 && htOperation.secondaryChannelOffset != 1 && htOperation.secondaryChannelOffset != 3)
+        throw cRuntimeError("htSecondaryChannelOffset must be 0, 1, or 3");
+    bool use40Mhz = htOperation.secondaryChannelOffset != 0;
+    if (use40Mhz && localHtCapabilities.supportedChannelWidths.count(MHz(40)) == 0)
+        throw cRuntimeError("40 MHz HT operation requires a 40 MHz-capable mode set");
+    htOperation.operatingChannelWidth = use40Mhz ? MHz(40) : MHz(20);
+    int protectionMode = par("htProtectionMode");
+    if (protectionMode < 0 || protectionMode > 3)
+        throw cRuntimeError("htProtectionMode must be between 0 and 3");
+    htOperation.protectionMode = static_cast<Ieee80211HtProtectionMode>(protectionMode);
+    for (auto& entry : peerHtStates)
+        if (entry.second.valid)
+            entry.second.negotiatedCapabilities = negotiateHtCapabilities(localHtCapabilities,
+                    entry.second.advertisedCapabilities, entry.second.negotiatedCapabilities.operation);
+}
+
+const Ieee80211Mib::PeerHtState *Ieee80211Mib::findPeerHtState(const MacAddress& address) const
+{
+    auto it = peerHtStates.find(address);
+    return it == peerHtStates.end() || !it->second.valid ? nullptr : &it->second;
+}
+
+void Ieee80211Mib::setPeerHtCapabilities(const MacAddress& address, const Ieee80211HtCapabilities& capabilities,
+        const Ieee80211HtOperation& operation)
+{
+    if (!localHtCapabilitiesValid)
+        throw cRuntimeError("Cannot install peer HT capabilities when local HT operation is disabled");
+    auto& state = peerHtStates[address];
+    state.valid = true;
+    state.advertisedCapabilities = capabilities;
+    state.negotiatedCapabilities = negotiateHtCapabilities(localHtCapabilities, capabilities, operation);
+    if (++state.generation == 0)
+        state.generation = 1;
+    EV_INFO << "Installed peer HT state, peer = " << address
+            << ", txValid = " << state.negotiatedCapabilities.localTxPeerRx.valid
+            << ", rxValid = " << state.negotiatedCapabilities.localRxPeerTx.valid << endl;
+}
+
+void Ieee80211Mib::removePeerHtCapabilities(const MacAddress& address)
+{
+    peerHtStates.erase(address);
+}
+
+void Ieee80211Mib::clearPeerHtCapabilities()
+{
+    peerHtStates.clear();
 }
 
 std::string Ieee80211Mib::getSsidStr() const
@@ -82,6 +172,7 @@ short Ieee80211Mib::allocateAssociationId(const MacAddress& address)
 void Ieee80211Mib::releaseAssociationId(const MacAddress& address)
 {
     bssAccessPointData.associationIds.erase(address);
+    removePeerHtCapabilities(address);
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -24,6 +24,7 @@ void Ieee80211Mib::initialize(int stage)
         WATCH(mode);
         WATCH(qos);
         WATCH(localHtCapabilitiesValid);
+        WATCH(primaryChannelAvailable);
         WATCH(bssData.bssid);
         WATCH(bssStationData.stationType);
         WATCH(bssStationData.isAssociated);
@@ -36,7 +37,29 @@ void Ieee80211Mib::initialize(int stage)
         WATCH_EXPR("ssidStr", getSsidStr());
         WATCH_EXPR("ssid", bssData.ssid.empty() ? std::string("-") : bssData.ssid); // associated SSID ("-" if none), for node display strings
         WATCH_EXPR("associatedStr", bssStationData.stationType == STATION ? (bssStationData.isAssociated ? "\nAssociated" : "\nNot associated") : "");
+        WATCH_EXPR("primaryChannel", primaryChannelAvailable ? std::to_string(htOperation.primaryChannel) : "unavailable");
     }
+}
+
+int Ieee80211Mib::requirePrimaryChannel() const
+{
+    if (!primaryChannelAvailable)
+        throw cRuntimeError("IEEE 802.11 primary channel is unavailable");
+    return htOperation.primaryChannel;
+}
+
+void Ieee80211Mib::setPrimaryChannel(int primaryChannel)
+{
+    if (primaryChannel < 0 || primaryChannel > 255)
+        throw cRuntimeError("IEEE 802.11 primary channel must be in the range 0..255, not %d", primaryChannel);
+    htOperation.primaryChannel = primaryChannel;
+    primaryChannelAvailable = true;
+}
+
+const Ieee80211HtOperation& Ieee80211Mib::getHtOperation() const
+{
+    requirePrimaryChannel();
+    return htOperation;
 }
 
 void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet)
@@ -44,10 +67,12 @@ void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeS
     // The radio publishes its initial channel at PHYSICAL_LAYER before the MAC
     // publishes its mode set at LINK_LAYER. Preserve that independent BSS
     // operation input when rebuilding the mode-derived capability subset.
+    bool wasPrimaryChannelAvailable = primaryChannelAvailable;
     int primaryChannel = htOperation.primaryChannel;
     localHtCapabilities = Ieee80211HtCapabilities();
     htOperation = Ieee80211HtOperation();
     htOperation.primaryChannel = primaryChannel;
+    primaryChannelAvailable = wasPrimaryChannelAvailable;
     localHtCapabilitiesValid = modeSet != nullptr && modeSet->isHtOperationSupported();
     if (!localHtCapabilitiesValid) {
         clearPeerHtCapabilities();

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -29,6 +29,7 @@ void Ieee80211Mib::initialize(int stage)
         WATCH(bssStationData.isAssociated);
         WATCH(bssAccessPointData.stations);
         WATCH(bssAccessPointData.associationIds);
+        WATCH(associationIdReservations);
         WATCH_EXPR("modeStr", getModeStr(mode));
         WATCH_EXPR("stationTypeStr", getStationTypeStr(bssStationData.stationType));
         WATCH_EXPR("qosStr", qos ? ", QoS" : ", Non-QoS");
@@ -149,30 +150,74 @@ const char *Ieee80211Mib::getStationTypeStr(Ieee80211Mib::BssStationType station
     }
 }
 
-short Ieee80211Mib::allocateAssociationId(const MacAddress& address)
+short Ieee80211Mib::reserveAssociationId(const MacAddress& address)
 {
-    auto existing = bssAccessPointData.associationIds.find(address);
-    if (existing != bssAccessPointData.associationIds.end())
-        return existing->second;
+    // IEEE Std 802.11-2024, 9.4.1.8: an AP assigns AID values in the range 1 through 2007.
+    auto committed = bssAccessPointData.associationIds.find(address);
+    if (committed != bssAccessPointData.associationIds.end())
+        return committed->second;
+    auto reserved = associationIdReservations.find(address);
+    if (reserved != associationIdReservations.end())
+        return reserved->second;
+
+    std::array<bool, 2008> used = {};
+    for (const auto& entry : bssAccessPointData.associationIds)
+        if (entry.second >= 1 && entry.second <= 2007)
+            used[entry.second] = true;
+    for (const auto& entry : associationIdReservations)
+        if (entry.second >= 1 && entry.second <= 2007)
+            used[entry.second] = true;
     for (short aid = 1; aid <= 2007; aid++) {
-        bool used = false;
-        for (const auto& entry : bssAccessPointData.associationIds)
-            if (entry.second == aid) {
-                used = true;
-                break;
-            }
-        if (!used) {
-            bssAccessPointData.associationIds[address] = aid;
+        if (!used[aid]) {
+            associationIdReservations[address] = aid;
             return aid;
         }
     }
     throw cRuntimeError("No IEEE 802.11 association ID is available");
 }
 
+short Ieee80211Mib::commitAssociationId(const MacAddress& address)
+{
+    auto committed = bssAccessPointData.associationIds.find(address);
+    if (committed != bssAccessPointData.associationIds.end()) {
+        associationIdReservations.erase(address);
+        return committed->second;
+    }
+    auto reserved = associationIdReservations.find(address);
+    if (reserved == associationIdReservations.end())
+        throw cRuntimeError("No IEEE 802.11 association ID is reserved for %s", address.str().c_str());
+    short aid = reserved->second;
+    for (const auto& entry : bssAccessPointData.associationIds)
+        if (entry.second == aid)
+            throw cRuntimeError("Reserved IEEE 802.11 association ID %d is already committed", aid);
+    bssAccessPointData.associationIds[address] = aid;
+    associationIdReservations.erase(reserved);
+    return aid;
+}
+
+void Ieee80211Mib::cancelAssociationIdReservation(const MacAddress& address)
+{
+    associationIdReservations.erase(address);
+}
+
+short Ieee80211Mib::allocateAssociationId(const MacAddress& address)
+{
+    reserveAssociationId(address);
+    return commitAssociationId(address);
+}
+
 void Ieee80211Mib::releaseAssociationId(const MacAddress& address)
 {
+    associationIdReservations.erase(address);
     bssAccessPointData.associationIds.erase(address);
     removePeerHtCapabilities(address);
+}
+
+void Ieee80211Mib::clearAssociationIds()
+{
+    associationIdReservations.clear();
+    bssAccessPointData.associationIds.clear();
+    clearPeerHtCapabilities();
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
@@ -81,6 +81,7 @@ class INET_API Ieee80211Mib : public SimpleModule
     Ieee80211HtOperation htOperation;
 
   private:
+    std::map<MacAddress, short> associationIdReservations;
     std::map<MacAddress, PeerHtState> peerHtStates;
 
   protected:
@@ -90,8 +91,12 @@ class INET_API Ieee80211Mib : public SimpleModule
     static const char *getModeStr(Ieee80211Mib::Mode mode);
     static const char *getStationTypeStr(Ieee80211Mib::BssStationType stationType);
     std::string getSsidStr() const;
+    short reserveAssociationId(const MacAddress& address);
+    short commitAssociationId(const MacAddress& address);
+    void cancelAssociationIdReservation(const MacAddress& address);
     short allocateAssociationId(const MacAddress& address);
     void releaseAssociationId(const MacAddress& address);
+    void clearAssociationIds();
     void updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet);
     bool isHtOperationSupported() const { return localHtCapabilitiesValid; }
     const PeerHtState *findPeerHtState(const MacAddress& address) const;

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
@@ -10,8 +10,13 @@
 
 #include "inet/common/SimpleModule.h"
 #include "inet/linklayer/common/MacAddress.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211HtCapabilities.h"
 
 namespace inet {
+
+namespace physicallayer {
+class Ieee80211ModeSet;
+}
 
 namespace ieee80211 {
 
@@ -53,6 +58,14 @@ class INET_API Ieee80211Mib : public SimpleModule
         std::map<MacAddress, short> associationIds;
     };
 
+    class INET_API PeerHtState {
+      public:
+        bool valid = false;
+        Ieee80211HtCapabilities advertisedCapabilities;
+        Ieee80211NegotiatedHtCapabilities negotiatedCapabilities;
+        uint64_t generation = 0;
+    };
+
   public:
     MacAddress address;
     Mode mode = static_cast<Mode>(-1);
@@ -61,6 +74,14 @@ class INET_API Ieee80211Mib : public SimpleModule
     BssData bssData;
     BssStationData bssStationData;
     BssAccessPointData bssAccessPointData;
+
+    // This is a deliberately model-backed subset, not a full Annex C HT MIB implementation.
+    bool localHtCapabilitiesValid = false;
+    Ieee80211HtCapabilities localHtCapabilities;
+    Ieee80211HtOperation htOperation;
+
+  private:
+    std::map<MacAddress, PeerHtState> peerHtStates;
 
   protected:
     virtual void initialize(int stage) override;
@@ -71,6 +92,12 @@ class INET_API Ieee80211Mib : public SimpleModule
     std::string getSsidStr() const;
     short allocateAssociationId(const MacAddress& address);
     void releaseAssociationId(const MacAddress& address);
+    void updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet);
+    bool isHtOperationSupported() const { return localHtCapabilitiesValid; }
+    const PeerHtState *findPeerHtState(const MacAddress& address) const;
+    void setPeerHtCapabilities(const MacAddress& address, const Ieee80211HtCapabilities& capabilities, const Ieee80211HtOperation& operation);
+    void removePeerHtCapabilities(const MacAddress& address);
+    void clearPeerHtCapabilities();
 };
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
@@ -78,9 +78,10 @@ class INET_API Ieee80211Mib : public SimpleModule
     // This is a deliberately model-backed subset, not a full Annex C HT MIB implementation.
     bool localHtCapabilitiesValid = false;
     Ieee80211HtCapabilities localHtCapabilities;
-    Ieee80211HtOperation htOperation;
 
   private:
+    Ieee80211HtOperation htOperation;
+    bool primaryChannelAvailable = false;
     std::map<MacAddress, short> associationIdReservations;
     std::map<MacAddress, PeerHtState> peerHtStates;
 
@@ -99,6 +100,10 @@ class INET_API Ieee80211Mib : public SimpleModule
     void clearAssociationIds();
     void updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet);
     bool isHtOperationSupported() const { return localHtCapabilitiesValid; }
+    bool hasPrimaryChannel() const { return primaryChannelAvailable; }
+    int requirePrimaryChannel() const;
+    void setPrimaryChannel(int primaryChannel);
+    const Ieee80211HtOperation& getHtOperation() const;
     const PeerHtState *findPeerHtState(const MacAddress& address) const;
     void setPeerHtCapabilities(const MacAddress& address, const Ieee80211HtCapabilities& capabilities, const Ieee80211HtOperation& operation);
     void removePeerHtCapabilities(const MacAddress& address);

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.ned
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.ned
@@ -20,7 +20,10 @@ simple Ieee80211Mib extends SimpleModule
 {
     parameters:
         @class(Ieee80211Mib);
+        // Model-backed subset of IEEE Std 802.11-2024 HT capability/operation state; not a full Annex C MIB.
+        int htMaxAmpduLengthExponent = default(0); // maximum received A-MPDU length exponent (0..3)
+        int htSecondaryChannelOffset = default(0); // BSS operation policy: 0=20 MHz, 1=40 MHz above, 3=40 MHz below; bounded by the mode set
+        int htProtectionMode = default(0); // 0=none, 1=nonmember, 2=20 MHz, 3=non-HT mixed
         displayStringTextFormat = default("Address: {address}{ssidStr}\n{modeStr}{stationTypeStr}{qosStr}{associatedStr}");
         @display("i=block/table");
 }
-

--- a/src/inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmReceiver.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmReceiver.cc
@@ -7,6 +7,7 @@
 
 #include "inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmReceiver.h"
 
+#include "inet/common/ProtocolTag_m.h"
 #include "inet/common/packet/chunk/BytesChunk.h"
 #include "inet/physicallayer/wireless/common/analogmodel/dimensional/DimensionalReceptionAnalogModel.h"
 #include "inet/physicallayer/wireless/common/analogmodel/dimensional/DimensionalMediumAnalogModel.h"
@@ -411,6 +412,14 @@ const IReceptionResult *Ieee80211LayeredOfdmReceiver::computeReceptionResult(con
     }
     // add indications
     auto packet = const_cast<Packet *>(packetModel->getPacket());
+    // Packet-domain error models duplicate the transmitted packet, including
+    // sender-local tags.  Reception results must expose only metadata that is
+    // authoritative at this boundary, just like ReceiverBase does for flat
+    // packet-level radios.
+    auto transmittedPacket = transmission->getPacket();
+    auto transmittedProtocolTag = transmittedPacket->getTag<PacketProtocolTag>();
+    packet->clearTags();
+    packet->addTag<PacketProtocolTag>()->setProtocol(transmittedProtocolTag->getProtocol());
     auto snirInd = packet->addTagIfAbsent<SnirInd>();
     snirInd->setMinimumSnir(snir->getMin());
     snirInd->setMaximumSnir(snir->getMax());

--- a/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
@@ -51,6 +51,10 @@ class INET_API IIeee80211DataMode : public cObject, public IPrintableObject
 class INET_API IIeee80211Mode : public cObject, public IPrintableObject
 {
   public:
+    // Returns the HT MCS index represented by this mode, or -1 for modes from
+    // other PHY generations. HT capability derivation must use this typed
+    // mode contract rather than concrete-type or name-based inference.
+    virtual int getHtMcsIndex() const { return -1; }
     virtual int getLegacyCwMin() const = 0;
     virtual int getLegacyCwMax() const = 0;
     virtual const char *getName() const = 0;
@@ -77,4 +81,3 @@ class INET_API IIeee80211Mode : public cObject, public IPrintableObject
 } // namespace inet
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h
@@ -55,6 +55,9 @@ class INET_API IIeee80211Mode : public cObject, public IPrintableObject
     // other PHY generations. HT capability derivation must use this typed
     // mode contract rather than concrete-type or name-based inference.
     virtual int getHtMcsIndex() const { return -1; }
+    // Returns whether this mode uses the optional 400 ns HT guard interval.
+    // Non-HT modes deliberately report false.
+    virtual bool isHtShortGuardInterval() const { return false; }
     virtual int getLegacyCwMin() const = 0;
     virtual int getLegacyCwMax() const = 0;
     virtual const char *getName() const = 0;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
@@ -245,6 +245,7 @@ class INET_API Ieee80211HtMode : public Ieee80211ModeBase
 
     virtual const Ieee80211HtDataMode *getDataMode() const override { return dataMode; }
     virtual int getHtMcsIndex() const override { return dataMode->getMcsIndex(); }
+    virtual bool isHtShortGuardInterval() const override { return dataMode->getGuardIntervalType() == Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT; }
     virtual const Ieee80211HtPreambleMode *getPreambleMode() const override { return preambleMode; }
     virtual const Ieee80211HtSignalMode *getHeaderMode() const override { return preambleMode->getSignalMode(); }
     virtual const Ieee80211OfdmSignalMode *getLegacySignalMode() const { return preambleMode->getLegacySignalMode(); }

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
@@ -249,13 +249,13 @@ class INET_API Ieee80211HtMode : public Ieee80211ModeBase
     virtual const Ieee80211HtSignalMode *getHeaderMode() const override { return preambleMode->getSignalMode(); }
     virtual const Ieee80211OfdmSignalMode *getLegacySignalMode() const { return preambleMode->getLegacySignalMode(); }
 
-    // Table 20-25—MIMO PHY characteristics
+    // IEEE Std 802.11-2024, Table 19-25—HT PHY characteristics.
     virtual const simtime_t getSlotTime() const override;
     virtual const simtime_t getShortSlotTime() const;
     virtual const simtime_t getSifsTime() const override;
     virtual const simtime_t getRifsTime() const override { return 2E-6; }
     virtual const simtime_t getCcaTime() const override { return 4E-6; } // < 4
-    virtual const simtime_t getPhyRxStartDelay() const override { return 33E-6; }
+    virtual const simtime_t getPhyRxStartDelay() const override { return 24E-6; }
     virtual const simtime_t getRxTxTurnaroundTime() const override { return 2E-6; } // < 2
     virtual const simtime_t getPreambleLength() const override { return 16E-6; }
     virtual const simtime_t getPlcpHeaderLength() const override { return 4E-6; }

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h
@@ -244,6 +244,7 @@ class INET_API Ieee80211HtMode : public Ieee80211ModeBase
     virtual ~Ieee80211HtMode() { delete preambleMode; delete dataMode; }
 
     virtual const Ieee80211HtDataMode *getDataMode() const override { return dataMode; }
+    virtual int getHtMcsIndex() const override { return dataMode->getMcsIndex(); }
     virtual const Ieee80211HtPreambleMode *getPreambleMode() const override { return preambleMode; }
     virtual const Ieee80211HtSignalMode *getHeaderMode() const override { return preambleMode->getSignalMode(); }
     virtual const Ieee80211OfdmSignalMode *getLegacySignalMode() const { return preambleMode->getLegacySignalMode(); }
@@ -473,4 +474,3 @@ class INET_API Ieee80211HtCompliantModes
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -546,7 +546,10 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
                     mcsIndex, entry.mode->getName(), this->name.c_str());
         htMcsSupported[mcsIndex] = true;
         htMcsMandatory[mcsIndex] = htMcsMandatory[mcsIndex] || entry.isMandatory;
-        htSupportedChannelWidths.insert(entry.mode->getDataMode()->getBandwidth());
+        auto bandwidth = entry.mode->getDataMode()->getBandwidth();
+        htSupportedChannelWidths.insert(bandwidth);
+        if (entry.mode->isHtShortGuardInterval())
+            htShortGuardIntervalChannelWidths.insert(bandwidth);
     }
     if (htOperationSupported) {
         for (int mcsIndex = 0; mcsIndex < 8; mcsIndex++)
@@ -674,6 +677,18 @@ const IIeee80211Mode *Ieee80211ModeSet::getFastestMandatoryMode() const
         if (entries[i].isMandatory)
             return entries[i].mode;
     return nullptr;
+}
+
+const IIeee80211Mode *Ieee80211ModeSet::getFastestLegacyOperationalMode() const
+{
+    const IIeee80211Mode *fastestMandatoryLegacyMode = nullptr;
+    for (const auto *mode : legacyOperationalModes) {
+        if (getIsMandatory(mode))
+            fastestMandatoryLegacyMode = mode;
+    }
+    if (fastestMandatoryLegacyMode != nullptr)
+        return fastestMandatoryLegacyMode;
+    return legacyOperationalModes.empty() ? nullptr : legacyOperationalModes.back();
 }
 
 const IIeee80211Mode *Ieee80211ModeSet::getSlowerMandatoryMode(const IIeee80211Mode *mode) const

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -35,13 +35,13 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211OfdmCompliantModes::ofdmMode36Mbps, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode48Mbps, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode54Mbps, true },
-    }),
+    }, OperatingPhy::OFDM),
     Ieee80211ModeSet("b", {
         { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
         { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps, true },
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble, true },
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
-    }),
+    }, OperatingPhy::HR_DSSS),
     // TODO slotTime, cwMin, cwMax must be identical in all modes
     Ieee80211ModeSet("g(mixed)", {
         { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
@@ -56,7 +56,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode36Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode48Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode54Mbps, true }, // TODO ERP-CCK, ERP-PBCC, DSSS-OFDM
-    }),
+    }, OperatingPhy::ERP),
     Ieee80211ModeSet("g(erp)", {
         { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode6Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode9Mbps, true },
@@ -66,7 +66,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode36Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode48Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode54Mbps, true },
-    }),
+    }, OperatingPhy::ERP),
     Ieee80211ModeSet("p", {
         { true, &Ieee80211OfdmCompliantModes::ofdmMode3MbpsCS10MHz, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode4_5MbpsCS10MHz, true },
@@ -76,7 +76,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211OfdmCompliantModes::ofdmMode18MbpsCS10MHz, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS10MHz, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode27Mbps, true },
-        }),
+        }, OperatingPhy::OFDM),
     Ieee80211ModeSet("n(mixed-2.4Ghz)", { // This table is not complete; it only contains 2.4GHz homogeneous spatial streams, all mandatory and optional modes
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs0BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs1BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -152,7 +152,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
         { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode12Mbps, true },
         { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode24Mbps, true }
-    }, true),
+    }, OperatingPhy::HT, true),
     Ieee80211ModeSet("ac", {
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs1BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -471,11 +471,12 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { true, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS20MHz, true },
     // Intentional model limitation: unlike IEEE Std 802.11-2024, 11.38.1,
     // this VHT-only profile has no selectable HT modes.
-    }, false),}; });
+    }, OperatingPhy::VHT),}; });
 
-Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, bool htOperationSupported) :
+Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, OperatingPhy operatingPhy, bool htOperationSupported) :
     name(name),
     entries(entries),
+    operatingPhy(operatingPhy),
     referenceMode(entries.empty() ? nullptr : entries.front().mode),
     htOperationSupported(htOperationSupported)
 {
@@ -505,6 +506,11 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
                 this->legacyOperationalModes.push_back(entry.mode);
         }
     }
+    // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6: an ordinary STA
+    // advertises its applicable operational rates in Supported Rates. This
+    // model has no selector-only S1G/CMMG mode-set exception.
+    if (this->legacyOperationalModes.empty())
+        throw cRuntimeError("IEEE 802.11 mode set '%s' must contain at least one legacy operational mode for Supported Rates", this->name.c_str());
     for (const auto *mode : this->legacyOperationalModes) {
         if (mode == nullptr)
             throw cRuntimeError("IEEE 802.11 mode set '%s' contains a null legacy operational mode", this->name.c_str());

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -35,14 +35,15 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211OfdmCompliantModes::ofdmMode36Mbps, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode48Mbps, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode54Mbps, true },
-    }, OperatingPhy::OFDM),
+    }, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS20MHz, OperatingPhy::OFDM),
     Ieee80211ModeSet("b", {
         { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
         { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps, true },
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble, true },
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
-    }, OperatingPhy::HR_DSSS),
-    // TODO slotTime, cwMin, cwMax must be identical in all modes
+    }, &Ieee80211DsssCompliantModes::dsssMode1Mbps, OperatingPhy::HR_DSSS),
+    // Mixed-ERP timing is intentionally anchored to the explicitly selected
+    // DSSS reference mode; the entries do not need identical timing values.
     Ieee80211ModeSet("g(mixed)", {
         { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
         { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps, true },
@@ -56,7 +57,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode36Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode48Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode54Mbps, true }, // TODO ERP-CCK, ERP-PBCC, DSSS-OFDM
-    }, OperatingPhy::ERP),
+    }, &Ieee80211DsssCompliantModes::dsssMode1Mbps, OperatingPhy::ERP),
     Ieee80211ModeSet("g(erp)", {
         { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode6Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode9Mbps, true },
@@ -66,7 +67,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode36Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode48Mbps, true },
         { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode54Mbps, true },
-    }, OperatingPhy::ERP),
+    }, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode6Mbps, OperatingPhy::ERP),
     Ieee80211ModeSet("p", {
         { true, &Ieee80211OfdmCompliantModes::ofdmMode3MbpsCS10MHz, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode4_5MbpsCS10MHz, true },
@@ -76,7 +77,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, &Ieee80211OfdmCompliantModes::ofdmMode18MbpsCS10MHz, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS10MHz, true },
         { false, &Ieee80211OfdmCompliantModes::ofdmMode27Mbps, true },
-        }, OperatingPhy::OFDM),
+        }, &Ieee80211OfdmCompliantModes::ofdmMode3MbpsCS10MHz, OperatingPhy::OFDM),
     Ieee80211ModeSet("n(mixed-2.4Ghz)", { // This table is not complete; it only contains 2.4GHz homogeneous spatial streams, all mandatory and optional modes
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs0BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs1BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -152,7 +153,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
         { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode12Mbps, true },
         { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode24Mbps, true }
-    }, OperatingPhy::HT, true),
+    }, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs0BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG), OperatingPhy::HT, true),
     Ieee80211ModeSet("ac", {
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs1BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -471,28 +472,44 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { true, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS20MHz, true },
     // Intentional model limitation: unlike IEEE Std 802.11-2024, 11.38.1,
     // this VHT-only profile has no selectable HT modes.
-    }, OperatingPhy::VHT),}; });
+    }, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG), OperatingPhy::VHT),}; });
 
-Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, OperatingPhy operatingPhy, bool htOperationSupported) :
+Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, const IIeee80211Mode *referenceMode,
+        OperatingPhy operatingPhy, bool htOperationSupported) :
     name(name),
     entries(entries),
     operatingPhy(operatingPhy),
-    referenceMode(entries.empty() ? nullptr : entries.front().mode),
+    referenceMode(referenceMode),
     htOperationSupported(htOperationSupported)
 {
     if (this->entries.empty())
         throw cRuntimeError("IEEE 802.11 mode set '%s' must contain at least one mode", this->name.c_str());
-    if (referenceMode == nullptr)
+    if (this->referenceMode == nullptr)
         throw cRuntimeError("IEEE 802.11 mode set '%s' has a null reference mode", this->name.c_str());
+    int referenceModeCount = 0;
     for (const auto& entry : this->entries) {
         if (entry.mode == nullptr)
             throw cRuntimeError("IEEE 802.11 mode set '%s' contains a null mode", this->name.c_str());
+        if (entry.mode == this->referenceMode)
+            referenceModeCount++;
         if (entry.isLegacyOperational) {
             auto bitrate = entry.mode->getDataMode()->getNetBitrate().get<Mbps>();
             if (!std::isfinite(bitrate) || bitrate <= 0 || bitrate > 63.5)
                 throw cRuntimeError("Mode '%s' is not representable as a legacy Supported Rate in IEEE 802.11 mode set '%s'", entry.mode->getName(), this->name.c_str());
         }
     }
+    if (referenceModeCount == 0)
+        throw cRuntimeError("Reference mode '%s' is not contained in IEEE 802.11 mode set '%s'", this->referenceMode->getName(), this->name.c_str());
+    if (referenceModeCount > 1)
+        throw cRuntimeError("Reference mode '%s' occurs %d times in IEEE 802.11 mode set '%s'", this->referenceMode->getName(), referenceModeCount, this->name.c_str());
+    if (this->referenceMode->getSifsTime() <= SIMTIME_ZERO)
+        throw cRuntimeError("Reference mode '%s' in IEEE 802.11 mode set '%s' has a non-positive SIFS time", this->referenceMode->getName(), this->name.c_str());
+    if (this->referenceMode->getSlotTime() <= SIMTIME_ZERO)
+        throw cRuntimeError("Reference mode '%s' in IEEE 802.11 mode set '%s' has a non-positive slot time", this->referenceMode->getName(), this->name.c_str());
+    if (this->referenceMode->getPhyRxStartDelay() <= SIMTIME_ZERO)
+        throw cRuntimeError("Reference mode '%s' in IEEE 802.11 mode set '%s' has a non-positive PHY RX start delay", this->referenceMode->getName(), this->name.c_str());
+    if (this->referenceMode->getLegacyCwMin() < 0 || this->referenceMode->getLegacyCwMax() < this->referenceMode->getLegacyCwMin())
+        throw cRuntimeError("Reference mode '%s' in IEEE 802.11 mode set '%s' has invalid contention window bounds", this->referenceMode->getName(), this->name.c_str());
     std::vector<Entry> *nonConstEntries = const_cast<std::vector<Entry> *>(&this->entries);
     std::stable_sort(nonConstEntries->begin(), nonConstEntries->end(), EntryNetBitrateComparator());
     // Explicit Supported-Rates eligibility on the authoritative Entry keeps
@@ -535,15 +552,6 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
         for (int mcsIndex = 0; mcsIndex < 8; mcsIndex++)
             if (!htMcsSupported[mcsIndex] || !htMcsMandatory[mcsIndex])
                 throw cRuntimeError("HT operation mode set '%s' must mark mandatory HT MCS %d as supported", this->name.c_str(), mcsIndex);
-    }
-    for (auto entry : entries) {
-        auto mode = entry.mode;
-        if (mode->getSifsTime() != referenceMode->getSifsTime() ||
-            mode->getSlotTime() != referenceMode->getSlotTime() ||
-            mode->getPhyRxStartDelay() != referenceMode->getPhyRxStartDelay())
-        {
-            // FIXME throw cRuntimeError("Sifs, slot and phyRxStartDelay time must be identical within a ModeSet");
-        }
     }
 }
 

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -8,6 +8,7 @@
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211DsssMode.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ErpOfdmMode.h"
@@ -26,55 +27,55 @@ Register_Abstract_Class(Ieee80211ModeSet);
 
 const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSets([]() { return new std::vector<Ieee80211ModeSet> {
     Ieee80211ModeSet("a", {
-        { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS20MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode9MbpsCS20MHz },
-        { true, &Ieee80211OfdmCompliantModes::ofdmMode12MbpsCS20MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode18MbpsCS20MHz },
-        { true, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS20MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode36Mbps },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode48Mbps },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode54Mbps },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS20MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode9MbpsCS20MHz, true },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode12MbpsCS20MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode18MbpsCS20MHz, true },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS20MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode36Mbps, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode48Mbps, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode54Mbps, true },
     }),
     Ieee80211ModeSet("b", {
-        { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps },
-        { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps },
-        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble },
-        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble },
+        { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
+        { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps, true },
+        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble, true },
+        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
     }),
     // TODO slotTime, cwMin, cwMax must be identical in all modes
     Ieee80211ModeSet("g(mixed)", {
-        { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps },
-        { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps },
-        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble },
-        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode6Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode9Mbps },
-        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble },
-        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode12Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode18Mbps },
-        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode24Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode36Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode48Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode54Mbps }, // TODO ERP-CCK, ERP-PBCC, DSSS-OFDM
+        { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
+        { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps, true },
+        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode6Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode9Mbps, true },
+        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode12Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode18Mbps, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode24Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode36Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode48Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode54Mbps, true }, // TODO ERP-CCK, ERP-PBCC, DSSS-OFDM
     }),
     Ieee80211ModeSet("g(erp)", {
-        { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode6Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode9Mbps },
-        { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode12Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode18Mbps },
-        { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode24Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode36Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode48Mbps },
-        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode54Mbps },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode6Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode9Mbps, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode12Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode18Mbps, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode24Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode36Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode48Mbps, true },
+        { false, &Ieee80211ErpOfdmCompliantModes::erpOnlyOfdmMode54Mbps, true },
     }),
     Ieee80211ModeSet("p", {
-        { true, &Ieee80211OfdmCompliantModes::ofdmMode3MbpsCS10MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode4_5MbpsCS10MHz },
-        { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS10MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode9MbpsCS10MHz },
-        { true, &Ieee80211OfdmCompliantModes::ofdmMode12MbpsCS10MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode18MbpsCS10MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS10MHz },
-        { false, &Ieee80211OfdmCompliantModes::ofdmMode27Mbps },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode3MbpsCS10MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode4_5MbpsCS10MHz, true },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS10MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode9MbpsCS10MHz, true },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode12MbpsCS10MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode18MbpsCS10MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS10MHz, true },
+        { false, &Ieee80211OfdmCompliantModes::ofdmMode27Mbps, true },
         }),
     Ieee80211ModeSet("n(mixed-2.4Ghz)", { // This table is not complete; it only contains 2.4GHz homogeneous spatial streams, all mandatory and optional modes
         { true, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs0BW20MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -140,7 +141,17 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs28BW40MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT) },
         { false, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs29BW40MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT) },
         { false, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs30BW40MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT) },
-        { false, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs31BW40MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT) }
+        { false, Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs31BW40MHz, Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT) },
+        // IEEE Std 802.11-2024, 11.1.4.6 and 19.1.1: these legacy modes are
+        // authoritative mode-set entries and are eligible for Supported Rates;
+        // HT MCS entries above remain in the HT capabilities set.
+        { true, &Ieee80211DsssCompliantModes::dsssMode1Mbps, true },
+        { true, &Ieee80211DsssCompliantModes::dsssMode2Mbps, true },
+        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode5_5MbpsCckLongPreamble, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode6Mbps, true },
+        { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode12Mbps, true },
+        { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode24Mbps, true }
     }),
     Ieee80211ModeSet("ac", {
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -453,6 +464,11 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { false, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs7BW160MHzNss8, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_SHORT) },
         { false, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs8BW160MHzNss8, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_SHORT) },
         { false, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs9BW160MHzNss8, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_SHORT) },
+        // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6: these legacy OFDM modes
+        // are eligible for Supported Rates; VHT MCS entries above are not.
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS20MHz, true },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode12MbpsCS20MHz, true },
+        { true, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS20MHz, true },
 }),}; });
 
 Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries) :
@@ -464,8 +480,37 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
         throw cRuntimeError("IEEE 802.11 mode set '%s' must contain at least one mode", this->name.c_str());
     if (referenceMode == nullptr)
         throw cRuntimeError("IEEE 802.11 mode set '%s' has a null reference mode", this->name.c_str());
+    for (const auto& entry : this->entries) {
+        if (entry.mode == nullptr)
+            throw cRuntimeError("IEEE 802.11 mode set '%s' contains a null mode", this->name.c_str());
+        if (entry.isLegacyOperational) {
+            auto bitrate = entry.mode->getDataMode()->getNetBitrate().get<Mbps>();
+            if (!std::isfinite(bitrate) || bitrate <= 0 || bitrate > 63.5)
+                throw cRuntimeError("Mode '%s' is not representable as a legacy Supported Rate in IEEE 802.11 mode set '%s'", entry.mode->getName(), this->name.c_str());
+        }
+    }
     std::vector<Entry> *nonConstEntries = const_cast<std::vector<Entry> *>(&this->entries);
     std::stable_sort(nonConstEntries->begin(), nonConstEntries->end(), EntryNetBitrateComparator());
+    // Explicit Supported-Rates eligibility on the authoritative Entry keeps
+    // HT/VHT MCSs out without concrete-type or name-based inference. The
+    // modeled OperationalRateSet is mandatory-first (IEEE Std 802.11-2024,
+    // 9.4.2.3 and 11.1.4.6); management splits it across the primary and
+    // Extended Supported Rates elements when necessary.
+    for (bool mandatory : {true, false}) {
+        for (const auto& entry : this->entries) {
+            if (entry.isLegacyOperational && entry.isMandatory == mandatory)
+                this->legacyOperationalModes.push_back(entry.mode);
+        }
+    }
+    for (const auto *mode : this->legacyOperationalModes) {
+        if (mode == nullptr)
+            throw cRuntimeError("IEEE 802.11 mode set '%s' contains a null legacy operational mode", this->name.c_str());
+        int modeIndex = findModeIndex(mode);
+        if (modeIndex < 0)
+            throw cRuntimeError("Legacy operational mode '%s' is not contained in IEEE 802.11 mode set '%s'", mode->getName(), this->name.c_str());
+        if (!this->entries[modeIndex].isLegacyOperational)
+            throw cRuntimeError("Legacy operational mode '%s' is not marked eligible in IEEE 802.11 mode set '%s'", mode->getName(), this->name.c_str());
+    }
     for (auto entry : entries) {
         auto mode = entry.mode;
         if (mode->getSifsTime() != referenceMode->getSifsTime() ||

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -152,7 +152,7 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { true, &Ieee80211HrDsssCompliantModes::hrDsssMode11MbpsCckLongPreamble, true },
         { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode12Mbps, true },
         { true, &Ieee80211ErpOfdmCompliantModes::erpOfdmMode24Mbps, true }
-    }),
+    }, true),
     Ieee80211ModeSet("ac", {
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs0BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
         { true, Ieee80211VhtCompliantModes::getCompliantMode(&Ieee80211VhtmcsTable::vhtMcs1BW20MHzNss1, Ieee80211VhtMode::BAND_5GHZ, Ieee80211VhtPreambleMode::HT_PREAMBLE_MIXED, Ieee80211VhtModeBase::HT_GUARD_INTERVAL_LONG) },
@@ -469,12 +469,15 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
         { true, &Ieee80211OfdmCompliantModes::ofdmMode6MbpsCS20MHz, true },
         { true, &Ieee80211OfdmCompliantModes::ofdmMode12MbpsCS20MHz, true },
         { true, &Ieee80211OfdmCompliantModes::ofdmMode24MbpsCS20MHz, true },
-}),}; });
+    // Intentional model limitation: unlike IEEE Std 802.11-2024, 11.38.1,
+    // this VHT-only profile has no selectable HT modes.
+    }, false),}; });
 
-Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries) :
+Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, bool htOperationSupported) :
     name(name),
     entries(entries),
-    referenceMode(entries.empty() ? nullptr : entries.front().mode)
+    referenceMode(entries.empty() ? nullptr : entries.front().mode),
+    htOperationSupported(htOperationSupported)
 {
     if (this->entries.empty())
         throw cRuntimeError("IEEE 802.11 mode set '%s' must contain at least one mode", this->name.c_str());
@@ -511,6 +514,22 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
         if (!this->entries[modeIndex].isLegacyOperational)
             throw cRuntimeError("Legacy operational mode '%s' is not marked eligible in IEEE 802.11 mode set '%s'", mode->getName(), this->name.c_str());
     }
+    for (const auto& entry : this->entries) {
+        int mcsIndex = entry.mode->getHtMcsIndex();
+        if (mcsIndex < 0)
+            continue;
+        if (mcsIndex >= 77)
+            throw cRuntimeError("HT MCS index %d in mode '%s' is outside the modeled range 0..76 in mode set '%s'",
+                    mcsIndex, entry.mode->getName(), this->name.c_str());
+        htMcsSupported[mcsIndex] = true;
+        htMcsMandatory[mcsIndex] = htMcsMandatory[mcsIndex] || entry.isMandatory;
+        htSupportedChannelWidths.insert(entry.mode->getDataMode()->getBandwidth());
+    }
+    if (htOperationSupported) {
+        for (int mcsIndex = 0; mcsIndex < 8; mcsIndex++)
+            if (!htMcsSupported[mcsIndex] || !htMcsMandatory[mcsIndex])
+                throw cRuntimeError("HT operation mode set '%s' must mark mandatory HT MCS %d as supported", this->name.c_str(), mcsIndex);
+    }
     for (auto entry : entries) {
         auto mode = entry.mode;
         if (mode->getSifsTime() != referenceMode->getSifsTime() ||
@@ -520,6 +539,22 @@ Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> en
             // FIXME throw cRuntimeError("Sifs, slot and phyRxStartDelay time must be identical within a ModeSet");
         }
     }
+}
+
+Hz Ieee80211ModeSet::getMaximumChannelWidth() const
+{
+    Hz maximum(0);
+    for (const auto& entry : entries)
+        maximum = std::max(maximum, entry.mode->getDataMode()->getBandwidth());
+    return maximum;
+}
+
+int Ieee80211ModeSet::getMaximumNumberOfSpatialStreams() const
+{
+    int maximum = 0;
+    for (const auto& entry : entries)
+        maximum = std::max(maximum, entry.mode->getDataMode()->getNumberOfSpatialStreams());
+    return maximum;
 }
 
 int Ieee80211ModeSet::findModeIndex(const IIeee80211Mode *mode) const

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -457,11 +457,15 @@ const DelayedInitializer<std::vector<Ieee80211ModeSet>> Ieee80211ModeSet::modeSe
 
 Ieee80211ModeSet::Ieee80211ModeSet(const char *name, const std::vector<Entry> entries) :
     name(name),
-    entries(entries)
+    entries(entries),
+    referenceMode(entries.empty() ? nullptr : entries.front().mode)
 {
+    if (this->entries.empty())
+        throw cRuntimeError("IEEE 802.11 mode set '%s' must contain at least one mode", this->name.c_str());
+    if (referenceMode == nullptr)
+        throw cRuntimeError("IEEE 802.11 mode set '%s' has a null reference mode", this->name.c_str());
     std::vector<Entry> *nonConstEntries = const_cast<std::vector<Entry> *>(&this->entries);
     std::stable_sort(nonConstEntries->begin(), nonConstEntries->end(), EntryNetBitrateComparator());
-    auto referenceMode = entries[0].mode;
     for (auto entry : entries) {
         auto mode = entry.mode;
         if (mode->getSifsTime() != referenceMode->getSifsTime() ||
@@ -626,4 +630,3 @@ const Ieee80211ModeSet *Ieee80211ModeSet::getModeSet(const char *mode)
 } // namespace physicallayer
 
 } // namespace inet
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -21,6 +21,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
       public:
         bool isMandatory;
         const IIeee80211Mode *mode;
+        bool isLegacyOperational = false;
     };
 
     struct EntryNetBitrateComparator {
@@ -33,6 +34,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     // PHY timing and contention parameters remain anchored to the first
     // configured mode, even though entries are sorted by bitrate for lookup.
     const IIeee80211Mode *referenceMode;
+    std::vector<const IIeee80211Mode *> legacyOperationalModes;
 
   public:
     static const DelayedInitializer<std::vector<Ieee80211ModeSet>> modeSets;
@@ -49,8 +51,12 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     const char *getName() const override { return name.c_str(); }
 
     int getNumModes() const { return entries.size(); }
-    const IIeee80211Mode *getMode(int index) { return entries[index].mode; }
-    bool isMandatory(int index) { return entries[index].isMandatory; }
+    const IIeee80211Mode *getMode(int index) const { return entries[index].mode; }
+    bool isMandatory(int index) const { return entries[index].isMandatory; }
+    // The management policy advertises all explicitly eligible representable
+    // legacy modes in deterministic mandatory-first order. Overflow is split
+    // into the Extended Supported Rates element by management.
+    const std::vector<const IIeee80211Mode *>& getLegacyOperationalModes() const { return legacyOperationalModes; }
 
     bool containsMode(const IIeee80211Mode *mode) const { return findModeIndex(mode) != -1; }
     bool getIsMandatory(const IIeee80211Mode *mode) const;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -30,6 +30,9 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
   protected:
     std::string name;
     const std::vector<Entry> entries;
+    // PHY timing and contention parameters remain anchored to the first
+    // configured mode, even though entries are sorted by bitrate for lookup.
+    const IIeee80211Mode *referenceMode;
 
   public:
     static const DelayedInitializer<std::vector<Ieee80211ModeSet>> modeSets;
@@ -68,11 +71,14 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     static const Ieee80211ModeSet *findModeSet(const char *mode);
     static const Ieee80211ModeSet *getModeSet(const char *mode);
 
-    simtime_t getSifsTime() const { return entries[0].mode->getSifsTime(); }
-    simtime_t getSlotTime() const { return entries[0].mode->getSlotTime(); }
-    simtime_t getPhyRxStartDelay() const { return entries[0].mode->getPhyRxStartDelay(); }
-    int getCwMin() const { return entries[0].mode->getLegacyCwMin(); }
-    int getCwMax() const { return entries[0].mode->getLegacyCwMax(); }
+    // PHY timing, contention and TXOP policy remain anchored to the first
+    // configured mode, which is the reference mode before bitrate sorting.
+    const IIeee80211Mode *getReferenceMode() const { return referenceMode; }
+    simtime_t getSifsTime() const { return referenceMode->getSifsTime(); }
+    simtime_t getSlotTime() const { return referenceMode->getSlotTime(); }
+    simtime_t getPhyRxStartDelay() const { return referenceMode->getPhyRxStartDelay(); }
+    int getCwMin() const { return referenceMode->getLegacyCwMin(); }
+    int getCwMax() const { return referenceMode->getLegacyCwMax(); }
 
     IIeee80211Mode *_getSlowestMode() const { return const_cast<IIeee80211Mode *>(getSlowestMode()); }
     IIeee80211Mode *_getFastestMode() const { return const_cast<IIeee80211Mode *>(getFastestMode()); }
@@ -84,4 +90,3 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
 } // namespace inet
 
 #endif
-

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -44,8 +44,8 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     std::string name;
     const std::vector<Entry> entries;
     const OperatingPhy operatingPhy;
-    // PHY timing and contention parameters remain anchored to the first
-    // configured mode, even though entries are sorted by bitrate for lookup.
+    // PHY timing and contention parameters remain anchored to the explicitly
+    // configured reference mode, even though entries are sorted by bitrate for lookup.
     const IIeee80211Mode *referenceMode;
     std::vector<const IIeee80211Mode *> legacyOperationalModes;
     std::array<bool, 77> htMcsSupported = {};
@@ -61,7 +61,8 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     int getModeIndex(const IIeee80211Mode *mode) const;
 
   public:
-    Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, OperatingPhy operatingPhy, bool htOperationSupported = false);
+    Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, const IIeee80211Mode *referenceMode,
+            OperatingPhy operatingPhy, bool htOperationSupported = false);
 
     virtual std::ostream& printToStream(std::ostream& stream, int level, int evFlags = 0) const override { return stream << "Ieee80211ModeSet, name = " << name; }
 
@@ -100,8 +101,8 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     static const Ieee80211ModeSet *findModeSet(const char *mode);
     static const Ieee80211ModeSet *getModeSet(const char *mode);
 
-    // PHY timing and contention policy remain anchored to the first configured
-    // mode, which is the reference mode before bitrate sorting.
+    // PHY timing and contention policy remain anchored to the explicitly
+    // configured reference mode, independent of bitrate sorting.
     OperatingPhy getOperatingPhy() const { return operatingPhy; }
     const IIeee80211Mode *getReferenceMode() const { return referenceMode; }
     simtime_t getSifsTime() const { return referenceMode->getSifsTime(); }

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -51,6 +51,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     std::array<bool, 77> htMcsSupported = {};
     std::array<bool, 77> htMcsMandatory = {};
     std::set<Hz> htSupportedChannelWidths;
+    std::set<Hz> htShortGuardIntervalChannelWidths;
     bool htOperationSupported = false;
 
   public:
@@ -78,9 +79,12 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     // legacy modes in deterministic mandatory-first order. Overflow is split
     // into the Extended Supported Rates element by management.
     const std::vector<const IIeee80211Mode *>& getLegacyOperationalModes() const { return legacyOperationalModes; }
+    const IIeee80211Mode *getFastestLegacyOperationalMode() const;
     const std::array<bool, 77>& getHtMcsSupported() const { return htMcsSupported; }
     const std::array<bool, 77>& getHtMcsMandatory() const { return htMcsMandatory; }
     const std::set<Hz>& getHtSupportedChannelWidths() const { return htSupportedChannelWidths; }
+    const std::set<Hz>& getHtShortGuardIntervalChannelWidths() const { return htShortGuardIntervalChannelWidths; }
+    bool isHtShortGuardIntervalSupported(Hz bandwidth) const { return htShortGuardIntervalChannelWidths.count(bandwidth) != 0; }
 
     bool containsMode(const IIeee80211Mode *mode) const { return findModeIndex(mode) != -1; }
     bool getIsMandatory(const IIeee80211Mode *mode) const;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -19,6 +19,15 @@ namespace physicallayer {
 
 class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
 {
+  public:
+    enum class OperatingPhy {
+        OFDM,
+        HR_DSSS,
+        ERP,
+        HT,
+        VHT,
+    };
+
   protected:
     class INET_API Entry {
       public:
@@ -34,6 +43,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
   protected:
     std::string name;
     const std::vector<Entry> entries;
+    const OperatingPhy operatingPhy;
     // PHY timing and contention parameters remain anchored to the first
     // configured mode, even though entries are sorted by bitrate for lookup.
     const IIeee80211Mode *referenceMode;
@@ -51,7 +61,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     int getModeIndex(const IIeee80211Mode *mode) const;
 
   public:
-    Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, bool htOperationSupported = false);
+    Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, OperatingPhy operatingPhy, bool htOperationSupported = false);
 
     virtual std::ostream& printToStream(std::ostream& stream, int level, int evFlags = 0) const override { return stream << "Ieee80211ModeSet, name = " << name; }
 
@@ -90,8 +100,9 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     static const Ieee80211ModeSet *findModeSet(const char *mode);
     static const Ieee80211ModeSet *getModeSet(const char *mode);
 
-    // PHY timing, contention and TXOP policy remain anchored to the first
-    // configured mode, which is the reference mode before bitrate sorting.
+    // PHY timing and contention policy remain anchored to the first configured
+    // mode, which is the reference mode before bitrate sorting.
+    OperatingPhy getOperatingPhy() const { return operatingPhy; }
     const IIeee80211Mode *getReferenceMode() const { return referenceMode; }
     simtime_t getSifsTime() const { return referenceMode->getSifsTime(); }
     simtime_t getSlotTime() const { return referenceMode->getSlotTime(); }

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -8,6 +8,9 @@
 #ifndef __INET_IEEE80211MODESET_H
 #define __INET_IEEE80211MODESET_H
 
+#include <array>
+#include <set>
+
 #include "inet/common/DelayedInitializer.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h"
 
@@ -35,6 +38,10 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     // configured mode, even though entries are sorted by bitrate for lookup.
     const IIeee80211Mode *referenceMode;
     std::vector<const IIeee80211Mode *> legacyOperationalModes;
+    std::array<bool, 77> htMcsSupported = {};
+    std::array<bool, 77> htMcsMandatory = {};
+    std::set<Hz> htSupportedChannelWidths;
+    bool htOperationSupported = false;
 
   public:
     static const DelayedInitializer<std::vector<Ieee80211ModeSet>> modeSets;
@@ -44,7 +51,7 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     int getModeIndex(const IIeee80211Mode *mode) const;
 
   public:
-    Ieee80211ModeSet(const char *name, const std::vector<Entry> entries);
+    Ieee80211ModeSet(const char *name, const std::vector<Entry> entries, bool htOperationSupported = false);
 
     virtual std::ostream& printToStream(std::ostream& stream, int level, int evFlags = 0) const override { return stream << "Ieee80211ModeSet, name = " << name; }
 
@@ -53,10 +60,16 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     int getNumModes() const { return entries.size(); }
     const IIeee80211Mode *getMode(int index) const { return entries[index].mode; }
     bool isMandatory(int index) const { return entries[index].isMandatory; }
+    bool isHtOperationSupported() const { return htOperationSupported; }
+    Hz getMaximumChannelWidth() const;
+    int getMaximumNumberOfSpatialStreams() const;
     // The management policy advertises all explicitly eligible representable
     // legacy modes in deterministic mandatory-first order. Overflow is split
     // into the Extended Supported Rates element by management.
     const std::vector<const IIeee80211Mode *>& getLegacyOperationalModes() const { return legacyOperationalModes; }
+    const std::array<bool, 77>& getHtMcsSupported() const { return htMcsSupported; }
+    const std::array<bool, 77>& getHtMcsMandatory() const { return htMcsMandatory; }
+    const std::set<Hz>& getHtSupportedChannelWidths() const { return htSupportedChannelWidths; }
 
     bool containsMode(const IIeee80211Mode *mode) const { return findModeIndex(mode) != -1; }
     bool getIsMandatory(const IIeee80211Mode *mode) const;

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211VhtMode.h
@@ -267,13 +267,13 @@ class INET_API Ieee80211VhtMode : public Ieee80211ModeBase
     virtual const Ieee80211VhtSignalMode *getHeaderMode() const override { return preambleMode->getSignalMode(); }
     virtual const Ieee80211OfdmSignalMode *getLegacySignalMode() const { return preambleMode->getLegacySignalMode(); }
 
-    // Table 20-25—MIMO PHY characteristics
+    // IEEE Std 802.11-2024, 21.4.4 and Table 21-28—VHT PHY characteristics.
     virtual const simtime_t getSlotTime() const override;
     virtual const simtime_t getShortSlotTime() const;
     virtual const simtime_t getSifsTime() const override;
     virtual const simtime_t getRifsTime() const override { return 2E-6; }
     virtual const simtime_t getCcaTime() const override { return 4E-6; } // < 4
-    virtual const simtime_t getPhyRxStartDelay() const override { return 33E-6; }
+    virtual const simtime_t getPhyRxStartDelay() const override { return 24E-6; }
     virtual const simtime_t getRxTxTurnaroundTime() const override { return 2E-6; } // < 2
     virtual const simtime_t getPreambleLength() const override { return 16E-6; }
     virtual const simtime_t getPlcpHeaderLength() const override { return 4E-6; }
@@ -692,4 +692,3 @@ class INET_API Ieee80211VhtCompliantModes
 } /* namespace inet */
 
 #endif
-

--- a/src/inet/queueing/base/PacketQueueBase.h
+++ b/src/inet/queueing/base/PacketQueueBase.h
@@ -25,6 +25,7 @@ class INET_API PacketQueueBase : public PacketProcessorBase, public virtual IPac
 
     cGate *inputGate = nullptr;
     cGate *outputGate = nullptr;
+    IPacketQueue::ICallback *packetDropCallback = nullptr;
 
   protected:
     virtual void initialize(int stage) override;
@@ -40,7 +41,15 @@ class INET_API PacketQueueBase : public PacketProcessorBase, public virtual IPac
 
     virtual void enqueuePacket(Packet *packet) override;
     virtual Packet *dequeuePacket() override;
+    virtual void setPacketDropCallback(IPacketQueue::ICallback *callback) override { packetDropCallback = callback; }
 
+  protected:
+    virtual void notifyPacketDropped(Packet *packet) {
+        if (packetDropCallback != nullptr)
+            packetDropCallback->handlePacketDropped(packet);
+    }
+
+  public:
     virtual void pushPacketStart(Packet *packet, const cGate *gate, bps datarate) override { throw cRuntimeError("Invalid operation"); }
     virtual void pushPacketEnd(Packet *packet, const cGate *gate) override { throw cRuntimeError("Invalid operation"); }
     virtual void pushPacketProgress(Packet *packet, const cGate *gate, bps datarate, b position, b extraProcessableLength = b(0)) override { throw cRuntimeError("Invalid operation"); }
@@ -54,4 +63,3 @@ class INET_API PacketQueueBase : public PacketProcessorBase, public virtual IPac
 } // namespace inet
 
 #endif
-

--- a/src/inet/queueing/buffer/PacketBuffer.cc
+++ b/src/inet/queueing/buffer/PacketBuffer.cc
@@ -66,7 +66,7 @@ void PacketBuffer::addPacket(Packet *packet)
                 if (queue != nullptr) {
                     ICallback *callback = dynamic_cast<ICallback *>(queue->getOwner());
                     if (callback != nullptr)
-                        callback->handlePacketRemoved(packet);
+                        callback->handlePacketDropped(packet);
                 }
                 // TODO maybe the buffer should take ownership and queues should be aware of it
                 take(packet);
@@ -118,4 +118,3 @@ Packet *PacketBuffer::getPacket(int index) const
 
 } // namespace queueing
 } // namespace inet
-

--- a/src/inet/queueing/contract/IPacketBuffer.h
+++ b/src/inet/queueing/contract/IPacketBuffer.h
@@ -27,6 +27,13 @@ class INET_API IPacketBuffer : public virtual IPacketCollection
          * The packet is never nullptr.
          */
         virtual void handlePacketRemoved(Packet *packet) = 0;
+
+        /**
+         * Notifies the packet owner before a packet is deleted because of an
+         * overflow/dropper decision. The default keeps compatibility with
+         * buffers that only distinguish removal from retention.
+         */
+        virtual void handlePacketDropped(Packet *packet) { handlePacketRemoved(packet); }
     };
 
   public:
@@ -47,4 +54,3 @@ class INET_API IPacketBuffer : public virtual IPacketCollection
 } // namespace inet
 
 #endif
-

--- a/src/inet/queueing/contract/IPacketQueue.h
+++ b/src/inet/queueing/contract/IPacketQueue.h
@@ -22,12 +22,29 @@ class INET_API IPacketQueue : public virtual IPacketCollection, public virtual I
 {
   public:
     /**
+     * Receives a synchronous notification while a packet is still valid and
+     * owned by the queue, immediately before the queue drops it.
+     */
+    class INET_API ICallback {
+      public:
+        virtual ~ICallback() {}
+        virtual void handlePacketDropped(Packet *packet) = 0;
+    };
+
+  public:
+    /**
      * Enqueues the packet into the packet queue. The onwership of the packet
      * is transferred from the caller to the queue.
      *
      * The queue must not be full. The packet must not be nullptr.
      */
     virtual void enqueuePacket(Packet *packet) = 0;
+
+    /**
+     * Installs the owner that is synchronously notified before a queued
+     * packet is deleted because of an overflow/dropper decision.
+     */
+    virtual void setPacketDropCallback(ICallback *callback) = 0;
 
     /**
      * Dequeues the packet from the packet queue. The onwership of the packet
@@ -42,4 +59,3 @@ class INET_API IPacketQueue : public virtual IPacketCollection, public virtual I
 } // namespace inet
 
 #endif
-

--- a/src/inet/queueing/queue/CompoundPacketQueueBase.cc
+++ b/src/inet/queueing/queue/CompoundPacketQueueBase.cc
@@ -62,12 +62,24 @@ void CompoundPacketQueueBase::pushPacket(Packet *packet, const cGate *gate)
             auto packet = packetDropperFunction->selectPacket(this);
             EV_INFO << "Dropping packet" << EV_FIELD(packet) << EV_ENDL;
             removePacket(packet);
+            take(packet);
+            notifyPacketDropped(packet);
             dropPacket(packet, QUEUE_OVERFLOW);
         }
     }
     ASSERT(!isOverloaded());
     cNamedObject packetPushEndedDetails("atomicOperationEnded");
     emit(packetPushEndedSignal, nullptr, &packetPushEndedDetails);
+}
+
+void CompoundPacketQueueBase::setPacketDropCallback(IPacketQueue::ICallback *callback)
+{
+    PacketQueueBase::setPacketDropCallback(callback);
+    for (cModule::SubmoduleIterator it(this); !it.end(); ++it) {
+        auto queue = dynamic_cast<IPacketQueue *>(*it);
+        if (queue != nullptr)
+            queue->setPacketDropCallback(callback);
+    }
 }
 
 Packet *CompoundPacketQueueBase::pullPacket(const cGate *gate)
@@ -127,4 +139,3 @@ void CompoundPacketQueueBase::receiveSignal(cComponent *source, simsignal_t sign
 
 } // namespace queueing
 } // namespace inet
-

--- a/src/inet/queueing/queue/CompoundPacketQueueBase.h
+++ b/src/inet/queueing/queue/CompoundPacketQueueBase.h
@@ -54,6 +54,7 @@ class INET_API CompoundPacketQueueBase : public PacketQueueBase, public cListene
     virtual bool canPushSomePacket(const cGate *gate) const override;
     virtual bool canPushPacket(Packet *packet, const cGate *gate) const override;
     virtual void pushPacket(Packet *packet, const cGate *gate) override;
+    virtual void setPacketDropCallback(IPacketQueue::ICallback *callback) override;
 
     virtual bool supportsPacketPulling(const cGate *gate) const override { return outputGate == gate; }
     virtual bool canPullSomePacket(const cGate *gate) const override { return provider.canPullSomePacket(); }
@@ -67,4 +68,3 @@ class INET_API CompoundPacketQueueBase : public PacketQueueBase, public cListene
 } // namespace inet
 
 #endif
-

--- a/src/inet/queueing/queue/PacketQueue.cc
+++ b/src/inet/queueing/queue/PacketQueue.cc
@@ -104,6 +104,7 @@ void PacketQueue::pushPacket(Packet *packet, const cGate *gate)
             auto packet = packetDropperFunction->selectPacket(this);
             EV_INFO << "Dropping packet" << EV_FIELD(packet) << EV_ENDL;
             queue.remove(packet);
+            notifyPacketDropped(packet);
             dropPacket(packet, QUEUE_OVERFLOW);
         }
     }
@@ -193,6 +194,12 @@ void PacketQueue::handlePacketRemoved(Packet *packet)
     }
 }
 
+void PacketQueue::handlePacketDropped(Packet *packet)
+{
+    Enter_Method("handlePacketDropped");
+    handlePacketRemoved(packet);
+    notifyPacketDropped(packet);
+}
+
 } // namespace queueing
 } // namespace inet
-

--- a/src/inet/queueing/queue/PacketQueue.h
+++ b/src/inet/queueing/queue/PacketQueue.h
@@ -71,10 +71,10 @@ class INET_API PacketQueue : public PacketQueueBase, public IPacketBuffer::ICall
     virtual Packet *pullPacket(const cGate *gate) override;
 
     virtual void handlePacketRemoved(Packet *packet) override;
+    virtual void handlePacketDropped(Packet *packet) override;
 };
 
 } // namespace queueing
 } // namespace inet
 
 #endif
-

--- a/tests/module/Ieee80211HtAssociation_1.test
+++ b/tests/module/Ieee80211HtAssociation_1.test
@@ -9,6 +9,8 @@ at both ends.
 #include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
 #include "inet/common/Simsignals.h"
 #include "inet/common/SimpleModule.h"
+#include "inet/common/packet/Packet.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
 
@@ -106,6 +108,32 @@ class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
         ASSERT(apMib->requirePrimaryChannel() == 11);
         ASSERT(apMib->findPeerHtState(staAddress)->negotiatedCapabilities.operation.primaryChannel == 6);
         ASSERT(staMib->bssStationData.isAssociated);
+        // IEEE Std 802.11-2024, 9.4.2.54.2/Figure 9-456 and Table 9-224: the n(mixed-2.4Ghz)
+        // profile exposes both short-GI capability bits from its typed HT
+        // mode entries, and the association exchange carries them on wire.
+        ASSERT(staMib->localHtCapabilities.shortGi20);
+        ASSERT(staMib->localHtCapabilities.shortGi40);
+        ASSERT(apMib->localHtCapabilities.shortGi20);
+        ASSERT(apMib->localHtCapabilities.shortGi40);
+        // Bridge the MIB-derived capability contract to the actual management
+        // frame serializer: the n(mixed-2.4Ghz) profile must advertise both
+        // short-GI bits in HT Capabilities (IEEE Std 802.11-2024, 9.4.2.54.2,
+        // Figure 9-456 and Table 9-224).
+        auto serializedResponse = makeShared<Ieee80211AssociationResponseFrame>();
+        serializedResponse->setStatusCode(SC_SUCCESSFUL);
+        serializedResponse->setAid(1);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        serializedResponse->setSupportedRates(rates);
+        setHtCapabilities(serializedResponse, staMib->localHtCapabilities);
+        serializedResponse->setChunkLength(B(37)); // fixed fields/rates (9) + HT Capabilities IE (28)
+        Packet serializedPacket("mib-ht-capabilities", serializedResponse);
+        auto serializedBytes = serializedPacket.peekAllAsBytes()->getBytes();
+        ASSERT(serializedBytes.size() == 37);
+        ASSERT(serializedBytes[9] == 45 && serializedBytes[10] == 26);
+        ASSERT((serializedBytes[11] & (1 << 5)) != 0);
+        ASSERT((serializedBytes[11] & (1 << 6)) != 0);
         ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
         ASSERT(staMib->findPeerHtState(apMib->address)->valid);
         ASSERT(staMib->findPeerHtState(apMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);

--- a/tests/module/Ieee80211HtAssociation_1.test
+++ b/tests/module/Ieee80211HtAssociation_1.test
@@ -5,12 +5,34 @@ at both ends.
 
 %file: Ieee80211HtAssociationChecker.cc
 
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
 #include "inet/common/Simsignals.h"
 #include "inet/common/SimpleModule.h"
 #include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 
 using namespace inet;
 using namespace inet::ieee80211;
+
+class Ieee80211HcfRtsFailureMac : public Ieee80211Mac
+{
+  protected:
+    bool firstRtsBlocked = false;
+
+    virtual void handleLowerPacket(Packet *packet) override
+    {
+        const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+        if (!firstRtsBlocked && header->getType() == ST_RTS) {
+            firstRtsBlocked = true;
+            EV_INFO << "Intentionally blocking the first RTS frame.\n";
+            delete packet;
+        }
+        else
+            Ieee80211Mac::handleLowerPacket(packet);
+    }
+};
+
+Define_Module(Ieee80211HcfRtsFailureMac);
 
 class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
 {
@@ -56,9 +78,16 @@ Define_Module(Ieee80211HtAssociationChecker);
 %file: test.ned
 
 import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mac.Ieee80211Mac;
 import inet.node.inet.WirelessHost;
 import inet.node.wireless.AccessPoint;
 import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+module Ieee80211HcfRtsFailureMac extends Ieee80211Mac
+{
+    parameters:
+        @class(::Ieee80211HcfRtsFailureMac);
+}
 
 simple Ieee80211HtAssociationChecker extends SimpleModule
 {
@@ -74,6 +103,7 @@ network Ieee80211HtAssociationTest
             parameters:
                 wlan[*].mgmt.typename = "Ieee80211MgmtSta";
                 wlan[*].agent.typename = "Ieee80211AgentSta";
+                wlan[*].mac.typename = "Ieee80211HcfRtsFailureMac";
         }
         ap: AccessPoint {
             parameters:
@@ -114,7 +144,10 @@ record-scalar-results = false
 **.wlan[*].radio.receiver.snirThreshold = 4dB
 
 **.mgmt.numChannels = 1
+*.ap.wlan[*].mac.qosStation = true
 *.ap.wlan[*].mac.dcf.rtsPolicy.rtsThreshold = 0B
+*.ap.wlan[*].mac.hcf.rtsPolicy.rtsThreshold = 0B
+*.ap.wlan[*].mac.hcf.rateControl.typename = "AarfRateControl"
 *.sta.wlan[*].agent.startingTime = 0s
 *.sta.wlan[*].agent.probeDelay = 1ms
 *.sta.wlan[*].agent.minChannelTime = 5ms
@@ -133,6 +166,9 @@ AssocResp-OK .*?Ieee80211AssociationResponseFrame.*?htCapabilitiesPresent.*?true
 
 %contains: stdout
 Installed peer HT state, peer =
+
+%contains: stdout
+Intentionally blocking the first RTS frame.
 
 %contains: stdout
 RTS-protected association committed at AP and STA.

--- a/tests/module/Ieee80211HtAssociation_1.test
+++ b/tests/module/Ieee80211HtAssociation_1.test
@@ -10,6 +10,7 @@ at both ends.
 #include "inet/common/Simsignals.h"
 #include "inet/common/SimpleModule.h"
 #include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
 
 using namespace inet;
 using namespace inet::ieee80211;
@@ -40,20 +41,54 @@ class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
 
   protected:
     int apAssociationNotifications = 0;
+    cMessage *channelChangeTimer = nullptr;
+    cModule *apQosEdcaf = nullptr;
 
+  public:
+    virtual ~Ieee80211HtAssociationChecker()
+    {
+        if (channelChangeTimer != nullptr)
+            cancelAndDelete(channelChangeTimer);
+    }
+
+  protected:
     virtual void initialize() override
     {
         getModuleByPath("^.ap.wlan[0].mgmt")->subscribe(l2ApAssociatedSignal, this);
+        apQosEdcaf = getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3]");
+        apQosEdcaf->subscribe(packetSentToPeerSignal, this);
+        channelChangeTimer = new cMessage("channelChange");
     }
 
     virtual void handleMessage(cMessage *message) override
     {
-        throw cRuntimeError("Unexpected message");
+        if (message != channelChangeTimer)
+            throw cRuntimeError("Unexpected message");
+        auto apMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto apRadio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.ap.wlan[0].radio"));
+        auto staRadio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.sta.wlan[0].radio"));
+        ASSERT(apMib->requirePrimaryChannel() == 6);
+        apRadio->setChannelNumber(11);
+        // Keep the response exchange on-air after the AP's channel update so
+        // the terminal ACK can still be received while the pending operation
+        // snapshot is committed.
+        staRadio->setChannelNumber(11);
+        ASSERT(apMib->requirePrimaryChannel() == 11);
+        delete message;
+        channelChangeTimer = nullptr;
+        std::cout << "AP primary channel follows a dynamic radio change from 6 to 11 before association ACK.\n";
     }
 
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
     {
-        apAssociationNotifications++;
+        if (source == apQosEdcaf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && channelChangeTimer != nullptr && !channelChangeTimer->isScheduled())
+                scheduleAfter(SimTime(1, SIMTIME_US), channelChangeTimer);
+        }
+        else if (signalID == l2ApAssociatedSignal)
+            apAssociationNotifications++;
     }
 
     virtual void finish() override
@@ -61,13 +96,19 @@ class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
         auto apMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
         auto staMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.sta.wlan[0].mib"));
         const auto& staAddress = staMib->address;
+        ASSERT(apMib->requirePrimaryChannel() == 11);
+        ASSERT(channelChangeTimer == nullptr);
         ASSERT(apMib->bssAccessPointData.stations.at(staAddress) == Ieee80211Mib::ASSOCIATED);
         ASSERT(apMib->bssAccessPointData.associationIds.at(staAddress) != 0);
         ASSERT(apMib->findPeerHtState(staAddress) != nullptr);
         ASSERT(apMib->findPeerHtState(staAddress)->valid);
+        ASSERT(apMib->hasPrimaryChannel());
+        ASSERT(apMib->requirePrimaryChannel() == 11);
+        ASSERT(apMib->findPeerHtState(staAddress)->negotiatedCapabilities.operation.primaryChannel == 6);
         ASSERT(staMib->bssStationData.isAssociated);
         ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
         ASSERT(staMib->findPeerHtState(apMib->address)->valid);
+        ASSERT(staMib->findPeerHtState(apMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);
         ASSERT(apAssociationNotifications == 1);
         EV << "RTS-protected association committed at AP and STA.\n";
     }
@@ -108,6 +149,7 @@ network Ieee80211HtAssociationTest
         ap: AccessPoint {
             parameters:
                 wlan[*].mgmt.typename = "Ieee80211MgmtAp";
+                wlan[*].radio.channelNumber = 6;
         }
         test: Ieee80211HtAssociationChecker;
 }
@@ -136,6 +178,7 @@ record-scalar-results = false
 
 **.wlan[*].opMode = "n(mixed-2.4Ghz)"
 **.wlan[*].bitrate = 65Mbps
+*.sta.wlan[0].radio.channelNumber = 6
 **.wlan[*].radio.bandName = "2.4 GHz"
 **.wlan[*].radio.centerFrequency = 2.4GHz
 **.wlan[*].radio.antenna.numAntennas = 1
@@ -149,6 +192,7 @@ record-scalar-results = false
 *.ap.wlan[*].mac.hcf.rtsPolicy.rtsThreshold = 0B
 *.ap.wlan[*].mac.hcf.rateControl.typename = "AarfRateControl"
 *.sta.wlan[*].agent.startingTime = 0s
+*.sta.wlan[*].agent.channelsToScan = "6"
 *.sta.wlan[*].agent.probeDelay = 1ms
 *.sta.wlan[*].agent.minChannelTime = 5ms
 *.sta.wlan[*].agent.maxChannelTime = 5ms

--- a/tests/module/Ieee80211HtAssociation_1.test
+++ b/tests/module/Ieee80211HtAssociation_1.test
@@ -1,0 +1,138 @@
+%description:
+Verify the RTS/CTS-protected detailed IEEE 802.11 management exchange carries
+the standard HT element presence matrix and commits mutually usable peer state
+at both ends.
+
+%file: Ieee80211HtAssociationChecker.cc
+
+#include "inet/common/Simsignals.h"
+#include "inet/common/SimpleModule.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
+{
+    using cListener::finish;
+
+  protected:
+    int apAssociationNotifications = 0;
+
+    virtual void initialize() override
+    {
+        getModuleByPath("^.ap.wlan[0].mgmt")->subscribe(l2ApAssociatedSignal, this);
+    }
+
+    virtual void handleMessage(cMessage *message) override
+    {
+        throw cRuntimeError("Unexpected message");
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        apAssociationNotifications++;
+    }
+
+    virtual void finish() override
+    {
+        auto apMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto staMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.sta.wlan[0].mib"));
+        const auto& staAddress = staMib->address;
+        ASSERT(apMib->bssAccessPointData.stations.at(staAddress) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(apMib->bssAccessPointData.associationIds.at(staAddress) != 0);
+        ASSERT(apMib->findPeerHtState(staAddress) != nullptr);
+        ASSERT(apMib->findPeerHtState(staAddress)->valid);
+        ASSERT(staMib->bssStationData.isAssociated);
+        ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+        ASSERT(staMib->findPeerHtState(apMib->address)->valid);
+        ASSERT(apAssociationNotifications == 1);
+        EV << "RTS-protected association committed at AP and STA.\n";
+    }
+};
+
+Define_Module(Ieee80211HtAssociationChecker);
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple Ieee80211HtAssociationChecker extends SimpleModule
+{
+    parameters:
+        @class(::Ieee80211HtAssociationChecker);
+}
+
+network Ieee80211HtAssociationTest
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtSta";
+                wlan[*].agent.typename = "Ieee80211AgentSta";
+        }
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtAp";
+        }
+        test: Ieee80211HtAssociationChecker;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211HtAssociationTest
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50ms
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+**.constraintAreaMinX = 0m
+**.constraintAreaMinY = 0m
+**.constraintAreaMinZ = 0m
+**.constraintAreaMaxX = 100m
+**.constraintAreaMaxY = 100m
+**.constraintAreaMaxZ = 0m
+*.sta.mobility.initialX = 10m
+*.sta.mobility.initialY = 10m
+*.ap.mobility.initialX = 20m
+*.ap.mobility.initialY = 10m
+**.mobility.initialZ = 0m
+
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.antenna.numAntennas = 1
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+
+**.mgmt.numChannels = 1
+*.ap.wlan[*].mac.dcf.rtsPolicy.rtsThreshold = 0B
+*.sta.wlan[*].agent.startingTime = 0s
+*.sta.wlan[*].agent.probeDelay = 1ms
+*.sta.wlan[*].agent.minChannelTime = 5ms
+*.sta.wlan[*].agent.maxChannelTime = 5ms
+*.sta.wlan[*].agent.authenticationTimeout = 20ms
+*.sta.wlan[*].agent.associationTimeout = 20ms
+
+%contains: stdout
+Association successful, AP address=
+
+%contains-regex: stdout
+Assoc .*?Ieee80211AssociationRequestFrame.*?htCapabilitiesPresent.*?true.*?htOperationPresent.*?false
+
+%contains-regex: stdout
+AssocResp-OK .*?Ieee80211AssociationResponseFrame.*?htCapabilitiesPresent.*?true.*?htOperationPresent.*?true
+
+%contains: stdout
+Installed peer HT state, peer =
+
+%contains: stdout
+RTS-protected association committed at AP and STA.

--- a/tests/module/Ieee80211MgmtApHcfQueueDrop_1.test
+++ b/tests/module/Ieee80211MgmtApHcfQueueDrop_1.test
@@ -1,0 +1,303 @@
+%description:
+Verify that a tagged Association or Reassociation Response dropped from an
+HCF EDCA compound pending queue reaches the AP as a terminal outcome. The
+child management queue callback is propagated through the compound queue,
+pending state is cleared, and a retransmission completes without disturbing a
+committed association.
+
+%file: TestIeee80211MgmtApHcfQueueDrop.cc
+
+#include <vector>
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/queueing/queue/CompoundPacketQueueBase.h"
+#include "inet/queueing/queue/PacketQueue.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestHcfManagementQueue : public queueing::PacketQueue
+{
+  public:
+    void setPacketCapacityForTest(int capacity) { packetCapacity = capacity; }
+    bool hasPacketDropCallbackForTest() const { return packetDropCallback != nullptr; }
+};
+
+Define_Module(TestHcfManagementQueue);
+
+class TestCompoundPendingQueueForHcf : public queueing::CompoundPacketQueueBase
+{
+  public:
+    void setPacketCapacityForTest(int capacity) { packetCapacity = capacity; }
+    bool hasPacketDropCallbackForTest() const { return packetDropCallback != nullptr; }
+};
+
+Define_Module(TestCompoundPendingQueueForHcf);
+
+class TestIeee80211MgmtApHcfQueueDrop : public Ieee80211MgmtAp
+{
+  public:
+    std::vector<IFrameTransmissionCallback::Status> statuses;
+    std::vector<uint64_t> transactionIds;
+
+    void markAuthenticated(const MacAddress& address)
+    {
+        Enter_Method("markAuthenticated");
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    void submitReassociationRequest(const MacAddress& address, const MacAddress& currentAp)
+    {
+        Enter_Method("submitReassociationRequest");
+        auto packet = new Packet("ReassociationRequest");
+        auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+        body->setSSID("SSID");
+        body->setCurrentAP(currentAp);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleReassociationRequestFrame(packet, header);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const { return staList.at(address).pendingAssociationTransactionId; }
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+    short getCommittedAssociationId(const MacAddress& address) const
+    {
+        auto it = mib->bssAccessPointData.associationIds.find(address);
+        return it == mib->bssAccessPointData.associationIds.end() ? 0 : it->second;
+    }
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const { return mib->bssAccessPointData.stations.at(address); }
+
+  protected:
+    virtual void frameTransmissionFinished(const IFrameTransmissionCallback::Result& result) override
+    {
+        statuses.push_back(result.getStatus());
+        auto frame = result.getFrame();
+        auto transactionTag = frame == nullptr ? nullptr : frame->findTag<Ieee80211MgmtTransactionTag>();
+        transactionIds.push_back(transactionTag == nullptr ? 0 : transactionTag->getTransactionId());
+        Ieee80211MgmtAp::frameTransmissionFinished(result);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApHcfQueueDrop);
+
+class Ieee80211MgmtApHcfQueueDropTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApHcfQueueDropTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtApHcfQueueDrop *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto compoundQueue = check_and_cast<TestCompoundPendingQueueForHcf *>(getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3].pendingQueue"));
+        auto managementQueue = check_and_cast<TestHcfManagementQueue *>(getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3].pendingQueue.managementQueue"));
+        const MacAddress station("02:00:00:00:00:09");
+        const MacAddress reusable("02:00:00:00:00:0a");
+        const MacAddress apAddress("02:00:00:00:00:01");
+
+        ASSERT(compoundQueue->getMaxNumPackets() == -1);
+        ASSERT(managementQueue->getMaxNumPackets() == 0);
+        ASSERT(compoundQueue->hasPacketDropCallbackForTest());
+        ASSERT(managementQueue->hasPacketDropCallbackForTest());
+        mgmt->markAuthenticated(station);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && mgmt->statuses.empty(); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 1);
+        ASSERT(mgmt->statuses.back() == IFrameTransmissionCallback::Status::DROPPED_BEFORE_TRANSMISSION);
+        ASSERT(mgmt->transactionIds.back() != 0);
+        auto firstTransactionId = mgmt->transactionIds.back();
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mgmt->getCommittedAssociationId(station) == 0);
+        ASSERT(mgmt->reserveAssociationId(reusable) == 1);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        managementQueue->setPacketCapacityForTest(-1);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && !mgmt->hasPendingAssociation(station); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->hasPendingAssociation(station));
+        auto secondTransactionId = mgmt->getPendingAssociationTransactionId(station);
+        ASSERT(secondTransactionId != 0 && secondTransactionId != firstTransactionId);
+        for (int i = 0; i < 10000 && mgmt->statuses.size() < 2; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 2);
+        ASSERT(mgmt->statuses.back() == IFrameTransmissionCallback::Status::ACKNOWLEDGED);
+        ASSERT(mgmt->transactionIds.back() == secondTransactionId);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+        auto committedAid = mgmt->getCommittedAssociationId(station);
+        ASSERT(committedAid == 1);
+
+        managementQueue->setPacketCapacityForTest(-1);
+        compoundQueue->setPacketCapacityForTest(0);
+        mgmt->submitReassociationRequest(station, apAddress);
+        for (int i = 0; i < 100 && mgmt->statuses.size() < 3; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 3);
+        ASSERT(mgmt->statuses.back() == IFrameTransmissionCallback::Status::DROPPED_BEFORE_TRANSMISSION);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(station) == committedAid);
+
+        compoundQueue->setPacketCapacityForTest(-1);
+        mgmt->submitReassociationRequest(station, apAddress);
+        for (int i = 0; i < 100 && !mgmt->hasPendingAssociation(station); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->hasPendingAssociation(station));
+        auto reassociationTransactionId = mgmt->getPendingAssociationTransactionId(station);
+        for (int i = 0; i < 10000 && mgmt->statuses.size() < 4; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 4);
+        ASSERT(mgmt->statuses.back() == IFrameTransmissionCallback::Status::ACKNOWLEDGED);
+        ASSERT(mgmt->transactionIds.back() == reassociationTransactionId);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(station) == committedAid);
+
+        std::cout << "HCF compound pending-queue drop cleanup, AID preservation, and reassociation recovery verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApHcfQueueDropTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.linklayer.ieee80211.mac.queue.CompoundPendingQueue;
+import inet.queueing.classifier.PacketClassifier;
+import inet.queueing.queue.CompoundPacketQueueBase;
+import inet.queueing.queue.PacketQueue;
+import inet.queueing.scheduler.PriorityScheduler;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestHcfManagementQueue extends PacketQueue
+{
+    parameters:
+        @class(::inet::ieee80211::TestHcfManagementQueue);
+        packetCapacity = default(0);
+        dropperClass = default("inet::queueing::PacketAtCollectionEndDropper");
+}
+
+module TestCompoundPendingQueueForHcf extends CompoundPacketQueueBase
+{
+    parameters:
+        @class(::inet::ieee80211::TestCompoundPendingQueueForHcf);
+        packetCapacity = default(-1);
+        dropperClass = default("inet::queueing::PacketAtCollectionEndDropper");
+    submodules:
+        classifier: PacketClassifier {
+            parameters:
+                classifierClass = default("inet::ieee80211::MgmtOverDataClassifier");
+        }
+        managementQueue: TestHcfManagementQueue;
+        multicastQueue: PacketQueue;
+        unicastQueue: PacketQueue;
+        prioritizer: PriorityScheduler;
+    connections:
+        in --> classifier.in;
+        classifier.out++ --> managementQueue.in;
+        classifier.out++ --> multicastQueue.in;
+        classifier.out++ --> unicastQueue.in;
+        managementQueue.out --> prioritizer.in++;
+        multicastQueue.out --> prioritizer.in++;
+        unicastQueue.out --> prioritizer.in++;
+        prioritizer.out --> out;
+}
+
+simple TestIeee80211MgmtApHcfQueueDrop extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApHcfQueueDrop);
+}
+
+simple Ieee80211MgmtApHcfQueueDropTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApHcfQueueDropTest);
+}
+
+network Ieee80211MgmtApHcfQueueDropTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApHcfQueueDrop";
+                wlan[*].mac.qosStation = true;
+                wlan[*].mac.hcf.edca.edcaf[*].pendingQueue.typename = "TestCompoundPendingQueueForHcf";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtStaSimplified";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApHcfQueueDropTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApHcfQueueDropTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+
+%contains: stdout
+HCF compound pending-queue drop cleanup, AID preservation, and reassociation recovery verified.

--- a/tests/module/Ieee80211MgmtApHcfRtsTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApHcfRtsTimeout_1.test
@@ -1,0 +1,278 @@
+%description:
+Exercise an AP QoS/HCF management response protected by RTS when the peer
+does not return CTS.  The deterministic two-attempt retry exhaustion must
+reach the typed terminal callback, clear the AP's pending association
+transaction, release its reserved AID, and emit no association notification.
+
+%file: TestIeee80211MgmtApHcfRtsTimeout.cc
+
+#include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
+#include "inet/linklayer/ieee80211/mac/contract/IRecoveryProcedure.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtApHcf : public Ieee80211MgmtAp
+{
+  public:
+    int terminalCallbacks = 0;
+    int associationResponseCallbacks = 0;
+    IFrameTransmissionCallback::Status lastStatus = IFrameTransmissionCallback::Status::ACKNOWLEDGED;
+
+    virtual void start() override
+    {
+        // Keep beacon generation out of this focused transaction.  The HCF
+        // exchange below is then the only AP-originated management traffic.
+        Ieee80211MgmtApBase::start();
+    }
+
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    short submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+        return mib->reserveAssociationId(address);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const
+    {
+        return staList.at(address).pendingAssociationTransactionId;
+    }
+
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+
+    bool hasCommittedAssociationId(const MacAddress& address) const
+    {
+        return mib->bssAccessPointData.associationIds.find(address) != mib->bssAccessPointData.associationIds.end();
+    }
+
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const
+    {
+        return mib->bssAccessPointData.stations.at(address);
+    }
+
+  protected:
+    virtual void frameTransmissionFinished(const IFrameTransmissionCallback::Result& result) override
+    {
+        terminalCallbacks++;
+        lastStatus = result.getStatus();
+        const auto *frame = result.getFrame();
+        if (frame != nullptr) {
+            const auto& header = frame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR);
+            const auto& mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(header);
+            if (mgmtHeader != nullptr && (mgmtHeader->getType() == ST_ASSOCIATIONRESPONSE || mgmtHeader->getType() == ST_REASSOCIATIONRESPONSE))
+                associationResponseCallbacks++;
+        }
+        Ieee80211MgmtAp::frameTransmissionFinished(result);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApHcf);
+
+class Ieee80211MgmtApHcfRtsTimeoutTest : public cSimpleModule, public cListener
+{
+    using cListener::finish;
+
+  protected:
+    TestIeee80211MgmtApHcf *mgmt = nullptr;
+    cModule *apHcf = nullptr;
+    cModule *apRecoveryProcedure = nullptr;
+    cModule *apQosEdcaf = nullptr;
+    MacAddress expectedAddress;
+    int associationNotifications = 0;
+    int hcfDrops = 0;
+    int retryLimitNotifications = 0;
+    int rtsAttempts = 0;
+
+  public:
+    Ieee80211MgmtApHcfRtsTimeoutTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtApHcf *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        apHcf = getModuleByPath("^.ap.wlan[0].mac.hcf");
+        apRecoveryProcedure = getModuleByPath("^.ap.wlan[0].mac.hcf.edca.mgmtAndNonQoSRecoveryProcedure");
+        apQosEdcaf = getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3]");
+        mgmt->subscribe(l2ApAssociatedSignal, this);
+        apHcf->subscribe(packetDroppedSignal, this);
+        apRecoveryProcedure->subscribe(IRecoveryProcedure::retryLimitReachedSignal, this);
+        apQosEdcaf->subscribe(packetSentToPeerSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (source == mgmt && signalID == l2ApAssociatedSignal) {
+            const auto& notification = check_and_cast<Ieee80211MgmtAp::NotificationInfoSta *>(value);
+            ASSERT(notification->getStaAddress() == expectedAddress);
+            associationNotifications++;
+        }
+        else if (source == apQosEdcaf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_RTS && header->getReceiverAddress() == expectedAddress)
+                rtsAttempts++;
+        }
+        else if (source == apRecoveryProcedure && signalID == IRecoveryProcedure::retryLimitReachedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAddress)
+                retryLimitNotifications++;
+        }
+        else if (source == apHcf && signalID == packetDroppedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAddress) {
+                auto packetDropDetails = check_and_cast<PacketDropDetails *>(details);
+                ASSERT(packetDropDetails->getReason() == RETRY_LIMIT_REACHED);
+                hcfDrops++;
+            }
+        }
+    }
+
+    virtual void activity() override
+    {
+        expectedAddress = MacAddress("02:00:00:00:00:09");
+        mgmt->markAuthenticated(expectedAddress);
+        short associationId = mgmt->submitAssociationRequest(expectedAddress);
+        uint64_t transactionId = mgmt->getPendingAssociationTransactionId(expectedAddress);
+        ASSERT(associationId == 1);
+        ASSERT(transactionId != 0);
+        ASSERT(mgmt->hasPendingAssociation(expectedAddress));
+        ASSERT(mgmt->getStationStatus(expectedAddress) == Ieee80211Mib::AUTHENTICATED);
+
+        // The tester MAC blocks both RTS attempts.  There is intentionally no
+        // ctsTimeout override: the normal HCF timeout and retry path must
+        // deliver the terminal callback.
+        for (int i = 0; i < 100 && mgmt->terminalCallbacks == 0; i++)
+            wait(SimTime(1, SIMTIME_MS));
+
+        ASSERT(rtsAttempts == 2);
+        ASSERT(retryLimitNotifications == 1);
+        ASSERT(hcfDrops == 1);
+        ASSERT(mgmt->terminalCallbacks == 1);
+        ASSERT(mgmt->associationResponseCallbacks == 1);
+        ASSERT(mgmt->lastStatus == IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED);
+        ASSERT(associationNotifications == 0);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAddress));
+        ASSERT(!mgmt->hasCommittedAssociationId(expectedAddress));
+        ASSERT(mgmt->getStationStatus(expectedAddress) == Ieee80211Mib::AUTHENTICATED);
+
+        // A failed transaction releases its reservation so another STA can
+        // reuse the same AID.
+        MacAddress reusable("02:00:00:00:00:0a");
+        ASSERT(mgmt->reserveAssociationId(reusable) == associationId);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        std::cout << "HCF management RTS retry exhaustion and typed AP terminal cleanup verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApHcfRtsTimeoutTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtApHcf extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApHcf);
+}
+
+simple Ieee80211MgmtApHcfRtsTimeoutTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApHcfRtsTimeoutTest);
+}
+
+network Ieee80211MgmtApHcfRtsTimeoutTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApHcf";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mac.typename = "Ieee80211TesterMac";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApHcfRtsTimeoutTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApHcfRtsTimeoutTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+*.sta.mobility.initialX = 1m
+*.sta.mobility.initialY = 0m
+**.wlan[*].opMode = "g(mixed)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+*.ap.wlan[0].mac.qosStation = true
+*.ap.wlan[0].mac.hcf.rtsPolicy.rtsThreshold = 0B
+*.ap.wlan[0].mac.hcf.edca.mgmtAndNonQoSRecoveryProcedure.shortRetryLimit = 2
+*.sta.wlan[0].mac.actions = "BB"
+*.sta.wlan[0].mgmt.typename = "Ieee80211MgmtStaSimplified"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+
+%contains: stdout
+HCF management RTS retry exhaustion and typed AP terminal cleanup verified.

--- a/tests/module/Ieee80211MgmtApQueueDrop_1.test
+++ b/tests/module/Ieee80211MgmtApQueueDrop_1.test
@@ -1,0 +1,210 @@
+%description:
+Verify that a tagged Association Response dropped by the real DCF pending
+queue reaches the AP as a terminal DROPPED_BEFORE_TRANSMISSION outcome. The
+pending association and reserved AID are cleared, and a retransmitted request
+gets a new transaction token.
+
+%file: TestIeee80211MgmtApQueueDrop.cc
+
+#include <vector>
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/queueing/queue/PacketQueue.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestPendingQueue : public queueing::PacketQueue
+{
+  public:
+    void setPacketCapacityForTest(int capacity) { packetCapacity = capacity; }
+};
+
+Define_Module(TestPendingQueue);
+
+class TestIeee80211MgmtApQueueDrop : public Ieee80211MgmtAp
+{
+  public:
+    std::vector<IFrameTransmissionCallback::Status> statuses;
+    std::vector<uint64_t> transactionIds;
+
+    void markAuthenticated(const MacAddress& address)
+    {
+        Enter_Method("markAuthenticated");
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const { return staList.at(address).pendingAssociationTransactionId; }
+
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const { return mib->bssAccessPointData.stations.at(address); }
+
+  protected:
+    virtual void frameTransmissionFinished(const IFrameTransmissionCallback::Result& result) override
+    {
+        statuses.push_back(result.getStatus());
+        auto frame = result.getFrame();
+        auto transactionTag = frame == nullptr ? nullptr : frame->findTag<Ieee80211MgmtTransactionTag>();
+        transactionIds.push_back(transactionTag == nullptr ? 0 : transactionTag->getTransactionId());
+        Ieee80211MgmtAp::frameTransmissionFinished(result);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApQueueDrop);
+
+class Ieee80211MgmtApQueueDropTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApQueueDropTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtApQueueDrop *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto queue = check_and_cast<TestPendingQueue *>(getModuleByPath("^.ap.wlan[0].mac.dcf.channelAccess.pendingQueue"));
+        const MacAddress station("02:00:00:00:00:09");
+        const MacAddress reusable("02:00:00:00:00:0a");
+
+        ASSERT(queue->getMaxNumPackets() == 0);
+        mgmt->markAuthenticated(station);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && mgmt->statuses.empty(); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 1);
+        ASSERT(mgmt->statuses.back() == IFrameTransmissionCallback::Status::DROPPED_BEFORE_TRANSMISSION);
+        ASSERT(mgmt->transactionIds.back() != 0);
+        auto firstTransactionId = mgmt->transactionIds.back();
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::AUTHENTICATED);
+
+        // The queue-owned callback runs before deletion, so the reservation
+        // is released synchronously and can be reused by another STA.
+        ASSERT(mgmt->reserveAssociationId(reusable) == 1);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        // A retransmitted request is not mistaken for the dropped transaction.
+        // Open the test queue after the first terminal callback so the second
+        // response can complete through the ordinary DCF/ACK path.
+        queue->setPacketCapacityForTest(-1);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && !mgmt->hasPendingAssociation(station); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->hasPendingAssociation(station));
+        auto secondTransactionId = mgmt->getPendingAssociationTransactionId(station);
+        ASSERT(secondTransactionId != 0);
+        ASSERT(secondTransactionId != firstTransactionId);
+        for (int i = 0; i < 10000 && mgmt->statuses.size() < 2; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 2);
+        ASSERT(mgmt->statuses.back() == IFrameTransmissionCallback::Status::ACKNOWLEDGED);
+        ASSERT(mgmt->transactionIds.back() == secondTransactionId);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+
+        std::cout << "DCF pending-queue overflow terminal cleanup and retransmission recovery verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApQueueDropTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.linklayer.ieee80211.mac.queue.PendingQueue;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestPendingQueue extends PendingQueue
+{
+    parameters:
+        @class(::inet::ieee80211::TestPendingQueue);
+}
+
+simple TestIeee80211MgmtApQueueDrop extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApQueueDrop);
+}
+
+simple Ieee80211MgmtApQueueDropTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApQueueDropTest);
+}
+
+network Ieee80211MgmtApQueueDropTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApQueueDrop";
+                wlan[*].mac.dcf.channelAccess.pendingQueue.typename = "TestPendingQueue";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtStaSimplified";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApQueueDropTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApQueueDropTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].mac.dcf.channelAccess.pendingQueue.packetCapacity = 0
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+
+%contains: stdout
+DCF pending-queue overflow terminal cleanup and retransmission recovery verified.

--- a/tests/module/Ieee80211MgmtApReassociationSnapshot_1.test
+++ b/tests/module/Ieee80211MgmtApReassociationSnapshot_1.test
@@ -1,0 +1,190 @@
+%description:
+Verify that an AP reassociation response commits the exact HT Operation
+snapshot advertised when the response was constructed, even if the AP radio
+changes channel before the terminal ACK callback.
+
+%file: TestIeee80211MgmtApReassociationSnapshot.cc
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class Ieee80211MgmtApReassociationSnapshotAp : public Ieee80211MgmtAp
+{
+  protected:
+    int advertisedPrimaryChannel = -1;
+
+    virtual void start() override
+    {
+        // The response is injected directly below; keep beacon traffic out
+        // of this focused transaction.
+        Ieee80211MgmtApBase::start();
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        if (subtype == ST_REASSOCIATIONRESPONSE) {
+            ASSERT(body->getHtOperationPresent());
+            advertisedPrimaryChannel = body->getHtOperation().primaryChannel;
+        }
+    }
+
+  public:
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitReassociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitReassociationRequest");
+        auto packet = new Packet("ReassociationRequest");
+        auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+        body->setCurrentAP(mib->address);
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setHtCapabilitiesPresent(true);
+        body->setHtCapabilities(makeHtCapabilitiesElement(mib->localHtCapabilities));
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleReassociationRequestFrame(packet, header);
+    }
+
+    int getAdvertisedPrimaryChannel() const { return advertisedPrimaryChannel; }
+
+    uint64_t getPendingTransactionId(const MacAddress& address) const
+    {
+        return staList.at(address).pendingAssociationTransactionId;
+    }
+
+    void finishReassociationResponse(const MacAddress& address)
+    {
+        Enter_Method("finishReassociationResponse");
+        auto response = new Packet("ReassociationResponse");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_REASSOCIATIONRESPONSE);
+        header->setReceiverAddress(address);
+        response->insertAtBack(header);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(getPendingTransactionId(address));
+        IFrameTransmissionCallback::Result result(response, IFrameTransmissionCallback::Status::ACKNOWLEDGED);
+        frameTransmissionFinished(result);
+        delete response;
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+};
+
+Define_Module(Ieee80211MgmtApReassociationSnapshotAp);
+
+class Ieee80211MgmtApReassociationSnapshotTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApReassociationSnapshotTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<Ieee80211MgmtApReassociationSnapshotAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto mib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto radio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.ap.wlan[0].radio"));
+        const MacAddress staAddress("02:00:00:00:00:09");
+
+        mgmt->markAuthenticated(staAddress);
+        mgmt->submitReassociationRequest(staAddress);
+        ASSERT(mgmt->getAdvertisedPrimaryChannel() == 6);
+        ASSERT(mib->requirePrimaryChannel() == 6);
+
+        radio->setChannelNumber(11);
+        ASSERT(mib->requirePrimaryChannel() == 11);
+        mgmt->finishReassociationResponse(staAddress);
+
+        ASSERT(!mgmt->hasPendingAssociation(staAddress));
+        ASSERT(mib->bssAccessPointData.stations.at(staAddress) == Ieee80211Mib::ASSOCIATED);
+        const auto *peerState = mib->findPeerHtState(staAddress);
+        ASSERT(peerState != nullptr);
+        ASSERT(peerState->negotiatedCapabilities.operation.primaryChannel == 6);
+        std::cout << "AP reassociation commits the response-time HT Operation snapshot after a channel change.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApReassociationSnapshotTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple Ieee80211MgmtApReassociationSnapshotAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApReassociationSnapshotAp);
+}
+
+simple Ieee80211MgmtApReassociationSnapshotTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApReassociationSnapshotTest);
+}
+
+network Ieee80211MgmtApReassociationSnapshotNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtApReassociationSnapshotAp";
+        }
+        test: Ieee80211MgmtApReassociationSnapshotTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApReassociationSnapshotNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 1ms
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.ap.wlan[0].radio.channelNumber = 6
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%contains: stdout
+AP reassociation commits the response-time HT Operation snapshot after a channel change.

--- a/tests/module/Ieee80211MgmtApTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApTimeout_1.test
@@ -4,11 +4,17 @@ terminal MAC completion: pending state survives beyond the former AP response
 deadline, commits exactly once, and preserves its association ID while
 duplicate association or reassociation requests are coalesced. Also verify
 failure, deauthentication, disassociation, and same-AP reassociation cleanup.
+Exercise the live DCF path by suppressing two acknowledgments until the retry
+limit drops an Association Response, then verify that a fresh transaction
+recovers through a real response/ACK exchange and reuses the released AID.
 
 %file: TestIeee80211MgmtAp.cc
 
+#include <vector>
+
 #include "inet/common/Simsignals.h"
 #include "inet/linklayer/ieee80211/mac/contract/IFrameSequenceHandler.h"
+#include "inet/linklayer/ieee80211/mac/contract/IRecoveryProcedure.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
@@ -21,6 +27,14 @@ namespace ieee80211 {
 class TestIeee80211MgmtAp : public Ieee80211MgmtAp
 {
   public:
+    virtual void start() override
+    {
+        // Keep the AP beacon timer out of this focused exchange.  The STA's
+        // scripted tester must see exactly the two failed response attempts
+        // followed by the response for the recovered transaction.
+        Ieee80211MgmtApBase::start();
+    }
+
     short startPendingAssociation(const MacAddress& address)
     {
         Enter_Method("startPendingAssociation");
@@ -31,6 +45,23 @@ class TestIeee80211MgmtAp : public Ieee80211MgmtAp
         sta.pendingAssociationSuccessful = true;
         sta.pendingAssociationTransactionId = createAssociationTransactionId();
         return aid;
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
     }
 
     short startPendingReassociation(const MacAddress& address)
@@ -167,26 +198,6 @@ class TestIeee80211MgmtAp : public Ieee80211MgmtAp
             handleAssociationRequestFrame(packet, header);
     }
 
-    void finishFailedReassociation(const MacAddress& address, uint64_t transactionId)
-    {
-        auto response = new Packet("ReassocResp-failed");
-        auto responseHeader = makeShared<Ieee80211MgmtHeader>();
-        responseHeader->setType(ST_REASSOCIATIONRESPONSE);
-        responseHeader->setReceiverAddress(address);
-        response->insertAtBack(responseHeader);
-        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
-
-        FrameSequenceContext context(MacAddress::UNSPECIFIED_ADDRESS, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-        auto transmitStep = new TransmitStep(response, SIMTIME_ZERO);
-        transmitStep->setCompletion(IFrameSequenceStep::Completion::REJECTED);
-        context.addStep(transmitStep);
-        auto receiveStep = new ReceiveStep();
-        receiveStep->setCompletion(IFrameSequenceStep::Completion::REJECTED);
-        context.addStep(receiveStep);
-
-        receiveSignal(this, IFrameSequenceHandler::frameSequenceFinishedSignal, &context, nullptr);
-        delete response;
-    }
 };
 
 Define_Module(TestIeee80211MgmtAp);
@@ -197,11 +208,18 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
 
   protected:
     TestIeee80211MgmtAp *mgmt = nullptr;
+    cModule *apDcf = nullptr;
+    cModule *apRecoveryProcedure = nullptr;
+    cModule *staDcf = nullptr;
     MacAddress expectedAssociatedAddress;
     MacAddress expectedDisassociatedAddress;
     short expectedAssociationId = 0;
     int associationNotifications = 0;
     int disassociationNotifications = 0;
+    int retryLimitReachedNotifications = 0;
+    int retryLimitReachedDrops = 0;
+    int staAckTransmissions = 0;
+    std::vector<bool> associationResponseRetries;
 
   public:
     Ieee80211MgmtApTimeoutTest() : cSimpleModule(65536) {}
@@ -210,26 +228,65 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
     virtual void initialize() override
     {
         mgmt = check_and_cast<TestIeee80211MgmtAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        apDcf = getModuleByPath("^.ap.wlan[0].mac.dcf");
+        apRecoveryProcedure = getModuleByPath("^.ap.wlan[0].mac.dcf.recoveryProcedure");
+        staDcf = getModuleByPath("^.sta.wlan[0].mac.dcf");
         mgmt->subscribe(l2ApAssociatedSignal, this);
         mgmt->subscribe(l2ApDisassociatedSignal, this);
+        apDcf->subscribe(packetSentToPeerSignal, this);
+        apDcf->subscribe(packetDroppedSignal, this);
+        apRecoveryProcedure->subscribe(IRecoveryProcedure::retryLimitReachedSignal, this);
+        staDcf->subscribe(packetSentToPeerSignal, this);
     }
 
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
     {
-        ASSERT(source == mgmt);
-        const auto& notification = check_and_cast<Ieee80211MgmtAp::NotificationInfoSta *>(value);
-        if (signalID == l2ApAssociatedSignal) {
-            ASSERT(notification->getStaAddress() == expectedAssociatedAddress);
-            ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
-            ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
-            associationNotifications++;
+        if (source == mgmt) {
+            const auto& notification = check_and_cast<Ieee80211MgmtAp::NotificationInfoSta *>(value);
+            if (signalID == l2ApAssociatedSignal) {
+                ASSERT(notification->getStaAddress() == expectedAssociatedAddress);
+                ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
+                ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
+                associationNotifications++;
+            }
+            else {
+                ASSERT(signalID == l2ApDisassociatedSignal);
+                ASSERT(notification->getStaAddress() == expectedDisassociatedAddress);
+                ASSERT(!mgmt->hasPendingAssociation(expectedDisassociatedAddress));
+                disassociationNotifications++;
+            }
         }
-        else {
-            ASSERT(signalID == l2ApDisassociatedSignal);
-            ASSERT(notification->getStaAddress() == expectedDisassociatedAddress);
-            ASSERT(!mgmt->hasPendingAssociation(expectedDisassociatedAddress));
-            disassociationNotifications++;
+        else if (source == apDcf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAssociatedAddress) {
+                associationResponseRetries.push_back(header->getRetry());
+                ASSERT(associationResponseRetries.size() <= 3);
+            }
         }
+        else if (source == apRecoveryProcedure && signalID == IRecoveryProcedure::retryLimitReachedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAssociatedAddress)
+                retryLimitReachedNotifications++;
+        }
+        else if (source == apDcf && signalID == packetDroppedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAssociatedAddress) {
+                auto packetDropDetails = check_and_cast<PacketDropDetails *>(details);
+                ASSERT(packetDropDetails->getReason() == RETRY_LIMIT_REACHED);
+                retryLimitReachedDrops++;
+            }
+        }
+        else if (source == staDcf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ACK && header->getReceiverAddress() == MacAddress("02:00:00:00:00:01"))
+                staAckTransmissions++;
+        }
+        else
+            ASSERT(false);
     }
 
     virtual void activity() override
@@ -306,18 +363,67 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         mgmt->finishSuccessfulReassociation(disassociated, staleDisassociationTransaction);
         ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
 
-        // A terminal MAC failure also clears a pending reservation, while a
-        // later stale completion remains ignored by the transaction token.
+        // Exercise the real AP response path.  With actions "BBA", the tester
+        // MAC consumes the AP's first two responses: the same response is
+        // observed twice, but neither blocked copy reaches the recipient ACK
+        // procedure.  The third action accepts the response for the new
+        // transaction and sends a real ACK.
         MacAddress failed("02:00:00:00:00:09");
-        short failedAid = mgmt->startPendingAssociation(failed);
+        expectedAssociatedAddress = failed;
+        mgmt->markAuthenticated(failed);
+        int notificationsBeforeRetry = associationNotifications;
+        mgmt->submitAssociationRequest(failed);
         uint64_t failedTransaction = mgmt->getPendingAssociationTransactionId(failed);
+        short failedAid = mgmt->reserveAssociationId(failed);
         ASSERT(failedAid == 3);
-        mgmt->finishFailedReassociation(failed, failedTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(failed));
+        mgmt->submitAssociationRequest(failed);
+        ASSERT(mgmt->getPendingAssociationTransactionId(failed) == failedTransaction);
+
+        for (int i = 0; i < 100 && (associationResponseRetries.size() < 2 || retryLimitReachedNotifications == 0 || retryLimitReachedDrops == 0 || mgmt->hasPendingAssociation(failed)); i++)
+            wait(SimTime(1, SIMTIME_MS));
+
+        ASSERT(associationResponseRetries.size() == 2);
+        ASSERT(!associationResponseRetries[0]);
+        ASSERT(associationResponseRetries[1]);
+        ASSERT(retryLimitReachedNotifications == 1);
+        ASSERT(retryLimitReachedDrops == 1);
         ASSERT(!mgmt->hasPendingAssociation(failed));
         ASSERT(!mgmt->hasCommittedAssociationId(failed));
+        ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(associationNotifications == notificationsBeforeRetry);
+        MacAddress reusable("02:00:00:00:00:0a");
+        ASSERT(mgmt->reserveAssociationId(reusable) == failedAid);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        expectedAssociationId = failedAid;
+        mgmt->submitAssociationRequest(failed);
+        uint64_t recoveredTransaction = mgmt->getPendingAssociationTransactionId(failed);
+        ASSERT(recoveredTransaction != failedTransaction);
+        ASSERT(mgmt->reserveAssociationId(failed) == failedAid);
+        ASSERT(!mgmt->hasCommittedAssociationId(failed));
+        for (int i = 0; i < 100 && associationNotifications != notificationsBeforeRetry + 1; i++)
+            wait(SimTime(1, SIMTIME_MS));
+
+        ASSERT(associationResponseRetries.size() == 3);
+        ASSERT(!associationResponseRetries[2]);
+        ASSERT(staAckTransmissions == 1);
+        ASSERT(associationNotifications == notificationsBeforeRetry + 1);
+        ASSERT(!mgmt->hasPendingAssociation(failed));
+        ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->hasCommittedAssociationId(failed));
+        ASSERT(mgmt->getCommittedAssociationId(failed) == failedAid);
+        // A stale completion from the failed transaction must not clear the
+        // recovered transaction's committed association.
+        mgmt->finishSuccessfulReassociation(failed, failedTransaction);
+        ASSERT(associationNotifications == notificationsBeforeRetry + 1);
+        ASSERT(!mgmt->hasPendingAssociation(failed));
+        ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(failed) == failedAid);
 
         std::cout << "AP association response delayed-completion lifecycle verified.\n";
         std::cout << "AP reassociation notification commit ordering verified.\n";
+        std::cout << "AP retry-limit exhaustion and association recovery verified.\n";
     }
 };
 
@@ -330,6 +436,7 @@ Define_Module(Ieee80211MgmtApTimeoutTest);
 
 import inet.common.SimpleModule;
 import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.inet.WirelessHost;
 import inet.node.wireless.AccessPoint;
 import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
 
@@ -353,6 +460,11 @@ network Ieee80211MgmtApTimeoutTestNetwork
             parameters:
                 wlan[*].mgmt.typename = "TestIeee80211MgmtAp";
         }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mac.typename = "Ieee80211TesterMac";
+                wlan[*].agent.typename = "";
+        }
         test: Ieee80211MgmtApTimeoutTest;
 }
 
@@ -374,9 +486,30 @@ record-scalar-results = false
 **.mobility.constraintAreaMaxX = 100m
 **.mobility.constraintAreaMaxY = 100m
 **.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+*.sta.mobility.initialX = 1m
+*.sta.mobility.initialY = 0m
+**.wlan[*].opMode = "g(mixed)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+*.sta.wlan[0].mac.actions = "BBA"
+*.sta.wlan[0].mgmt.typename = "Ieee80211MgmtStaSimplified"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+*.ap.wlan[0].mac.dcf.recoveryProcedure.shortRetryLimit = 2
+*.ap.wlan[0].mac.dcf.rtsPolicy.rtsThreshold = 4096B
 
 %contains: stdout
 AP association response delayed-completion lifecycle verified.
 
 %contains: stdout
 AP reassociation notification commit ordering verified.
+
+%contains: stdout
+AP retry-limit exhaustion and association recovery verified.

--- a/tests/module/Ieee80211MgmtApTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApTimeout_1.test
@@ -25,6 +25,16 @@ namespace ieee80211 {
 class TestIeee80211MgmtAp : public Ieee80211MgmtAp
 {
   public:
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype,
+            const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        // Authentication replies are irrelevant to this AP-side transaction
+        // test; suppress them so the tester MAC does not need auth actions.
+        if (subtype == ST_AUTHENTICATION)
+            return;
+        Ieee80211MgmtAp::sendManagementFrame(name, body, subtype, destAddr, transactionId);
+    }
+
     virtual void start() override
     {
         // Keep the AP beacon timer out of this focused exchange.  The STA's
@@ -155,6 +165,34 @@ class TestIeee80211MgmtAp : public Ieee80211MgmtAp
         auto& sta = staList[address];
         sta.address = address;
         mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void setAuthenticationSequenceExpected(const MacAddress& address, int sequenceNumber)
+    {
+        staList.at(address).authSeqExpected = sequenceNumber;
+    }
+
+    void submitAuthentication(const MacAddress& address, int sequenceNumber)
+    {
+        Enter_Method("submitAuthentication");
+        auto packet = new Packet("Authentication");
+        auto body = makeShared<Ieee80211AuthenticationFrame>();
+        body->setSequenceNumber(sequenceNumber);
+        body->setStatusCode(SC_SUCCESSFUL);
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAuthenticationFrame(packet, header);
+    }
+
+    bool hasPendingHtState(const MacAddress& address) const
+    {
+        return staList.at(address).pendingHtStateAvailable;
+    }
+
+    void setPendingHtState(const MacAddress& address)
+    {
+        staList.at(address).pendingHtStateAvailable = true;
     }
 
     void submitDuplicateRequest(const MacAddress& address, bool reassociation)
@@ -426,6 +464,40 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->hasPendingAssociation(failed));
         ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::ASSOCIATED);
         ASSERT(mgmt->getCommittedAssociationId(failed) == failedAid);
+
+        // Authentication traffic with an invalid sequence number must not
+        // revoke the response transaction that the MAC still owns.
+        MacAddress invalidAuthentication("02:00:00:00:00:0d");
+        short invalidAuthenticationAid = mgmt->startPendingAssociation(invalidAuthentication);
+        uint64_t invalidAuthenticationTransaction = mgmt->getPendingAssociationTransactionId(invalidAuthentication);
+        mgmt->setAuthenticationSequenceExpected(invalidAuthentication, 1);
+        mgmt->markAuthenticated(invalidAuthentication);
+        mgmt->setPendingHtState(invalidAuthentication);
+        mgmt->submitAuthentication(invalidAuthentication, 2);
+        ASSERT(mgmt->hasPendingAssociation(invalidAuthentication));
+        ASSERT(mgmt->getPendingAssociationTransactionId(invalidAuthentication) == invalidAuthenticationTransaction);
+        ASSERT(mgmt->hasPendingHtState(invalidAuthentication));
+        ASSERT(mgmt->reserveAssociationId(invalidAuthentication) == invalidAuthenticationAid);
+        expectedAssociatedAddress = invalidAuthentication;
+        expectedAssociationId = invalidAuthenticationAid;
+        mgmt->finishAssociationResponse(invalidAuthentication, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, invalidAuthenticationTransaction);
+        ASSERT(!mgmt->hasPendingAssociation(invalidAuthentication));
+        ASSERT(mgmt->getStationStatus(invalidAuthentication) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(invalidAuthentication) == invalidAuthenticationAid);
+
+        // Frame 1 keeps the existing INET restart policy: it supersedes an
+        // in-flight response, and a stale terminal callback is harmless.
+        MacAddress restartedAuthentication("02:00:00:00:00:0e");
+        short restartedAuthenticationAid = mgmt->startPendingAssociation(restartedAuthentication);
+        uint64_t restartedAuthenticationTransaction = mgmt->getPendingAssociationTransactionId(restartedAuthentication);
+        mgmt->setAuthenticationSequenceExpected(restartedAuthentication, 1);
+        mgmt->markAuthenticated(restartedAuthentication);
+        mgmt->submitAuthentication(restartedAuthentication, 1);
+        ASSERT(!mgmt->hasPendingAssociation(restartedAuthentication));
+        ASSERT(mgmt->reserveAssociationId(restartedAuthentication) == restartedAuthenticationAid);
+        mgmt->cancelAssociationIdReservation(restartedAuthentication);
+        mgmt->finishAssociationResponse(restartedAuthentication, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, restartedAuthenticationTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(restartedAuthentication));
 
         std::cout << "AP association response delayed-completion lifecycle verified.\n";
         std::cout << "AP reassociation notification commit ordering verified.\n";

--- a/tests/module/Ieee80211MgmtApTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApTimeout_1.test
@@ -1,0 +1,382 @@
+%description:
+Verify the AP association-response state machine by injecting a delayed
+terminal MAC completion: pending state survives beyond the former AP response
+deadline, commits exactly once, and preserves its association ID while
+duplicate association or reassociation requests are coalesced. Also verify
+failure, deauthentication, disassociation, and same-AP reassociation cleanup.
+
+%file: TestIeee80211MgmtAp.cc
+
+#include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameSequenceHandler.h"
+#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
+#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtAp : public Ieee80211MgmtAp
+{
+  public:
+    short startPendingAssociation(const MacAddress& address)
+    {
+        Enter_Method("startPendingAssociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        short aid = mib->reserveAssociationId(address);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    short startPendingReassociation(const MacAddress& address)
+    {
+        Enter_Method("startPendingReassociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        short aid = mib->allocateAssociationId(address);
+        ASSERT(mib->reserveAssociationId(address) == aid);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    short startSuccessfulReassociation(const MacAddress& address, Ieee80211Mib::BssMemberStatus status)
+    {
+        Enter_Method("startSuccessfulReassociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        mib->bssAccessPointData.stations[address] = status;
+        short aid = mib->reserveAssociationId(address);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    short startPendingAssociatedReassociation(const MacAddress& address)
+    {
+        Enter_Method("startPendingAssociatedReassociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        short aid = mib->allocateAssociationId(address);
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
+        ASSERT(mib->reserveAssociationId(address) == aid);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    void finishSuccessfulReassociation(const MacAddress& address, uint64_t transactionId = 0)
+    {
+        if (transactionId == 0)
+            transactionId = staList.at(address).pendingAssociationTransactionId;
+        auto response = new Packet("ReassocResp-OK");
+        auto responseHeader = makeShared<Ieee80211MgmtHeader>();
+        responseHeader->setType(ST_REASSOCIATIONRESPONSE);
+        responseHeader->setReceiverAddress(address);
+        response->insertAtBack(responseHeader);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
+
+        FrameSequenceContext context(MacAddress::UNSPECIFIED_ADDRESS, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+        auto transmitStep = new TransmitStep(response, SIMTIME_ZERO);
+        transmitStep->setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
+        context.addStep(transmitStep);
+        auto receiveStep = new ReceiveStep();
+        receiveStep->setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
+        receiveStep->setFrameToReceive(new Packet("ACK", makeShared<Ieee80211AckFrame>()));
+        context.addStep(receiveStep);
+
+        receiveSignal(this, IFrameSequenceHandler::frameSequenceFinishedSignal, &context, nullptr);
+        delete response;
+    }
+
+    void deauthenticate(const MacAddress& address)
+    {
+        Enter_Method("deauthenticate");
+        auto packet = new Packet("Deauth");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleDeauthenticationFrame(packet, header);
+    }
+
+    void disassociate(const MacAddress& address)
+    {
+        Enter_Method("disassociate");
+        auto packet = new Packet("Disassoc");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleDisassociationFrame(packet, header);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const { return staList.at(address).pendingAssociationTransactionId; }
+
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+    bool hasCommittedAssociationId(const MacAddress& address) const { return mib->bssAccessPointData.associationIds.find(address) != mib->bssAccessPointData.associationIds.end(); }
+    short getCommittedAssociationId(const MacAddress& address) const { return mib->bssAccessPointData.associationIds.at(address); }
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const { return mib->bssAccessPointData.stations.at(address); }
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitDuplicateRequest(const MacAddress& address, bool reassociation)
+    {
+        auto packet = new Packet(reassociation ? "DuplicateReassoc" : "DuplicateAssoc");
+        if (reassociation) {
+            auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+            body->setCurrentAP(MacAddress::UNSPECIFIED_ADDRESS);
+            body->setSSID("SSID");
+            Ieee80211SupportedRatesElement rates;
+            rates.numRates = 1;
+            rates.rate[0] = 1;
+            body->setSupportedRates(rates);
+            body->setChunkLength(B(1));
+            packet->insertAtBack(body);
+        }
+        else {
+            auto body = makeShared<Ieee80211AssociationRequestFrame>();
+            body->setSSID("SSID");
+            Ieee80211SupportedRatesElement rates;
+            rates.numRates = 1;
+            rates.rate[0] = 1;
+            body->setSupportedRates(rates);
+            body->setChunkLength(B(1));
+            packet->insertAtBack(body);
+        }
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        if (reassociation)
+            handleReassociationRequestFrame(packet, header);
+        else
+            handleAssociationRequestFrame(packet, header);
+    }
+
+    void finishFailedReassociation(const MacAddress& address, uint64_t transactionId)
+    {
+        auto response = new Packet("ReassocResp-failed");
+        auto responseHeader = makeShared<Ieee80211MgmtHeader>();
+        responseHeader->setType(ST_REASSOCIATIONRESPONSE);
+        responseHeader->setReceiverAddress(address);
+        response->insertAtBack(responseHeader);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
+
+        FrameSequenceContext context(MacAddress::UNSPECIFIED_ADDRESS, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+        auto transmitStep = new TransmitStep(response, SIMTIME_ZERO);
+        transmitStep->setCompletion(IFrameSequenceStep::Completion::REJECTED);
+        context.addStep(transmitStep);
+        auto receiveStep = new ReceiveStep();
+        receiveStep->setCompletion(IFrameSequenceStep::Completion::REJECTED);
+        context.addStep(receiveStep);
+
+        receiveSignal(this, IFrameSequenceHandler::frameSequenceFinishedSignal, &context, nullptr);
+        delete response;
+    }
+};
+
+Define_Module(TestIeee80211MgmtAp);
+
+class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
+{
+    using cListener::finish;
+
+  protected:
+    TestIeee80211MgmtAp *mgmt = nullptr;
+    MacAddress expectedAssociatedAddress;
+    MacAddress expectedDisassociatedAddress;
+    short expectedAssociationId = 0;
+    int associationNotifications = 0;
+    int disassociationNotifications = 0;
+
+  public:
+    Ieee80211MgmtApTimeoutTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        mgmt->subscribe(l2ApAssociatedSignal, this);
+        mgmt->subscribe(l2ApDisassociatedSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        ASSERT(source == mgmt);
+        const auto& notification = check_and_cast<Ieee80211MgmtAp::NotificationInfoSta *>(value);
+        if (signalID == l2ApAssociatedSignal) {
+            ASSERT(notification->getStaAddress() == expectedAssociatedAddress);
+            ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
+            ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
+            associationNotifications++;
+        }
+        else {
+            ASSERT(signalID == l2ApDisassociatedSignal);
+            ASSERT(notification->getStaAddress() == expectedDisassociatedAddress);
+            ASSERT(!mgmt->hasPendingAssociation(expectedDisassociatedAddress));
+            disassociationNotifications++;
+        }
+    }
+
+    virtual void activity() override
+    {
+        // The old AP-local deadline was 100 ms in this test. Keep the
+        // transaction pending beyond it and verify that the reserved AID and
+        // transaction token remain stable until the MAC reports completion.
+        expectedAssociatedAddress = MacAddress("02:00:00:00:00:01");
+        uint64_t delayedTransaction = 0;
+        short delayedAid = mgmt->startPendingAssociation(expectedAssociatedAddress);
+        expectedAssociationId = delayedAid;
+        delayedTransaction = mgmt->getPendingAssociationTransactionId(expectedAssociatedAddress);
+        ASSERT(delayedAid == 1);
+        mgmt->markAuthenticated(expectedAssociatedAddress);
+        mgmt->submitDuplicateRequest(expectedAssociatedAddress, false);
+        mgmt->submitDuplicateRequest(expectedAssociatedAddress, true);
+        ASSERT(mgmt->getPendingAssociationTransactionId(expectedAssociatedAddress) == delayedTransaction);
+        ASSERT(mgmt->reserveAssociationId(expectedAssociatedAddress) == delayedAid);
+
+        MacAddress notReusedWhilePending("02:00:00:00:00:02");
+        ASSERT(mgmt->reserveAssociationId(notReusedWhilePending) == 2);
+        mgmt->cancelAssociationIdReservation(notReusedWhilePending);
+        wait(SimTime(150, SIMTIME_MS));
+        ASSERT(mgmt->hasPendingAssociation(expectedAssociatedAddress));
+        ASSERT(mgmt->getPendingAssociationTransactionId(expectedAssociatedAddress) == delayedTransaction);
+        ASSERT(mgmt->reserveAssociationId(notReusedWhilePending) == 2);
+        mgmt->cancelAssociationIdReservation(notReusedWhilePending);
+
+        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress, delayedTransaction);
+        ASSERT(associationNotifications == 1);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+        ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == delayedAid);
+        // A duplicate terminal signal cannot commit or notify a second time.
+        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress, delayedTransaction);
+        ASSERT(associationNotifications == 1);
+
+        expectedAssociatedAddress = MacAddress("02:00:00:00:00:06");
+        expectedAssociationId = mgmt->startSuccessfulReassociation(expectedAssociatedAddress, Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(!mgmt->hasCommittedAssociationId(expectedAssociatedAddress));
+        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress);
+        ASSERT(associationNotifications == 2);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+
+        short sameApAid = mgmt->startSuccessfulReassociation(expectedAssociatedAddress, Ieee80211Mib::ASSOCIATED);
+        ASSERT(sameApAid == expectedAssociationId);
+        ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
+        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress);
+        ASSERT(associationNotifications == 2);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+
+        MacAddress deauthenticated("02:00:00:00:00:07");
+        mgmt->startPendingAssociatedReassociation(deauthenticated);
+        uint64_t staleDeauthenticationTransaction = mgmt->getPendingAssociationTransactionId(deauthenticated);
+        expectedDisassociatedAddress = deauthenticated;
+        mgmt->deauthenticate(deauthenticated);
+        ASSERT(disassociationNotifications == 1);
+        ASSERT(!mgmt->hasPendingAssociation(deauthenticated));
+        ASSERT(!mgmt->hasCommittedAssociationId(deauthenticated));
+        ASSERT(mgmt->getStationStatus(deauthenticated) == Ieee80211Mib::NOT_AUTHENTICATED);
+        mgmt->finishSuccessfulReassociation(deauthenticated, staleDeauthenticationTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(deauthenticated));
+
+        MacAddress disassociated("02:00:00:00:00:08");
+        mgmt->startPendingAssociatedReassociation(disassociated);
+        uint64_t staleDisassociationTransaction = mgmt->getPendingAssociationTransactionId(disassociated);
+        expectedDisassociatedAddress = disassociated;
+        mgmt->disassociate(disassociated);
+        ASSERT(disassociationNotifications == 2);
+        ASSERT(!mgmt->hasPendingAssociation(disassociated));
+        ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
+        ASSERT(mgmt->getStationStatus(disassociated) == Ieee80211Mib::AUTHENTICATED);
+        mgmt->finishSuccessfulReassociation(disassociated, staleDisassociationTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
+
+        // A terminal MAC failure also clears a pending reservation, while a
+        // later stale completion remains ignored by the transaction token.
+        MacAddress failed("02:00:00:00:00:09");
+        short failedAid = mgmt->startPendingAssociation(failed);
+        uint64_t failedTransaction = mgmt->getPendingAssociationTransactionId(failed);
+        ASSERT(failedAid == 3);
+        mgmt->finishFailedReassociation(failed, failedTransaction);
+        ASSERT(!mgmt->hasPendingAssociation(failed));
+        ASSERT(!mgmt->hasCommittedAssociationId(failed));
+
+        std::cout << "AP association response delayed-completion lifecycle verified.\n";
+        std::cout << "AP reassociation notification commit ordering verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApTimeoutTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtAp);
+}
+
+simple Ieee80211MgmtApTimeoutTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApTimeoutTest);
+}
+
+network Ieee80211MgmtApTimeoutTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtAp";
+        }
+        test: Ieee80211MgmtApTimeoutTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApTimeoutTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 200ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+AP association response delayed-completion lifecycle verified.
+
+%contains: stdout
+AP reassociation notification commit ordering verified.

--- a/tests/module/Ieee80211MgmtApTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApTimeout_1.test
@@ -13,10 +13,8 @@ recovers through a real response/ACK exchange and reuses the released AID.
 #include <vector>
 
 #include "inet/common/Simsignals.h"
-#include "inet/linklayer/ieee80211/mac/contract/IFrameSequenceHandler.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRecoveryProcedure.h"
-#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
-#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
@@ -104,27 +102,20 @@ class TestIeee80211MgmtAp : public Ieee80211MgmtAp
         return aid;
     }
 
-    void finishSuccessfulReassociation(const MacAddress& address, uint64_t transactionId = 0)
+    void finishAssociationResponse(const MacAddress& address, IFrameTransmissionCallback::Status status,
+            bool moreFragments = false, uint64_t transactionId = 0)
     {
         if (transactionId == 0)
             transactionId = staList.at(address).pendingAssociationTransactionId;
-        auto response = new Packet("ReassocResp-OK");
+        auto response = new Packet("ReassocResp");
         auto responseHeader = makeShared<Ieee80211MgmtHeader>();
         responseHeader->setType(ST_REASSOCIATIONRESPONSE);
         responseHeader->setReceiverAddress(address);
+        responseHeader->setMoreFragments(moreFragments);
         response->insertAtBack(responseHeader);
         response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
-
-        FrameSequenceContext context(MacAddress::UNSPECIFIED_ADDRESS, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-        auto transmitStep = new TransmitStep(response, SIMTIME_ZERO);
-        transmitStep->setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
-        context.addStep(transmitStep);
-        auto receiveStep = new ReceiveStep();
-        receiveStep->setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
-        receiveStep->setFrameToReceive(new Packet("ACK", makeShared<Ieee80211AckFrame>()));
-        context.addStep(receiveStep);
-
-        receiveSignal(this, IFrameSequenceHandler::frameSequenceFinishedSignal, &context, nullptr);
+        IFrameTransmissionCallback::Result result(response, status);
+        frameTransmissionFinished(result);
         delete response;
     }
 
@@ -315,19 +306,22 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         ASSERT(mgmt->reserveAssociationId(notReusedWhilePending) == 2);
         mgmt->cancelAssociationIdReservation(notReusedWhilePending);
 
-        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress, delayedTransaction);
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, IFrameTransmissionCallback::Status::ACKNOWLEDGED, true, delayedTransaction);
+        ASSERT(mgmt->hasPendingAssociation(expectedAssociatedAddress));
+        ASSERT(associationNotifications == 0);
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, delayedTransaction);
         ASSERT(associationNotifications == 1);
         ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
         ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == delayedAid);
-        // A duplicate terminal signal cannot commit or notify a second time.
-        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress, delayedTransaction);
+        // A duplicate terminal callback cannot commit or notify a second time.
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, delayedTransaction);
         ASSERT(associationNotifications == 1);
 
         expectedAssociatedAddress = MacAddress("02:00:00:00:00:06");
         expectedAssociationId = mgmt->startSuccessfulReassociation(expectedAssociatedAddress, Ieee80211Mib::AUTHENTICATED);
         ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::AUTHENTICATED);
         ASSERT(!mgmt->hasCommittedAssociationId(expectedAssociatedAddress));
-        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress);
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, IFrameTransmissionCallback::Status::ACKNOWLEDGED);
         ASSERT(associationNotifications == 2);
         ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
 
@@ -335,7 +329,7 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         ASSERT(sameApAid == expectedAssociationId);
         ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
         ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
-        mgmt->finishSuccessfulReassociation(expectedAssociatedAddress);
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, IFrameTransmissionCallback::Status::ACKNOWLEDGED);
         ASSERT(associationNotifications == 2);
         ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
 
@@ -348,7 +342,7 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->hasPendingAssociation(deauthenticated));
         ASSERT(!mgmt->hasCommittedAssociationId(deauthenticated));
         ASSERT(mgmt->getStationStatus(deauthenticated) == Ieee80211Mib::NOT_AUTHENTICATED);
-        mgmt->finishSuccessfulReassociation(deauthenticated, staleDeauthenticationTransaction);
+        mgmt->finishAssociationResponse(deauthenticated, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, staleDeauthenticationTransaction);
         ASSERT(!mgmt->hasCommittedAssociationId(deauthenticated));
 
         MacAddress disassociated("02:00:00:00:00:08");
@@ -360,8 +354,20 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->hasPendingAssociation(disassociated));
         ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
         ASSERT(mgmt->getStationStatus(disassociated) == Ieee80211Mib::AUTHENTICATED);
-        mgmt->finishSuccessfulReassociation(disassociated, staleDisassociationTransaction);
+        mgmt->finishAssociationResponse(disassociated, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, staleDisassociationTransaction);
         ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
+
+        // A terminal retry result clears a pending transaction and releases
+        // its reservation, while a result for an unknown STA is ignored.
+        MacAddress terminalFailure("02:00:00:00:00:0b");
+        short terminalFailureAid = mgmt->startPendingAssociation(terminalFailure);
+        uint64_t terminalFailureTransaction = mgmt->getPendingAssociationTransactionId(terminalFailure);
+        mgmt->finishAssociationResponse(terminalFailure, IFrameTransmissionCallback::Status::RETRY_LIMIT_REACHED, false, terminalFailureTransaction);
+        ASSERT(!mgmt->hasPendingAssociation(terminalFailure));
+        ASSERT(!mgmt->hasCommittedAssociationId(terminalFailure));
+        ASSERT(mgmt->reserveAssociationId(terminalFailure) == terminalFailureAid);
+        mgmt->cancelAssociationIdReservation(terminalFailure);
+        mgmt->finishAssociationResponse(MacAddress("02:00:00:00:00:0c"), IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, 1);
 
         // Exercise the real AP response path.  With actions "BBA", the tester
         // MAC consumes the AP's first two responses: the same response is
@@ -415,7 +421,7 @@ class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
         ASSERT(mgmt->getCommittedAssociationId(failed) == failedAid);
         // A stale completion from the failed transaction must not clear the
         // recovered transaction's committed association.
-        mgmt->finishSuccessfulReassociation(failed, failedTransaction);
+        mgmt->finishAssociationResponse(failed, IFrameTransmissionCallback::Status::ACKNOWLEDGED, false, failedTransaction);
         ASSERT(associationNotifications == notificationsBeforeRetry + 1);
         ASSERT(!mgmt->hasPendingAssociation(failed));
         ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::ASSOCIATED);

--- a/tests/module/Ieee80211MgmtApUnavailableChannel_1.test
+++ b/tests/module/Ieee80211MgmtApUnavailableChannel_1.test
@@ -1,0 +1,44 @@
+%description:
+An HT-capable AP must not serialize a management frame before its radio has
+published a valid primary channel.  A radio channel of -1 suppresses the
+initial channel signal, so the first beacon deterministically reports the
+missing MIB-owned channel instead of serializing an invalid value.
+
+%file: test.ned
+
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+network Ieee80211MgmtApUnavailableChannelTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApUnavailableChannelTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].radio.channelNumber = -1
+*.ap.wlan[0].mgmt.beaconInterval = 1us
+**.wlan[0].opMode = "n(mixed-2.4Ghz)"
+**.wlan[0].bitrate = 65Mbps
+**.wlan[0].radio.bandName = "2.4 GHz"
+**.wlan[0].radio.centerFrequency = 2.4GHz
+*.ap.mobility.initFromDisplayString = false
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%exitcode: 1
+
+%postrun-command: grep "<!>" test.* > test_err.out || true
+
+%contains: test_err.out
+IEEE 802.11 primary channel is unavailable

--- a/tests/module/Ieee80211MgmtStaDeauthentication_1.test
+++ b/tests/module/Ieee80211MgmtStaDeauthentication_1.test
@@ -1,0 +1,340 @@
+%description:
+Verify that a station tears down its current association when the associated
+AP sends Deauthentication, while preserving unrelated AP transactions.
+
+%file: TestIeee80211MgmtStaDeauthentication.cc
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    ApInfo *ensureAccessPoint(const MacAddress& address)
+    {
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 1;
+            ap->ssid = "SSID";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+        }
+        ap->isAuthenticated = true;
+        return ap;
+    }
+
+  public:
+    int associationConfirms = 0;
+    int reassociationConfirms = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+    MacAddress lastAssociationAddress;
+    MacAddress lastReassociationAddress;
+    bool confirmationSawClearedAssociation = false;
+    bool confirmationSawDeauthenticatedAssociation = false;
+
+    void setAssociated(const MacAddress& address, bool cacheAp = true)
+    {
+        Enter_Method("setAssociated");
+        ASSERT(!mib->bssStationData.isAssociated);
+        if (cacheAp)
+            ensureAccessPoint(address);
+        mib->bssData.bssid = address;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.address = address;
+        assocAP.channel = 1;
+        assocAP.ssid = "SSID";
+        assocAP.isAuthenticated = true;
+        assocAP.beaconInterval = SimTime(100, SIMTIME_MS);
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 6);
+        scheduleAfter(SimTime(1, SIMTIME_S), assocAP.beaconTimeoutMsg);
+    }
+
+    void installPeerHtState(const MacAddress& address)
+    {
+        Enter_Method("installPeerHtState");
+        mib->setPrimaryChannel(1);
+        mib->setPeerHtCapabilities(address, mib->localHtCapabilities, mib->getHtOperation());
+    }
+
+    void authenticatePeer(const MacAddress& address)
+    {
+        Enter_Method("authenticatePeer");
+        ensureAccessPoint(address);
+    }
+
+    void clearCachedAccessPoints()
+    {
+        Enter_Method("clearCachedAccessPoints");
+        clearAPList();
+    }
+
+    void preparePendingAssociation(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("preparePendingAssociation");
+        ASSERT(assocTimeoutMsg == nullptr);
+        auto ap = ensureAccessPoint(address);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+        scheduleAfter(SimTime(1, SIMTIME_S), assocTimeoutMsg);
+    }
+
+    bool hasPendingAssociation() const { return assocTimeoutMsg != nullptr; }
+    bool isPendingAssociationScheduled() const { return assocTimeoutMsg != nullptr && assocTimeoutMsg->isScheduled(); }
+    bool isReassociationPending() const { return reassociationInProgress; }
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    bool hasBeaconTimer() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+    bool isAuthenticated(const MacAddress& address) const
+    {
+        auto ap = const_cast<TestIeee80211MgmtSta *>(this)->lookupAP(address);
+        return ap != nullptr && ap->isAuthenticated;
+    }
+    bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
+
+    void deliverDeauthentication(const MacAddress& transmitter, const MacAddress& address3)
+    {
+        Enter_Method("deliverDeauthentication");
+        auto packet = new Packet("Deauthentication");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        header->setAddress3(address3);
+        handleDeauthenticationFrame(packet, header);
+    }
+
+    void deliverAssociationResponse(const MacAddress& transmitter, bool reassociation, Ieee80211StatusCode statusCode)
+    {
+        Enter_Method("deliverAssociationResponse");
+        auto packet = new Packet("AssociationResponse");
+        auto body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+  protected:
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associationConfirms++;
+        lastAssociationAddress = ap->address;
+        lastAssociationResult = resultCode;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+        confirmationSawDeauthenticatedAssociation = confirmationSawDeauthenticatedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified() && !ap->isAuthenticated);
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociationConfirms++;
+        lastReassociationAddress = ap->address;
+        lastReassociationResult = resultCode;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+        confirmationSawDeauthenticatedAssociation = confirmationSawDeauthenticatedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified() && !ap->isAuthenticated);
+    }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class Ieee80211MgmtStaDeauthenticationTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211MgmtSta *mgmt = nullptr;
+
+  public:
+    Ieee80211MgmtStaDeauthenticationTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+    }
+
+    virtual void activity() override
+    {
+        const MacAddress currentAp("02:00:00:00:00:01");
+        const MacAddress targetAp("02:00:00:00:00:02");
+        const MacAddress foreignAp("02:00:00:00:00:03");
+
+        // Address 2 identifies the sender. A forged/different Address 3 must
+        // not tear down the current association.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->deliverDeauthentication(foreignAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+
+        // The associated AP's discovery entry and negotiated HT state are
+        // both cleared, and the beacon timer and association snapshot vanish.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        ASSERT(mgmt->isAuthenticated(currentAp));
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasBeaconTimer());
+        ASSERT(!mgmt->isAuthenticated(currentAp));
+        ASSERT(!mgmt->hasPeerHtState(currentAp));
+        ASSERT(mgmt->associationConfirms == 0);
+        ASSERT(mgmt->reassociationConfirms == 0);
+
+        // Association state remains authoritative even when the AP is no
+        // longer present in the scan/authentication cache.
+        mgmt->clearCachedAccessPoints();
+        mgmt->setAssociated(currentAp, false);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->deliverDeauthentication(currentAp, currentAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasBeaconTimer());
+        ASSERT(!mgmt->hasPeerHtState(currentAp));
+
+        // An authenticated but non-associated AP keeps the current pair
+        // intact while its own authentication and HT state are removed.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->authenticatePeer(foreignAp);
+        mgmt->installPeerHtState(foreignAp);
+        mgmt->deliverDeauthentication(foreignAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        ASSERT(!mgmt->isAuthenticated(foreignAp));
+        ASSERT(!mgmt->hasPeerHtState(foreignAp));
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+
+        // A current-AP deauthentication does not cancel a reassociation to a
+        // different AP; that transaction can still complete successfully.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == targetAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->reassociationConfirms == 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        mgmt->deliverDeauthentication(targetAp, foreignAp);
+
+        // A same-peer pending association is canceled once, and its refusal
+        // is observed only after current association state was cleared.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(currentAp, false);
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->associationConfirms == 1);
+        ASSERT(mgmt->lastAssociationAddress == currentAp);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(mgmt->confirmationSawClearedAssociation);
+        ASSERT(mgmt->confirmationSawDeauthenticatedAssociation);
+        mgmt->deliverAssociationResponse(currentAp, false, SC_SUCCESSFUL);
+        ASSERT(mgmt->associationConfirms == 1);
+
+        // The same transaction rule applies to a pending reassociation.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(currentAp, true);
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociationConfirms == 2);
+        ASSERT(mgmt->lastReassociationAddress == currentAp);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+        mgmt->deliverAssociationResponse(currentAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->reassociationConfirms == 2);
+
+        std::cout << "STA Deauthentication peer filtering and association teardown verified.\n";
+        std::cout << "STA deauthentication transaction cancellation and preservation verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaDeauthenticationTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple Ieee80211MgmtStaDeauthenticationTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaDeauthenticationTest);
+}
+
+network Ieee80211MgmtStaDeauthenticationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+        }
+        test: Ieee80211MgmtStaDeauthenticationTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaDeauthenticationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 1s
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+STA Deauthentication peer filtering and association teardown verified.
+
+%contains: stdout
+STA deauthentication transaction cancellation and preservation verified.

--- a/tests/module/Ieee80211MgmtStaDeauthentication_1.test
+++ b/tests/module/Ieee80211MgmtStaDeauthentication_1.test
@@ -36,6 +36,8 @@ class TestIeee80211MgmtSta : public Ieee80211MgmtSta
     MacAddress lastReassociationAddress;
     bool confirmationSawClearedAssociation = false;
     bool confirmationSawDeauthenticatedAssociation = false;
+    bool lastAssociationConfirmationSawTerminalState = false;
+    bool lastReassociationConfirmationSawTerminalState = false;
 
     void setAssociated(const MacAddress& address, bool cacheAp = true)
     {
@@ -127,6 +129,7 @@ class TestIeee80211MgmtSta : public Ieee80211MgmtSta
         associationConfirms++;
         lastAssociationAddress = ap->address;
         lastAssociationResult = resultCode;
+        lastAssociationConfirmationSawTerminalState = !ap->isAuthenticated && assocTimeoutMsg == nullptr;
         confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
                 (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
         confirmationSawDeauthenticatedAssociation = confirmationSawDeauthenticatedAssociation ||
@@ -138,6 +141,7 @@ class TestIeee80211MgmtSta : public Ieee80211MgmtSta
         reassociationConfirms++;
         lastReassociationAddress = ap->address;
         lastReassociationResult = resultCode;
+        lastReassociationConfirmationSawTerminalState = !ap->isAuthenticated && assocTimeoutMsg == nullptr;
         confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
                 (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
         confirmationSawDeauthenticatedAssociation = confirmationSawDeauthenticatedAssociation ||
@@ -237,34 +241,99 @@ class Ieee80211MgmtStaDeauthenticationTest : public cSimpleModule
         ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
         mgmt->deliverDeauthentication(targetAp, foreignAp);
 
+        // A deauthentication from an unrelated AP does not cancel an initial
+        // association to the pending target, but the target's deauthentication
+        // cancels it and emits exactly one refusal.
+        ASSERT(!mgmt->isAssociated());
+        mgmt->preparePendingAssociation(targetAp, false);
+        mgmt->authenticatePeer(foreignAp);
+        mgmt->installPeerHtState(targetAp);
+        mgmt->installPeerHtState(foreignAp);
+        int associationConfirmsBeforeTargetDeauthentication = mgmt->associationConfirms;
+        mgmt->deliverDeauthentication(foreignAp, targetAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isAuthenticated(targetAp));
+        ASSERT(mgmt->hasPeerHtState(targetAp));
+        ASSERT(!mgmt->isAuthenticated(foreignAp));
+        ASSERT(!mgmt->hasPeerHtState(foreignAp));
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication);
+        mgmt->deliverDeauthentication(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAuthenticated(targetAp));
+        ASSERT(!mgmt->hasPeerHtState(targetAp));
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication + 1);
+        ASSERT(mgmt->lastAssociationAddress == targetAp);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(mgmt->lastAssociationConfirmationSawTerminalState);
+        mgmt->deliverAssociationResponse(targetAp, false, SC_SUCCESSFUL);
+        ASSERT(!mgmt->isAssociated());
+        mgmt->deliverDeauthentication(targetAp, foreignAp);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication + 1);
+
+        // A target deauthentication cancels a reassociation without disturbing
+        // the current AP association or its negotiated HT state.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->installPeerHtState(targetAp);
+        int reassociationConfirmsBeforeTargetDeauthentication = mgmt->reassociationConfirms;
+        associationConfirmsBeforeTargetDeauthentication = mgmt->associationConfirms;
+        mgmt->deliverDeauthentication(targetAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAuthenticated(targetAp));
+        ASSERT(!mgmt->hasPeerHtState(targetAp));
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeTargetDeauthentication + 1);
+        ASSERT(mgmt->lastReassociationAddress == targetAp);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+        ASSERT(mgmt->lastReassociationConfirmationSawTerminalState);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication);
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        mgmt->deliverDeauthentication(targetAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeTargetDeauthentication + 1);
+        mgmt->deliverDeauthentication(currentAp, targetAp);
+
         // A same-peer pending association is canceled once, and its refusal
         // is observed only after current association state was cleared.
         mgmt->setAssociated(currentAp);
         mgmt->preparePendingAssociation(currentAp, false);
+        int associationConfirmsBeforeSamePeer = mgmt->associationConfirms;
         mgmt->deliverDeauthentication(currentAp, foreignAp);
         ASSERT(!mgmt->isAssociated());
         ASSERT(!mgmt->hasPendingAssociation());
         ASSERT(!mgmt->isReassociationPending());
-        ASSERT(mgmt->associationConfirms == 1);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeSamePeer + 1);
         ASSERT(mgmt->lastAssociationAddress == currentAp);
         ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
         ASSERT(mgmt->confirmationSawClearedAssociation);
         ASSERT(mgmt->confirmationSawDeauthenticatedAssociation);
         mgmt->deliverAssociationResponse(currentAp, false, SC_SUCCESSFUL);
-        ASSERT(mgmt->associationConfirms == 1);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeSamePeer + 1);
 
         // The same transaction rule applies to a pending reassociation.
         mgmt->setAssociated(currentAp);
         mgmt->preparePendingAssociation(currentAp, true);
+        int reassociationConfirmsBeforeSamePeer = mgmt->reassociationConfirms;
         mgmt->deliverDeauthentication(currentAp, foreignAp);
         ASSERT(!mgmt->isAssociated());
         ASSERT(!mgmt->hasPendingAssociation());
         ASSERT(!mgmt->isReassociationPending());
-        ASSERT(mgmt->reassociationConfirms == 2);
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeSamePeer + 1);
         ASSERT(mgmt->lastReassociationAddress == currentAp);
         ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
         mgmt->deliverAssociationResponse(currentAp, true, SC_SUCCESSFUL);
-        ASSERT(mgmt->reassociationConfirms == 2);
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeSamePeer + 1);
 
         std::cout << "STA Deauthentication peer filtering and association teardown verified.\n";
         std::cout << "STA deauthentication transaction cancellation and preservation verified.\n";

--- a/tests/module/Ieee80211MgmtStaDisassociation_1.test
+++ b/tests/module/Ieee80211MgmtStaDisassociation_1.test
@@ -1,0 +1,301 @@
+%description:
+Verify that a station processes a Disassociation only when it is transmitted
+by the currently associated AP. Foreign and pending-only frames preserve an
+active association transaction, while a current-AP frame clears the current
+association and emits one typed refusal only for a same-AP pending request.
+
+%file: TestIeee80211MgmtSta.cc
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    ApInfo *ensureAccessPoint(const MacAddress& address)
+    {
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 1;
+            ap->ssid = "SSID";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+            ap->isAuthenticated = true;
+        }
+        return ap;
+    }
+
+  public:
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+    MacAddress lastAssociationAddress;
+    MacAddress lastReassociationAddress;
+    bool confirmationSawClearedAssociation = false;
+
+    void setAssociated(const MacAddress& address)
+    {
+        Enter_Method("setAssociated");
+        ASSERT(!mib->bssStationData.isAssociated);
+        ensureAccessPoint(address);
+        mib->bssData.bssid = address;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.address = address;
+        assocAP.channel = 1;
+        assocAP.ssid = "SSID";
+        assocAP.beaconInterval = SimTime(100, SIMTIME_MS);
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 6);
+        scheduleAfter(SimTime(1, SIMTIME_S), assocAP.beaconTimeoutMsg);
+    }
+
+    void preparePendingAssociation(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("preparePendingAssociation");
+        ASSERT(assocTimeoutMsg == nullptr);
+        auto ap = ensureAccessPoint(address);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+        scheduleAfter(SimTime(1, SIMTIME_S), assocTimeoutMsg);
+    }
+
+    void abandonPendingAssociation()
+    {
+        Enter_Method("abandonPendingAssociation");
+        cancelPendingAssociation();
+    }
+
+    bool hasPendingAssociation() const { return assocTimeoutMsg != nullptr; }
+    bool isPendingAssociationScheduled() const { return assocTimeoutMsg != nullptr && assocTimeoutMsg->isScheduled(); }
+    bool isReassociationPending() const { return reassociationInProgress; }
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+
+    void deliverDisassociation(const MacAddress& transmitter, const MacAddress& address3)
+    {
+        Enter_Method("deliverDisassociation");
+        auto packet = new Packet("Disassociation");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        header->setAddress3(address3);
+        handleDisassociationFrame(packet, header);
+    }
+
+    void deliverAssociationResponse(const MacAddress& transmitter, bool reassociation, Ieee80211StatusCode statusCode)
+    {
+        Enter_Method("deliverAssociationResponse");
+        auto packet = new Packet("AssociationResponse");
+        auto body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+  protected:
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associateConfirms++;
+        lastAssociationAddress = ap->address;
+        lastAssociationResult = resultCode;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociateConfirms++;
+        lastReassociationAddress = ap->address;
+        lastReassociationResult = resultCode;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+    }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class Ieee80211MgmtStaDisassociationTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211MgmtSta *mgmt = nullptr;
+
+  public:
+    Ieee80211MgmtStaDisassociationTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+    }
+
+    virtual void activity() override
+    {
+        const MacAddress currentAp("02:00:00:00:00:01");
+        const MacAddress targetAp("02:00:00:00:00:02");
+        const MacAddress foreignAp("02:00:00:00:00:03");
+
+        // A pending-only target is not an associated peer and cannot cancel
+        // the request merely by transmitting a Disassociation.
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        mgmt->abandonPendingAssociation();
+
+        // Address 3 is deliberately the pending target; Address 2 is
+        // unrelated. Validation must use the transmitter address.
+        mgmt->preparePendingAssociation(targetAp, false);
+        mgmt->deliverDisassociation(foreignAp, targetAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(!mgmt->isReassociationPending());
+        mgmt->abandonPendingAssociation();
+
+        // A current-AP frame tears down the current pair when no request is
+        // pending, including the beacon timer and copied association state.
+        mgmt->setAssociated(currentAp);
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(mgmt->associateConfirms == 0);
+        ASSERT(mgmt->reassociateConfirms == 0);
+
+        // A foreign frame leaves both the current association and a request
+        // to another AP untouched.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDisassociation(foreignAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociateConfirms == 0);
+
+        // The current AP can clear its own association without cancelling the
+        // reassociation transaction to another AP; that response can still
+        // complete the pending request.
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == targetAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->reassociateConfirms == 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+
+        // A same-AP pending reassociation is terminated exactly once. The
+        // overridden confirmation also proves that teardown precedes the
+        // primitive visible to the agent.
+        mgmt->setAssociated(targetAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociateConfirms == 2);
+        ASSERT(mgmt->lastReassociationAddress == targetAp);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+        ASSERT(mgmt->confirmationSawClearedAssociation);
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->reassociateConfirms == 2);
+
+        // Exercise the association confirmation branch as well, even though
+        // normal station sequencing starts association while unassociated.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(currentAp, false);
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->associateConfirms == 1);
+        ASSERT(mgmt->lastAssociationAddress == currentAp);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+
+        std::cout << "STA Disassociation peer filtering and pending-request preservation verified.\n";
+        std::cout << "STA same-peer disassociation confirmation typing and teardown verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaDisassociationTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple Ieee80211MgmtStaDisassociationTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaDisassociationTest);
+}
+
+network Ieee80211MgmtStaDisassociationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+        }
+        test: Ieee80211MgmtStaDisassociationTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaDisassociationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 1s
+**.wlan[*].opMode = "g(mixed)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+STA Disassociation peer filtering and pending-request preservation verified.
+
+%contains: stdout
+STA same-peer disassociation confirmation typing and teardown verified.

--- a/tests/module/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/module/Ieee80211MgmtStaDiscovery_1.test
@@ -1,0 +1,415 @@
+%description:
+Verify that serialized HT discovery stores the HT Operation primary channel and
+that the production authentication and association paths tune to that cached
+channel. Legacy packet-domain discovery keeps its channelNumber unchanged.
+
+%file: TestIeee80211MgmtStaDiscovery.cc
+
+#include <string>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtStaDiscovery : public Ieee80211MgmtSta
+{
+  public:
+    int changedChannel = -1;
+    int associationConfirms = 0;
+    int reassociationConfirms = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+
+    virtual void changeChannel(int channel) override { changedChannel = channel; }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& address) override
+    {
+        // The channel-tuning seam is the subject of this test; no peer is
+        // needed for the generated authentication/association requests.
+    }
+
+    void storeSerializedDiscovery(const MacAddress& address, int primaryChannel, bool probeResponse)
+    {
+        Enter_Method("storeSerializedDiscovery");
+        Ptr<Ieee80211BeaconFrame> original;
+        if (probeResponse)
+            original = makeShared<Ieee80211ProbeResponseFrame>();
+        else
+            original = makeShared<Ieee80211BeaconFrame>();
+        original->setSSID("serialized");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        original->setSupportedRates(rates);
+        original->setBeaconInterval(SimTime(100, SIMTIME_MS));
+        Ieee80211HtCapabilities capabilities;
+        capabilities.supportedChannelWidths.insert(MHz(20));
+        capabilities.rxMcsSupported[0] = true;
+        capabilities.txMcsNss.maxMcsPerNss[0] = 0;
+        setHtCapabilities(original, capabilities);
+        Ieee80211HtOperation operation;
+        operation.primaryChannel = primaryChannel;
+        operation.basicMcsSupported[0] = true;
+        setHtOperation(original, operation);
+        original->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(original));
+
+        Packet packet("discovery", original);
+        auto bytes = packet.peekAllAsBytes()->getBytes();
+        Packet encoded("encoded", makeShared<BytesChunk>(bytes));
+        encoded.addTag<SignalPowerInd>()->setPower(mW(1));
+        Ptr<const Ieee80211BeaconFrame> decoded;
+        if (probeResponse)
+            decoded = encoded.popAtFront<Ieee80211ProbeResponseFrame>(B(bytes.size()));
+        else
+            decoded = encoded.popAtFront<Ieee80211BeaconFrame>(B(bytes.size()));
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        storeAPInfo(&encoded, header, decoded);
+    }
+
+    void startAuthenticationForTest(const MacAddress& address)
+    {
+        Enter_Method("startAuthenticationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        startAuthentication(ap, SimTime(1, SIMTIME_MS));
+    }
+
+    void finishAuthenticationForTest(const MacAddress& address)
+    {
+        Enter_Method("finishAuthenticationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        cancelAndDelete(ap->authTimeoutMsg);
+        ap->authTimeoutMsg = nullptr;
+        ap->isAuthenticated = true;
+    }
+
+    void startAssociationForTest(const MacAddress& address)
+    {
+        Enter_Method("startAssociationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        startAssociation(ap, SimTime(1, SIMTIME_MS));
+    }
+
+    void cancelAssociationForTest()
+    {
+        Enter_Method("cancelAssociationForTest");
+        cancelPendingAssociation();
+    }
+
+    const ApInfo *getCachedAp(const MacAddress& address) const
+    {
+        return const_cast<TestIeee80211MgmtStaDiscovery *>(this)->lookupAP(address);
+    }
+
+    void prepareResponse(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("prepareResponse");
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 6;
+            ap->ssid = "serialized";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+        }
+        ap->isAuthenticated = true;
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+    }
+
+    enum class ResponseHtForm { LEGACY, VALID, PARTIAL, UNUSABLE };
+
+    void deliverResponse(const MacAddress& address, bool reassociation, Ieee80211StatusCode statusCode, ResponseHtForm htForm)
+    {
+        Enter_Method("deliverResponse");
+        Ptr<Ieee80211AssociationResponseFrame> body;
+        if (reassociation)
+            body = makeShared<Ieee80211ReassociationResponseFrame>();
+        else
+            body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setAid(1);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+        if (htForm != ResponseHtForm::LEGACY) {
+            auto capabilities = mib->localHtCapabilities;
+            auto operation = mib->getHtOperation();
+            if (htForm == ResponseHtForm::UNUSABLE) {
+                capabilities.rxMcsSupported.fill(false);
+                capabilities.txMcsNss.maxMcsPerNss.fill(-1);
+            }
+            setHtCapabilities(body, capabilities);
+            if (htForm != ResponseHtForm::PARTIAL)
+                setHtOperation(body, operation);
+        }
+        body->setChunkLength(B(9) + getHtMgmtElementsLength(body));
+        auto packet = new Packet("AssociationResponse");
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    void resetAssociationState()
+    {
+        Enter_Method("resetAssociationState");
+        cancelPendingAssociation();
+        if (mib->bssStationData.isAssociated)
+            clearCurrentAssociation();
+    }
+
+    bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
+
+    void setPrimaryChannelForTest(int channel)
+    {
+        Enter_Method("setPrimaryChannelForTest");
+        mib->setPrimaryChannel(channel);
+    }
+
+  protected:
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associationConfirms++;
+        lastAssociationResult = resultCode;
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociationConfirms++;
+        lastReassociationResult = resultCode;
+    }
+};
+
+Define_Module(TestIeee80211MgmtStaDiscovery);
+
+class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
+{
+    using cListener::finish;
+
+    int htNegotiationFailures = 0;
+    bool lastFailureWasReassociation = false;
+    std::string lastFailureReason;
+
+  public:
+    Ieee80211MgmtStaDiscoveryTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtStaDiscovery *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+        mgmt->subscribe(Ieee80211MgmtSta::htNegotiationFailedSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (signalID == Ieee80211MgmtSta::htNegotiationFailedSignal) {
+            auto notification = check_and_cast<Ieee80211MgmtSta::HtNegotiationFailure *>(value);
+            htNegotiationFailures++;
+            lastFailureWasReassociation = notification->isReassociation();
+            lastFailureReason = notification->getReason();
+        }
+    }
+
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtStaDiscovery *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+        const MacAddress address("02:00:00:00:00:01");
+
+        mgmt->setPrimaryChannelForTest(6);
+        mgmt->storeSerializedDiscovery(address, 11, false);
+        ASSERT(mgmt->getCachedAp(address)->channel == 11);
+
+        const MacAddress probeAddress("02:00:00:00:00:02");
+        mgmt->storeSerializedDiscovery(probeAddress, 6, true);
+        ASSERT(mgmt->getCachedAp(probeAddress)->channel == 6);
+
+        mgmt->startAuthenticationForTest(address);
+        ASSERT(mgmt->changedChannel == 11);
+        mgmt->finishAuthenticationForTest(address);
+
+        mgmt->startAssociationForTest(address);
+        ASSERT(mgmt->changedChannel == 11);
+        mgmt->cancelAssociationForTest();
+
+        // IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4: a successful
+        // association remains successful when the HT exchange is absent or
+        // unusable; only the negotiated HT state is suppressed.
+        mgmt->resetAssociationState();
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
+        ASSERT(mgmt->associationConfirms == 1);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 0);
+
+        mgmt->resetAssociationState();
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
+        ASSERT(mgmt->associationConfirms == 2);
+        ASSERT(mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 0);
+
+        auto staMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.sta.wlan[0].mib"));
+        auto dcfRateSelection = check_and_cast<RateSelection *>(getModuleByPath("^.sta.wlan[0].mac.dcf.rateSelection"));
+        auto qosRateSelection = check_and_cast<QosRateSelection *>(getModuleByPath("^.sta.wlan[0].mac.hcf.rateSelection"));
+        const auto *modeSet = physicallayer::Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+        auto dataHeader = makeShared<Ieee80211DataHeader>();
+        dataHeader->setReceiverAddress(address);
+        Packet ratePacket("rate-selection");
+        const auto *dcfHtMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+        const auto *qosHtMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+        ASSERT(dcfHtMode->getHtMcsIndex() >= 0);
+        ASSERT(qosHtMode->getHtMcsIndex() >= 0);
+
+        // The invalid/absent negotiated state is a legacy-only unicast
+        // condition, while group-addressed traffic keeps its existing HT
+        // selection policy.
+        staMib->removePeerHtCapabilities(address);
+        const auto *dcfLegacyMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+        const auto *qosLegacyMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+        ASSERT(dcfLegacyMode == modeSet->getFastestLegacyOperationalMode());
+        ASSERT(qosLegacyMode == modeSet->getFastestLegacyOperationalMode());
+        ASSERT(dcfLegacyMode->getHtMcsIndex() < 0);
+        ASSERT(qosLegacyMode->getHtMcsIndex() < 0);
+
+        auto multicastHeader = makeShared<Ieee80211DataHeader>();
+        multicastHeader->setReceiverAddress(MacAddress::BROADCAST_ADDRESS);
+        const auto *dcfMulticastMode = dcfRateSelection->computeMode(&ratePacket, multicastHeader);
+        const auto *qosMulticastMode = qosRateSelection->computeMode(&ratePacket, multicastHeader, nullptr);
+        ASSERT(dcfMulticastMode->getHtMcsIndex() >= 0);
+        ASSERT(qosMulticastMode->getHtMcsIndex() >= 0);
+        staMib->setPeerHtCapabilities(address, staMib->localHtCapabilities, staMib->getHtOperation());
+        ASSERT(dcfRateSelection->computeMode(&ratePacket, dataHeader)->getHtMcsIndex() >= 0);
+        ASSERT(qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr)->getHtMcsIndex() >= 0);
+
+        mgmt->resetAssociationState();
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::PARTIAL);
+        ASSERT(mgmt->associationConfirms == 3);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 1);
+        ASSERT(!lastFailureReason.empty());
+        ASSERT(!lastFailureWasReassociation);
+
+        mgmt->resetAssociationState();
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::UNUSABLE);
+        ASSERT(mgmt->associationConfirms == 4);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 2);
+
+        mgmt->resetAssociationState();
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_DATARATE_UNSUP, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
+        ASSERT(mgmt->associationConfirms == 5);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 2);
+
+        // The same policy applies to reassociation responses, and its
+        // diagnostic retains the procedure context for observers.
+        mgmt->resetAssociationState();
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
+        ASSERT(mgmt->hasPeerHtState(address));
+        mgmt->prepareResponse(probeAddress, true);
+        mgmt->deliverResponse(probeAddress, true, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::PARTIAL);
+        ASSERT(mgmt->reassociationConfirms == 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(probeAddress));
+        ASSERT(htNegotiationFailures == 3);
+        ASSERT(lastFailureWasReassociation);
+
+        std::cout << "Serialized Beacon and Probe Response HT discovery drive production tuning to advertised channels.\n";
+        std::cout << "Association and reassociation HT response semantics preserve success and diagnose invalid negotiation.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaDiscoveryTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtStaDiscovery extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtStaDiscovery);
+}
+
+simple Ieee80211MgmtStaDiscoveryTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaDiscoveryTest);
+}
+
+network Ieee80211MgmtStaDiscoveryTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtStaDiscovery";
+                wlan[*].agent.typename = "Ieee80211AgentSta";
+        }
+        test: Ieee80211MgmtStaDiscoveryTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaDiscoveryTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 100s
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+*.sta.wlan[0].mac.qosStation = true
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+Serialized Beacon and Probe Response HT discovery drive production tuning to advertised channels.
+
+%contains: stdout
+Association and reassociation HT response semantics preserve success and diagnose invalid negotiation.

--- a/tests/module/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/module/Ieee80211MgmtStaDiscovery_1.test
@@ -278,6 +278,23 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(dcfHtMode->getHtMcsIndex() >= 0);
         ASSERT(qosHtMode->getHtMcsIndex() >= 0);
 
+        // Both production selectors consume the same negotiated directional
+        // capability gate. A sparse peer that advertises only MCS 0 must not
+        // receive the configured faster HT mode.
+        Ieee80211HtCapabilities sparsePeer;
+        sparsePeer.supportedChannelWidths.insert(MHz(20));
+        sparsePeer.rxMcsSupported[0] = true;
+        sparsePeer.txMcsNss.maxMcsPerNss[0] = 0;
+        Ieee80211HtOperation sparseOperation;
+        sparseOperation.operatingChannelWidth = MHz(20);
+        sparseOperation.basicMcsSupported[0] = true;
+        staMib->setPeerHtCapabilities(address, sparsePeer, sparseOperation);
+        const auto *dcfSparseMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+        const auto *qosSparseMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+        ASSERT(dcfSparseMode == qosSparseMode);
+        ASSERT(dcfSparseMode->getHtMcsIndex() == 0);
+        ASSERT(dcfSparseMode->getDataMode()->getBandwidth() == MHz(20));
+
         // The invalid/absent negotiated state is a legacy-only unicast
         // condition, while group-addressed traffic keeps its existing HT
         // selection policy.

--- a/tests/module/Ieee80211MgmtStaLifecycle_1.test
+++ b/tests/module/Ieee80211MgmtStaLifecycle_1.test
@@ -1,0 +1,361 @@
+%description:
+Verify that detailed station management tears down production-reachable scan,
+authentication, association, reassociation, beacon, and negotiated peer HT
+state on shutdown and crash. The node remains down past every pending timer
+deadline and restarts without resurrecting the interrupted state.
+
+%file: TestIeee80211MgmtStaLifecycle.cc
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    static MacAddress getCurrentAccessPointAddress()
+    {
+        return MacAddress("02:00:00:00:00:01");
+    }
+
+    static MacAddress getTargetAccessPointAddress()
+    {
+        return MacAddress("02:00:00:00:00:02");
+    }
+
+    ApInfo *addAccessPoint(const MacAddress& address, bool authenticated)
+    {
+        ASSERT(lookupAP(address) == nullptr);
+        apList.push_back(ApInfo());
+        auto ap = &apList.back();
+        ap->channel = 6;
+        ap->address = address;
+        ap->ssid = "lifecycle-ssid";
+        ap->beaconInterval = SimTime(100, SIMTIME_US);
+        ap->isAuthenticated = authenticated;
+        return ap;
+    }
+
+    void assertCleanEntryState()
+    {
+        ASSERT(!isScanning);
+        ASSERT(scanTimer == nullptr);
+        ASSERT(apList.empty());
+        ASSERT(assocTimeoutMsg == nullptr);
+        ASSERT(!reassociationInProgress);
+        ASSERT(!mib->bssStationData.isAssociated);
+        ASSERT(assocAP.address.isUnspecified());
+        ASSERT(assocAP.beaconTimeoutMsg == nullptr);
+    }
+
+  public:
+    void startActiveScanPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startActiveScanPhase");
+        assertCleanEntryState();
+
+        Ieee80211Prim_ScanRequest request;
+        request.setBSSType(BSSTYPE_INFRASTRUCTURE);
+        request.setActiveScan(true);
+        request.setProbeDelay(timerDelay);
+        request.setMinChannelTime(timerDelay);
+        request.setMaxChannelTime(timerDelay);
+        request.setChannelListArraySize(1);
+        request.setChannelList(0, 6);
+        processScanCommand(&request);
+    }
+
+    void startAuthenticationPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startAuthenticationPhase");
+        assertCleanEntryState();
+        startAuthentication(addAccessPoint(getTargetAccessPointAddress(), false), timerDelay);
+    }
+
+    void startAssociationPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startAssociationPhase");
+        assertCleanEntryState();
+        startAssociation(addAccessPoint(getTargetAccessPointAddress(), true), timerDelay);
+    }
+
+    void startReassociationPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startReassociationPhase");
+        assertCleanEntryState();
+        ASSERT(mib->isHtOperationSupported());
+
+        const auto currentAddress = getCurrentAccessPointAddress();
+        auto targetAp = addAccessPoint(getTargetAccessPointAddress(), true);
+
+        // This is the coherent state produced by a successful Association
+        // Response: an associated AP, negotiated peer HT state, and beacon
+        // timeout. startReassociation() then enters the real pending path.
+        mib->bssData.ssid = "lifecycle-ssid";
+        mib->bssData.bssid = currentAddress;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.channel = 6;
+        assocAP.address = currentAddress;
+        assocAP.ssid = "lifecycle-ssid";
+        assocAP.beaconInterval = SimTime(100, SIMTIME_US);
+        assocAP.isAuthenticated = true;
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 6);
+        scheduleAfter(timerDelay, assocAP.beaconTimeoutMsg);
+
+        Ieee80211HtOperation operation;
+        operation.primaryChannel = 6;
+        operation.basicMcsSupported[0] = true;
+        mib->setPeerHtCapabilities(currentAddress, mib->localHtCapabilities, operation);
+        startReassociation(targetAp, timerDelay);
+    }
+
+    bool hasScanTimer() const { return scanTimer != nullptr; }
+    bool isActiveScanSubscribed() const { return host != nullptr && host->isSubscribed(physicallayer::IRadio::receptionStateChangedSignal, const_cast<TestIeee80211MgmtSta *>(this)); }
+    bool hasPendingAuthentication() const
+    {
+        for (const auto& ap : apList)
+            if (ap.authTimeoutMsg != nullptr)
+                return true;
+        return false;
+    }
+    bool hasPendingAssociation() const { return assocTimeoutMsg != nullptr; }
+    bool hasBeaconTimer() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    bool hasCurrentPeerHtState() const { return mib->findPeerHtState(getCurrentAccessPointAddress()) != nullptr; }
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    bool isReassociationPending() const { return reassociationInProgress; }
+    bool isScanningNow() const { return isScanning; }
+    bool isApListEmpty() const { return apList.empty(); }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+    const std::string& getCachedSsid() const { return mib->bssData.ssid; }
+    MacAddress getCachedBssid() const { return mib->bssData.bssid; }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class TestIeee80211AgentSta : public Ieee80211AgentSta
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        SimpleModule::initialize(stage);
+    }
+
+    virtual void handleMessage(cMessage *message) override
+    {
+        delete message;
+    }
+};
+
+Define_Module(TestIeee80211AgentSta);
+
+class Ieee80211MgmtStaLifecycleTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211MgmtSta *mgmt = nullptr;
+
+  public:
+    Ieee80211MgmtStaLifecycleTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+    }
+
+    virtual void activity() override
+    {
+        const auto timerDelay = SimTime(5, SIMTIME_US);
+        const auto downCheckDelay = SimTime(6, SIMTIME_US);
+        const auto restartOffset = SimTime(4500, SIMTIME_NS);
+        const auto nextDownCheckDelay = SimTime(5500, SIMTIME_NS);
+
+        mgmt->startActiveScanPhase(timerDelay);
+        ASSERT(mgmt->isScanningNow());
+        ASSERT(mgmt->hasScanTimer());
+        ASSERT(mgmt->isActiveScanSubscribed());
+        std::cout << "Detailed STA active scan entered through processScanCommand.\n";
+
+        wait(downCheckDelay); // shutdown at 1 us; old timer deadline at 5 us
+        checkClearedState(false, "active scan shutdown");
+        wait(restartOffset); // startup at 10 us
+        checkClearedState(false, "active scan restart");
+
+        mgmt->startAuthenticationPhase(timerDelay);
+        ASSERT(mgmt->hasPendingAuthentication());
+        ASSERT(!mgmt->isAssociated());
+        std::cout << "Detailed STA authentication entered through startAuthentication.\n";
+
+        wait(nextDownCheckDelay); // crash at 11.5 us; old deadline at 15.5 us
+        checkClearedState(false, "authentication crash");
+        wait(restartOffset); // startup at 20 us
+        checkClearedState(false, "authentication restart");
+
+        mgmt->startAssociationPhase(timerDelay);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAssociated());
+        std::cout << "Detailed STA association entered through startAssociation.\n";
+
+        wait(nextDownCheckDelay); // shutdown at 21.5 us; old deadline at 25.5 us
+        checkClearedState(false, "association shutdown");
+        wait(restartOffset); // startup at 30 us
+        checkClearedState(false, "association restart");
+
+        mgmt->startReassociationPhase(timerDelay);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isReassociationPending());
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasCurrentPeerHtState());
+        std::cout << "Detailed STA reassociation entered through startReassociation.\n";
+
+        wait(nextDownCheckDelay); // crash at 31.5 us; old deadlines at 35.5 us
+        checkClearedState(true, "reassociation crash");
+        wait(restartOffset); // startup at 40 us
+        checkClearedState(true, "reassociation restart");
+
+        std::cout << "Detailed STA reachable lifecycle teardown and restart cleanliness verified.\n";
+    }
+
+    void checkClearedState(bool expectCachedAssociation, const char *phase)
+    {
+        ASSERT(!mgmt->isScanningNow());
+        ASSERT(!mgmt->hasScanTimer());
+        ASSERT(!mgmt->isActiveScanSubscribed());
+        ASSERT(!mgmt->hasPendingAuthentication());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasBeaconTimer());
+        ASSERT(!mgmt->hasCurrentPeerHtState());
+        ASSERT(mgmt->isApListEmpty());
+        if (expectCachedAssociation) {
+            ASSERT(mgmt->getCachedSsid() == "lifecycle-ssid");
+            ASSERT(mgmt->getCachedBssid() == MacAddress("02:00:00:00:00:01"));
+        }
+        std::cout << "Detailed STA state cleared after " << phase << ".\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaLifecycleTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.common.scenario.ScenarioManager;
+import inet.linklayer.ieee80211.mgmt.Ieee80211AgentSta;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple TestIeee80211AgentSta extends Ieee80211AgentSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211AgentSta);
+}
+
+simple Ieee80211MgmtStaLifecycleTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaLifecycleTest);
+}
+
+network Ieee80211MgmtStaLifecycleTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        scenarioManager: ScenarioManager;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+                wlan[*].agent.typename = "TestIeee80211AgentSta";
+        }
+        test: Ieee80211MgmtStaLifecycleTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaLifecycleTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 45us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+*.sta.wlan[0].radio.channelNumber = 6
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+**.hasStatus = true
+**.scenarioManager.script = xmldoc("scenario.xml")
+
+%file: scenario.xml
+
+<scenario>
+    <at t="1us">
+        <shutdown module="sta"/>
+    </at>
+    <at t="10us">
+        <startup module="sta"/>
+    </at>
+    <at t="11500ns">
+        <crash module="sta"/>
+    </at>
+    <at t="20us">
+        <startup module="sta"/>
+    </at>
+    <at t="21500ns">
+        <shutdown module="sta"/>
+    </at>
+    <at t="30us">
+        <startup module="sta"/>
+    </at>
+    <at t="31500ns">
+        <crash module="sta"/>
+    </at>
+    <at t="40us">
+        <startup module="sta"/>
+    </at>
+</scenario>
+
+%contains: stdout
+Detailed STA active scan entered through processScanCommand.
+
+%contains: stdout
+Detailed STA authentication entered through startAuthentication.
+
+%contains: stdout
+Detailed STA association entered through startAssociation.
+
+%contains: stdout
+Detailed STA reassociation entered through startReassociation.
+
+%contains: stdout
+Detailed STA reachable lifecycle teardown and restart cleanliness verified.

--- a/tests/module/Ieee80211MgmtStaSimplifiedInitialization_1.test
+++ b/tests/module/Ieee80211MgmtStaSimplifiedInitialization_1.test
@@ -38,6 +38,8 @@ class TestInitializationObserver : public cSimpleModule
             auto staMib = check_and_cast<ieee80211::Ieee80211Mib *>(staInterface->getSubmodule("mib"));
 
             ASSERT(staInterface->getSubmodule("agent") == nullptr);
+            ASSERT(apMib->hasPrimaryChannel());
+            ASSERT(apMib->requirePrimaryChannel() == 6);
             if (stage == INITSTAGE_NETWORK_CONFIGURATION) {
                 ASSERT(apMib->bssData.ssid == "review-ssid");
                 ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
@@ -52,6 +54,8 @@ class TestInitializationObserver : public cSimpleModule
             else {
                 ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
                 ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+                ASSERT(apMib->findPeerHtState(staMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);
+                ASSERT(staMib->findPeerHtState(apMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);
                 std::cout << "Simplified STA HT peer state installed at last initialization stage.\n";
                 scheduleAt(SimTime(1500, SIMTIME_NS), new cMessage("checkShutdown"));
                 scheduleAt(SimTime(2500, SIMTIME_NS), new cMessage("checkShutdownRestart"));
@@ -180,6 +184,7 @@ record-scalar-results = false
 *.ap.wlan[0].address = "02:00:00:00:00:01"
 *.sta.wlan[0].address = "auto"
 *.ap.wlan[0].mgmt.ssid = "review-ssid"
+*.ap.wlan[0].radio.channelNumber = 6
 *.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
 **.wlan[0].opMode = "n(mixed-2.4Ghz)"
 **.hasStatus = true

--- a/tests/module/Ieee80211MgmtStaSimplifiedInitialization_1.test
+++ b/tests/module/Ieee80211MgmtStaSimplifiedInitialization_1.test
@@ -1,0 +1,240 @@
+%description:
+Verify simplified station BSS identity is visible to automatic network
+configuration while negotiated HT peer state is installed only at the last
+initialization stage. Verify shutdown removes the AP-side association and HT
+peer state and startup restores both. Verify crash performs the same cleanup,
+and remains safe when the recorded AP can no longer be resolved.
+
+%file: TestInitializationObserver.cc
+
+#include "inet/common/InitStages.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/networklayer/common/L3AddressResolver.h"
+#include "inet/networklayer/common/NetworkInterface.h"
+#include "inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h"
+
+namespace inet {
+
+class TestIpv4NetworkConfigurator : public Ipv4NetworkConfigurator
+{
+  public:
+    std::string getTestWirelessId(NetworkInterface *networkInterface) { return getWirelessId(networkInterface); }
+};
+
+Define_Module(TestIpv4NetworkConfigurator);
+
+class TestInitializationObserver : public cSimpleModule
+{
+  protected:
+    virtual int numInitStages() const override { return NUM_INIT_STAGES; }
+
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_NETWORK_CONFIGURATION || stage == INITSTAGE_LAST) {
+            auto configurator = check_and_cast<TestIpv4NetworkConfigurator *>(getModuleByPath("^.configurator"));
+            auto apInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.ap.wlan[0]"));
+            auto staInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.sta.wlan[0]"));
+            auto apMib = check_and_cast<ieee80211::Ieee80211Mib *>(apInterface->getSubmodule("mib"));
+            auto staMib = check_and_cast<ieee80211::Ieee80211Mib *>(staInterface->getSubmodule("mib"));
+
+            ASSERT(staInterface->getSubmodule("agent") == nullptr);
+            if (stage == INITSTAGE_NETWORK_CONFIGURATION) {
+                ASSERT(apMib->bssData.ssid == "review-ssid");
+                ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
+                ASSERT(configurator->getTestWirelessId(apInterface) == configurator->getTestWirelessId(staInterface));
+                ASSERT(!staMib->address.isUnspecified());
+                ASSERT(apMib->bssAccessPointData.stations.find(MacAddress::UNSPECIFIED_ADDRESS) == apMib->bssAccessPointData.stations.end());
+                ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+                ASSERT(apMib->findPeerHtState(staMib->address) == nullptr);
+                ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+                std::cout << "Simplified STA wireless identity available during network configuration.\n";
+            }
+            else {
+                ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+                ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+                std::cout << "Simplified STA HT peer state installed at last initialization stage.\n";
+                scheduleAt(SimTime(1500, SIMTIME_NS), new cMessage("checkShutdown"));
+                scheduleAt(SimTime(2500, SIMTIME_NS), new cMessage("checkShutdownRestart"));
+                scheduleAt(SimTime(3500, SIMTIME_NS), new cMessage("checkResolvableCrash"));
+                scheduleAt(SimTime(4500, SIMTIME_NS), new cMessage("checkCrashRestart"));
+                scheduleAt(SimTime(5500, SIMTIME_NS), new cMessage("prepareMissingApCrash"));
+                scheduleAt(SimTime(6500, SIMTIME_NS), new cMessage("checkMissingApCrash"));
+            }
+        }
+    }
+
+    virtual void handleMessage(cMessage *message) override
+    {
+        auto apInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.ap.wlan[0]"));
+        auto staInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.sta.wlan[0]"));
+        auto apMib = check_and_cast<ieee80211::Ieee80211Mib *>(apInterface->getSubmodule("mib"));
+        auto staMib = check_and_cast<ieee80211::Ieee80211Mib *>(staInterface->getSubmodule("mib"));
+        if (!strcmp(message->getName(), "checkShutdown")) {
+            ASSERT(!staMib->bssStationData.isAssociated);
+            ASSERT(apMib->bssAccessPointData.stations.find(staMib->address) == apMib->bssAccessPointData.stations.end());
+            ASSERT(apMib->findPeerHtState(staMib->address) == nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+            std::cout << "Simplified STA AP-side association and HT peer state removed after shutdown.\n";
+        }
+        else if (!strcmp(message->getName(), "checkShutdownRestart")) {
+            ASSERT(staMib->bssStationData.isAssociated);
+            ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+            std::cout << "Simplified STA association and HT peer state restored after shutdown restart.\n";
+        }
+        else if (!strcmp(message->getName(), "checkResolvableCrash")) {
+            ASSERT(!staMib->bssStationData.isAssociated);
+            ASSERT(apMib->bssAccessPointData.stations.find(staMib->address) == apMib->bssAccessPointData.stations.end());
+            ASSERT(apMib->findPeerHtState(staMib->address) == nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+            std::cout << "Simplified STA AP-side association and HT peer state removed after resolvable crash.\n";
+        }
+        else if (!strcmp(message->getName(), "checkCrashRestart")) {
+            ASSERT(staMib->bssStationData.isAssociated);
+            ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+            std::cout << "Simplified STA association and HT peer state restored after crash restart.\n";
+        }
+        else if (!strcmp(message->getName(), "prepareMissingApCrash")) {
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+            staMib->bssData.bssid = MacAddress("02:00:00:00:00:ff");
+            ASSERT(staMib->bssData.bssid != apMib->address);
+            ASSERT(L3AddressResolver().findHostWithAddress(staMib->bssData.bssid) == nullptr);
+            std::cout << "Simplified STA recorded BSSID made unresolvable before crash.\n";
+        }
+        else if (!strcmp(message->getName(), "checkMissingApCrash")) {
+            ASSERT(!staMib->bssStationData.isAssociated);
+            ASSERT(staMib->bssData.bssid == MacAddress("02:00:00:00:00:ff"));
+            ASSERT(L3AddressResolver().findHostWithAddress(staMib->bssData.bssid) == nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            std::cout << "Simplified STA crash tolerated missing AP lookup and cleared local HT peer state.\n";
+        }
+        else
+            ASSERT(false);
+        delete message;
+    }
+};
+
+Define_Module(TestInitializationObserver);
+
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.common.scenario.ScenarioManager;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIpv4NetworkConfigurator extends Ipv4NetworkConfigurator
+{
+    parameters:
+        @class(::inet::TestIpv4NetworkConfigurator);
+}
+
+simple TestInitializationObserver extends SimpleModule
+{
+    parameters:
+        @class(::inet::TestInitializationObserver);
+}
+
+network Ieee80211MgmtStaSimplifiedInitializationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        configurator: TestIpv4NetworkConfigurator;
+        scenarioManager: ScenarioManager;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtStaSimplified";
+                wlan[*].agent.typename = "";
+        }
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtApSimplified";
+                wlan[*].agent.typename = "";
+        }
+        observer: TestInitializationObserver;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaSimplifiedInitializationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 7us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "auto"
+*.ap.wlan[0].mgmt.ssid = "review-ssid"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+**.wlan[0].opMode = "n(mixed-2.4Ghz)"
+**.hasStatus = true
+**.scenarioManager.script = xmldoc("scenario.xml")
+**.wlan[0].bitrate = 65Mbps
+**.wlan[0].radio.bandName = "2.4 GHz"
+**.wlan[0].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%file: scenario.xml
+
+<scenario>
+    <at t="1us">
+        <shutdown module="sta"/>
+    </at>
+    <at t="2us">
+        <startup module="sta"/>
+    </at>
+    <at t="3us">
+        <crash module="sta"/>
+    </at>
+    <at t="4us">
+        <startup module="sta"/>
+    </at>
+    <at t="6us">
+        <crash module="sta"/>
+    </at>
+</scenario>
+
+%contains: stdout
+Simplified STA wireless identity available during network configuration.
+
+%contains: stdout
+Simplified STA HT peer state installed at last initialization stage.
+
+%contains: stdout
+Simplified STA AP-side association and HT peer state removed after shutdown.
+
+%contains: stdout
+Simplified STA association and HT peer state restored after shutdown restart.
+
+%contains: stdout
+Simplified STA AP-side association and HT peer state removed after resolvable crash.
+
+%contains: stdout
+Simplified STA association and HT peer state restored after crash restart.
+
+%contains: stdout
+Simplified STA recorded BSSID made unresolvable before crash.
+
+%contains: stdout
+Simplified STA crash tolerated missing AP lookup and cleared local HT peer state.

--- a/tests/module/Ieee80211PacketDomainTagBoundary_1.test
+++ b/tests/module/Ieee80211PacketDomainTagBoundary_1.test
@@ -1,0 +1,196 @@
+%description:
+Verify that a packet-domain IEEE 802.11 OFDM receiver removes sender-local
+packet tags while retaining the protocol and receiver indication tags required
+by the upper layers.
+
+%file: TestIeee80211PacketDomainTagBoundary.cc
+
+#include "inet/applications/base/ApplicationPacket_m.h"
+#include "inet/applications/udpapp/UdpBasicApp.h"
+#include "inet/applications/udpapp/UdpSink.h"
+#include "inet/common/ProtocolTag_m.h"
+#include "inet/common/Simsignals.h"
+#include "inet/common/TimeTag_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+class TaggedUdpBasicApp : public UdpBasicApp
+{
+  protected:
+    virtual void sendPacket() override
+    {
+        std::ostringstream str;
+        str << packetName << "-" << numSent;
+        auto packet = new Packet(str.str().c_str());
+        const auto& payload = makeShared<ApplicationPacket>();
+        payload->setChunkLength(B(par("messageLength")));
+        payload->setSequenceNumber(numSent);
+        payload->addTag<CreationTimeTag>()->setCreationTime(simTime());
+        packet->insertAtBack(payload);
+        packet->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(0x1234);
+        L3Address destAddr = chooseDestAddr();
+        emit(packetSentSignal, packet);
+        socket.sendTo(packet, destAddr, destPort);
+        numSent++;
+    }
+};
+
+Define_Module(TaggedUdpBasicApp);
+
+class CheckingUdpSink : public UdpSink
+{
+  protected:
+    virtual void processPacket(Packet *packet) override
+    {
+        ASSERT(packet->findTag<Ieee80211MgmtTransactionTag>() == nullptr);
+        UdpSink::processPacket(packet);
+    }
+};
+
+Define_Module(CheckingUdpSink);
+
+class Ieee80211PacketDomainTagBoundaryTest : public cSimpleModule, public cListener
+{
+  public:
+    Ieee80211PacketDomainTagBoundaryTest() : cSimpleModule(65536) {}
+
+  protected:
+    cModule *sourceRadio = nullptr;
+    cModule *destinationRadio = nullptr;
+    int sourcePacketsWithTransactionTag = 0;
+    int destinationPackets = 0;
+
+    virtual void initialize() override
+    {
+        sourceRadio = getModuleByPath("^.sourceHost.wlan[0].radio");
+        destinationRadio = getModuleByPath("^.destinationHost.wlan[0].radio");
+        sourceRadio->subscribe(packetReceivedFromUpperSignal, this);
+        destinationRadio->subscribe(packetSentToUpperSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        auto packet = check_and_cast<Packet *>(value);
+        if (source == sourceRadio && signalID == packetReceivedFromUpperSignal) {
+            if (packet->findTag<Ieee80211MgmtTransactionTag>() != nullptr)
+                sourcePacketsWithTransactionTag++;
+        }
+        else if (source == destinationRadio && signalID == packetSentToUpperSignal) {
+            ASSERT(packet->findTag<Ieee80211MgmtTransactionTag>() == nullptr);
+            ASSERT(packet->findTag<PacketProtocolTag>() != nullptr);
+            ASSERT(packet->findTag<SnirInd>() != nullptr);
+            ASSERT(packet->findTag<ErrorRateInd>() != nullptr);
+            ASSERT(packet->findTag<physicallayer::Ieee80211ModeInd>() != nullptr);
+            ASSERT(packet->findTag<physicallayer::Ieee80211ChannelInd>() != nullptr);
+            destinationPackets++;
+        }
+    }
+
+    virtual void activity() override
+    {
+        wait(SimTime(100, SIMTIME_MS));
+        ASSERT(sourcePacketsWithTransactionTag > 0);
+        ASSERT(destinationPackets > 0);
+        std::cout << "Packet-domain receiver tag boundary verified.\n";
+    }
+};
+
+Define_Module(Ieee80211PacketDomainTagBoundaryTest);
+
+%file: test.ned
+
+import inet.applications.udpapp.UdpBasicApp;
+import inet.applications.udpapp.UdpSink;
+import inet.common.SimpleModule;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.AdhocHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211DimensionalRadioMedium;
+
+simple TaggedUdpBasicApp extends UdpBasicApp
+{
+    parameters:
+        @class(::TaggedUdpBasicApp);
+}
+
+simple CheckingUdpSink extends UdpSink
+{
+    parameters:
+        @class(::CheckingUdpSink);
+}
+
+simple Ieee80211PacketDomainTagBoundaryTest extends SimpleModule
+{
+    parameters:
+        @class(::Ieee80211PacketDomainTagBoundaryTest);
+}
+
+network Ieee80211PacketDomainTagBoundaryTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211DimensionalRadioMedium;
+        configurator: Ipv4NetworkConfigurator;
+        sourceHost: AdhocHost;
+        destinationHost: AdhocHost;
+        test: Ieee80211PacketDomainTagBoundaryTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211PacketDomainTagBoundaryTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 200ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+**.arp.typename = "GlobalArp"
+**.checksumMode = "computed"
+**.fcsMode = "computed"
+**.mobility.initFromDisplayString = false
+**.mobility.typename = "StationaryMobility"
+*.sourceHost.mobility.initialX = 0m
+*.sourceHost.mobility.initialY = 0m
+*.destinationHost.mobility.initialX = 100m
+*.destinationHost.mobility.initialY = 0m
+**.constraintAreaMinX = 0m
+**.constraintAreaMinY = 0m
+**.constraintAreaMinZ = 0m
+**.constraintAreaMaxX = 200m
+**.constraintAreaMaxY = 100m
+**.constraintAreaMaxZ = 0m
+
+*.sourceHost.numApps = 1
+*.sourceHost.app[0].typename = "TaggedUdpBasicApp"
+*.sourceHost.app[0].destAddresses = "destinationHost"
+*.sourceHost.app[0].destPort = 5000
+*.sourceHost.app[0].messageLength = 100B
+*.sourceHost.app[0].sendInterval = 1s
+*.sourceHost.app[0].startTime = 10ms
+
+*.destinationHost.numApps = 1
+*.destinationHost.app[0].typename = "CheckingUdpSink"
+*.destinationHost.app[0].localPort = 5000
+
+*.sourceHost.wlan[*].typename = "Ieee80211Interface"
+*.destinationHost.wlan[*].typename = "Ieee80211Interface"
+**.wlan[*].radio.typename = "Ieee80211OfdmRadio"
+**.wlan[*].radio.transmitter.power = 0.1mW
+**.wlan[*].radio.receiver.sensitivity = -109dBm
+**.wlan[*].radio.receiver.snirThreshold = 0.1dB
+**.wlan[*].radio.receiver.energyDetection = -90dBm
+**.wlan[*].radio.bandwidth = 20MHz
+**.wlan[*].radio.centerFrequency = 2.412GHz
+**.wlan[*].radio.receiver.channelSpacing = 5MHz
+**.wlan[*].radio.receiver.levelOfDetail = "packet"
+**.wlan[*].radio.receiver.errorModel.snirOffset = -2dB
+**.wlan[*].bitrate = 6Mbps
+**.wlan[*].mac.**.responseAckFrameBitrate = 6Mbps
+**.wlan[*].mac.**.*Retry* = 0
+
+%contains: stdout
+Packet-domain receiver tag boundary verified.

--- a/tests/queueing/PacketQueueDropCallback_1.test
+++ b/tests/queueing/PacketQueueDropCallback_1.test
@@ -1,0 +1,94 @@
+%description:
+Verify that a PacketQueue using an external PacketBuffer reports one typed
+drop callback while the evicted packet is still valid, before the buffer
+deletes it.
+
+%file: TestPacketQueueDropCallback.cc
+
+#include <string>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/queueing/buffer/PacketBuffer.h"
+#include "inet/queueing/contract/IPacketQueue.h"
+#include "inet/queueing/queue/PacketQueue.h"
+
+namespace inet {
+namespace queueing {
+
+class TestPacketQueueDropCallback : public cSimpleModule, public IPacketQueue::ICallback
+{
+  public:
+    TestPacketQueueDropCallback() : cSimpleModule(65536) {}
+
+  protected:
+    int notificationCount = 0;
+    std::string lastPacketName;
+    bool packetWasOwned = false;
+
+    virtual void handlePacketDropped(Packet *packet) override
+    {
+        notificationCount++;
+        lastPacketName = packet->getName();
+        packetWasOwned = packet->getOwner() != nullptr;
+    }
+
+    virtual void activity() override
+    {
+        auto queue = check_and_cast<PacketQueue *>(getModuleByPath("^.queue"));
+        auto buffer = check_and_cast<PacketBuffer *>(getModuleByPath("^.buffer"));
+        queue->setPacketDropCallback(this);
+        ASSERT(queue->getMaxNumPackets() == -1);
+        ASSERT(buffer->getMaxNumPackets() == 0);
+
+        auto packet = new Packet("external-buffer-packet");
+        queue->enqueuePacket(packet);
+
+        ASSERT(notificationCount == 1);
+        ASSERT(lastPacketName == "external-buffer-packet");
+        ASSERT(packetWasOwned);
+        ASSERT(queue->isEmpty());
+        ASSERT(buffer->isEmpty());
+        std::cout << "External PacketBuffer eviction notified the queue callback exactly once before deletion.\n";
+    }
+};
+
+Define_Module(TestPacketQueueDropCallback);
+
+} // namespace queueing
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.queueing.buffer.PacketBuffer;
+import inet.queueing.queue.PacketQueue;
+
+simple TestPacketQueueDropCallback extends SimpleModule
+{
+    parameters:
+        @class(::inet::queueing::TestPacketQueueDropCallback);
+}
+
+network PacketQueueDropCallbackTestNetwork
+{
+    submodules:
+        buffer: PacketBuffer;
+        queue: PacketQueue;
+        test: TestPacketQueueDropCallback;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = PacketQueueDropCallbackTestNetwork
+sim-time-limit = 1us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.queue.bufferModule = "^.buffer"
+*.buffer.packetCapacity = 0
+*.buffer.dropperClass = "inet::queueing::PacketAtCollectionEndDropper"
+
+%contains: stdout
+External PacketBuffer eviction notified the queue callback exactly once before deletion.

--- a/tests/unit/Ieee80211HtCapabilities_1.test
+++ b/tests/unit/Ieee80211HtCapabilities_1.test
@@ -1,8 +1,9 @@
 %description:
-Verify directional HT negotiation, sparse MCS bitmaps, and HT operation
-compatibility for undefined or unequal Tx MCS advertisements.
+Verify directional HT negotiation and association-response classification,
+including acceptance of a genuinely legacy AP.
 
 %includes:
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/linklayer/ieee80211/mib/Ieee80211HtCapabilities.h"
 
 using namespace inet;
@@ -67,18 +68,42 @@ ASSERT(!supportsBasicHtMcsSet(peer, operation));
 peer.rxMcsSupported[1] = true;
 ASSERT(supportsBasicHtMcsSet(peer, operation));
 
-// An unequal Tx/Rx advertisement carries only summary Tx fields, so the exact
-// Tx bitmap is unknown while the peer remains eligible for association.
-peer.txMcsSetDefined = true;
-peer.txRxMcsSetNotEqual = true;
-peer.txMaxNss = 2;
-peer.txMcsNss = Ieee80211HtMcsNssMap();
-negotiated = negotiateHtCapabilities(local, peer, operation);
-ASSERT(negotiated.localRxPeerTx.valid);
-ASSERT(!negotiated.localRxPeerTx.supportedMcs[0]);
-ASSERT(negotiated.localTxPeerRx.supportedMcs[0]);
+Ieee80211HtCapabilities rxOnly;
+rxOnly.supportedChannelWidths.insert(MHz(20));
+rxOnly.rxMcsSupported[0] = true;
+rxOnly.txMcsSetDefined = false;
+auto rxOnlyElement = makeHtCapabilitiesElement(rxOnly);
+ASSERT(!rxOnlyElement.txMcsSetDefined);
+ASSERT(!rxOnlyElement.txRxMcsSetNotEqual);
+ASSERT(rxOnlyElement.txMaxNss == 0);
 
-EV << "HT directional and sparse capability checks passed.\n";
+// Table 9-226 does not carry an exact Tx bitmap for unequal Tx/Rx sets.
+for (bool unequalModulation : {false, true}) {
+    Ieee80211HtCapabilitiesElement unequalElement;
+    unequalElement.supportedChannelWidth40Mhz = true;
+    unequalElement.rxMcsSupported[0] = true;
+    unequalElement.rxMcsSupported[7] = true;
+    unequalElement.rxMcsSupported[8] = true;
+    unequalElement.txMcsSetDefined = true;
+    unequalElement.txRxMcsSetNotEqual = true;
+    unequalElement.txMaxNss = 2;
+    unequalElement.txUnequalModulation = unequalModulation;
+    auto unequal = makeHtCapabilities(unequalElement);
+    ASSERT(unequal.txRxMcsSetNotEqual);
+    ASSERT(unequal.txMaxNss == 2);
+    ASSERT(unequal.txUnequalModulation == unequalModulation);
+    ASSERT(unequal.txMcsNss.maxMcsPerNss[0] == -1);
+    ASSERT(unequal.txMcsNss.maxMcsPerNss[1] == -1);
+    auto unequalRoundTrip = makeHtCapabilitiesElement(unequal);
+    ASSERT(unequalRoundTrip.txRxMcsSetNotEqual);
+    ASSERT(unequalRoundTrip.txMaxNss == 2);
+    ASSERT(unequalRoundTrip.txUnequalModulation == unequalModulation);
+    auto unequalNegotiated = negotiateHtCapabilities(local, unequal, operation);
+    ASSERT(unequalNegotiated.localRxPeerTx.valid);
+    ASSERT(!unequalNegotiated.localRxPeerTx.supportedMcs[0]);
+}
+
+EV << "HT directional and legacy association checks passed.\n";
 
 %contains: stdout
-HT directional and sparse capability checks passed.
+HT directional and legacy association checks passed.

--- a/tests/unit/Ieee80211HtCapabilities_1.test
+++ b/tests/unit/Ieee80211HtCapabilities_1.test
@@ -1,0 +1,84 @@
+%description:
+Verify directional HT negotiation, sparse MCS bitmaps, and HT operation
+compatibility for undefined or unequal Tx MCS advertisements.
+
+%includes:
+#include "inet/linklayer/ieee80211/mib/Ieee80211HtCapabilities.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+using namespace inet::units::values;
+
+%activity:
+
+Ieee80211HtCapabilities local;
+local.supportedChannelWidths.insert(MHz(20));
+local.rxMcsSupported[0] = true;
+local.rxMcsSupported[1] = true;
+local.rxMcsSupported[2] = true;
+local.rxMcsSupported[3] = true;
+local.txMcsNss.maxMcsPerNss[0] = 3;
+local.ldpc = true;
+local.shortGi20 = true;
+local.maxAmpduLengthExponent = 1;
+
+Ieee80211HtCapabilities peer;
+peer.supportedChannelWidths.insert(MHz(20));
+peer.rxMcsSupported[0] = true;
+peer.rxMcsSupported[2] = true;
+peer.rxMcsSupported[3] = true;
+peer.txMcsNss.maxMcsPerNss[0] = 3;
+peer.maxAmpduLengthExponent = 3;
+
+Ieee80211HtOperation operation;
+operation.operatingChannelWidth = MHz(20);
+operation.basicMcsSupported[0] = true;
+
+auto negotiated = negotiateHtCapabilities(local, peer, operation);
+ASSERT(negotiated.localTxPeerRx.valid);
+ASSERT(negotiated.localRxPeerTx.valid);
+ASSERT(negotiated.localTxPeerRx.supportedMcs[0]);
+ASSERT(!negotiated.localTxPeerRx.supportedMcs[1]);
+ASSERT(negotiated.localTxPeerRx.supportedMcs[2]);
+ASSERT(negotiated.localTxPeerRx.supportedMcs[3]);
+ASSERT(negotiated.localRxPeerTx.supportedMcs[0]);
+ASSERT(!negotiated.localRxPeerTx.supportedMcs[1]);
+ASSERT(negotiated.localRxPeerTx.supportedMcs[2]);
+ASSERT(!negotiated.localTxPeerRx.receiverLdpc);
+ASSERT(negotiated.localRxPeerTx.receiverLdpc);
+ASSERT(negotiated.localTxPeerRx.receiverMaxAmpduLengthExponent == 3);
+ASSERT(negotiated.localRxPeerTx.receiverMaxAmpduLengthExponent == 1);
+
+// A 20 MHz-only peer may join a 20/40 MHz BSS.
+local.supportedChannelWidths.insert(MHz(40));
+operation.operatingChannelWidth = MHz(40);
+negotiated = negotiateHtCapabilities(local, peer, operation);
+ASSERT(negotiated.localTxPeerRx.valid);
+ASSERT(negotiated.localTxPeerRx.supportedChannelWidths.count(MHz(20)) == 1);
+
+// Table 9-226 permits an undefined Tx MCS set; unknown is not "cannot transmit".
+peer.txMcsSetDefined = false;
+peer.txMcsNss = Ieee80211HtMcsNssMap();
+negotiated = negotiateHtCapabilities(local, peer, operation);
+ASSERT(negotiated.localRxPeerTx.valid);
+
+operation.basicMcsSupported[1] = true;
+ASSERT(!supportsBasicHtMcsSet(peer, operation));
+peer.rxMcsSupported[1] = true;
+ASSERT(supportsBasicHtMcsSet(peer, operation));
+
+// An unequal Tx/Rx advertisement carries only summary Tx fields, so the exact
+// Tx bitmap is unknown while the peer remains eligible for association.
+peer.txMcsSetDefined = true;
+peer.txRxMcsSetNotEqual = true;
+peer.txMaxNss = 2;
+peer.txMcsNss = Ieee80211HtMcsNssMap();
+negotiated = negotiateHtCapabilities(local, peer, operation);
+ASSERT(negotiated.localRxPeerTx.valid);
+ASSERT(!negotiated.localRxPeerTx.supportedMcs[0]);
+ASSERT(negotiated.localTxPeerRx.supportedMcs[0]);
+
+EV << "HT directional and sparse capability checks passed.\n";
+
+%contains: stdout
+HT directional and sparse capability checks passed.

--- a/tests/unit/Ieee80211HtMgmtElements_1.test
+++ b/tests/unit/Ieee80211HtMgmtElements_1.test
@@ -1,0 +1,268 @@
+%description:
+Verify byte-exact HT Capabilities and HT Operation management elements, including
+non-contiguous MCS bitmaps, typed deserialization, and malformed-length rejection.
+
+%includes:
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+static Ptr<Ieee80211AssociationResponseFrame> makeHtResponse()
+{
+    auto frame = makeShared<Ieee80211AssociationResponseFrame>();
+    frame->setStatusCode(SC_SUCCESSFUL);
+    frame->setAid(1);
+    Ieee80211SupportedRatesElement rates;
+    rates.numRates = 1;
+    rates.rate[0] = 6;
+    frame->setSupportedRates(rates);
+
+    Ieee80211HtCapabilitiesElement capabilities;
+    capabilities.ldpc = true;
+    capabilities.supportedChannelWidth40Mhz = true;
+    capabilities.greenfield = true;
+    capabilities.shortGi20 = true;
+    capabilities.shortGi40 = true;
+    capabilities.maxAmpduLengthExponent = 2;
+    capabilities.rxMcsSupported[0] = true;
+    capabilities.rxMcsSupported[2] = true;
+    capabilities.rxMcsSupported[7] = true;
+    capabilities.rxMcsSupported[15] = true;
+    capabilities.rxMcsSupported[76] = true;
+    capabilities.txMcsSetDefined = true;
+    frame->setHtCapabilitiesPresent(true);
+    frame->setHtCapabilities(capabilities);
+
+    Ieee80211HtOperationElement operation;
+    operation.primaryChannel = 36;
+    operation.secondaryChannelOffset = 1;
+    operation.staChannelWidth40Mhz = true;
+    operation.protectionMode = 2;
+    operation.basicMcsSupported[0] = true;
+    operation.basicMcsSupported[3] = true;
+    operation.basicMcsSupported[7] = true;
+    operation.basicMcsSupported[76] = true;
+    frame->setHtOperationPresent(true);
+    frame->setHtOperation(operation);
+
+    // Fixed fields/rates (9) + HT Capabilities IE (28) + HT Operation IE (24).
+    frame->setChunkLength(B(61));
+    return frame;
+}
+
+static std::vector<uint8_t> serializeResponse(const Ptr<const Ieee80211AssociationResponseFrame>& frame)
+{
+    Packet packet("ht-response", frame);
+    return packet.peekAllAsBytes()->getBytes();
+}
+
+%activity:
+
+auto original = makeHtResponse();
+auto bytes = serializeResponse(original);
+ASSERT(bytes.size() == 61);
+
+// IEEE Std 802.11-2024, 9.4.2.54: element ID 45 and fixed 26-octet body.
+ASSERT(bytes[9] == 45 && bytes[10] == 26);
+ASSERT(bytes[11] == 0x7f && bytes[12] == 0x00); // modeled flags plus SMPS=3 (disabled)
+ASSERT(bytes[13] == 0x02);
+ASSERT(bytes[14] == 0x85); // non-contiguous Rx MCS 0, 2, and 7
+ASSERT(bytes[15] == 0x80); // Rx MCS 15
+ASSERT(bytes[23] == 0x10); // Rx MCS 76
+ASSERT(bytes[26] == 0x01); // Tx MCS Set Defined (bit 96)
+
+// IEEE Std 802.11-2024, 9.4.2.55: element ID 61 and fixed 22-octet body.
+ASSERT(bytes[37] == 61 && bytes[38] == 22);
+ASSERT(bytes[39] == 36);
+ASSERT(bytes[40] == 0x05 && bytes[41] == 0x02);
+ASSERT(bytes[45] == 0x89); // non-contiguous Basic MCS 0, 3, and 7
+ASSERT(bytes[54] == 0x10); // Basic MCS 76
+
+Packet encoded("encoded", makeShared<BytesChunk>(bytes));
+auto decoded = encoded.popAtFront<Ieee80211AssociationResponseFrame>(B(bytes.size()));
+ASSERT(decoded->getChunkLength() == B(bytes.size()));
+ASSERT(decoded->getHtCapabilitiesPresent());
+ASSERT(decoded->getHtOperationPresent());
+ASSERT(decoded->getHtCapabilities().rxMcsSupported[0]);
+ASSERT(!decoded->getHtCapabilities().rxMcsSupported[1]);
+ASSERT(decoded->getHtCapabilities().rxMcsSupported[2]);
+ASSERT(decoded->getHtCapabilities().rxMcsSupported[76]);
+ASSERT(decoded->getHtOperation().basicMcsSupported[0]);
+ASSERT(!decoded->getHtOperation().basicMcsSupported[1]);
+ASSERT(decoded->getHtOperation().basicMcsSupported[3]);
+ASSERT(decoded->getHtOperation().basicMcsSupported[76]);
+
+// The caller supplies the exact management-body region. A legal vendor IE before
+// the HT elements is ignored by the field parser but retained by
+// FieldsChunkSerializer's raw-data cache, while bytes beyond the requested body
+// remain in the packet.
+auto vendorBytes = bytes;
+vendorBytes.insert(vendorBytes.begin() + 9, {221, 3, 0x01, 0x02, 0x03});
+auto framedBytes = vendorBytes;
+std::vector<uint8_t> trailerBytes = {0xde, 0xad, 0xbe, 0xef};
+framedBytes.insert(framedBytes.end(), trailerBytes.begin(), trailerBytes.end());
+Packet framed("framed", makeShared<BytesChunk>(framedBytes));
+auto vendorDecoded = framed.popAtFront<Ieee80211AssociationResponseFrame>(B(vendorBytes.size()));
+ASSERT(vendorDecoded->getChunkLength() == B(vendorBytes.size()));
+ASSERT(serializeResponse(vendorDecoded) == vendorBytes);
+ASSERT(framed.peekDataAsBytes()->getBytes() == trailerBytes);
+
+auto unequalResponse = makeHtResponse();
+auto unequalCapabilities = unequalResponse->getHtCapabilities();
+unequalCapabilities.txRxMcsSetNotEqual = true;
+unequalCapabilities.txMaxNss = 2;
+unequalCapabilities.txUnequalModulation = true;
+unequalResponse->setHtCapabilities(unequalCapabilities);
+auto unequalBytes = serializeResponse(unequalResponse);
+ASSERT(unequalBytes[26] == 0x17);
+Packet unequalEncoded("unequal-encoded", makeShared<BytesChunk>(unequalBytes));
+auto unequalDecoded = unequalEncoded.popAtFront<Ieee80211AssociationResponseFrame>(B(unequalBytes.size()));
+ASSERT(unequalDecoded->getHtCapabilities().txRxMcsSetNotEqual);
+ASSERT(unequalDecoded->getHtCapabilities().txMaxNss == 2);
+ASSERT(unequalDecoded->getHtCapabilities().txUnequalModulation);
+
+// Copy decoded fields into a fresh chunk so serialization cannot reuse cached bytes.
+auto reencoded = makeShared<Ieee80211AssociationResponseFrame>();
+reencoded->setStatusCode(decoded->getStatusCode());
+reencoded->setAid(decoded->getAid());
+reencoded->setSupportedRates(decoded->getSupportedRates());
+reencoded->setHtCapabilitiesPresent(decoded->getHtCapabilitiesPresent());
+reencoded->setHtCapabilities(decoded->getHtCapabilities());
+reencoded->setHtOperationPresent(decoded->getHtOperationPresent());
+reencoded->setHtOperation(decoded->getHtOperation());
+reencoded->setChunkLength(B(61));
+ASSERT(serializeResponse(reencoded) == bytes);
+
+auto malformed = bytes;
+malformed[10] = 25;
+bool rejected = false;
+try {
+    Packet packet("malformed", makeShared<BytesChunk>(malformed));
+    packet.popAtFront<Ieee80211AssociationResponseFrame>(B(malformed.size()));
+}
+catch (const cRuntimeError&) {
+    rejected = true;
+}
+ASSERT(rejected);
+
+auto expectRejected = [](const std::vector<uint8_t>& invalid) {
+    bool rejected = false;
+    try {
+        Packet packet("invalid", makeShared<BytesChunk>(invalid));
+        packet.popAtFront<Ieee80211AssociationResponseFrame>(B(invalid.size()));
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+};
+
+auto malformedOperation = bytes;
+malformedOperation[38] = 21;
+expectRejected(malformedOperation);
+auto truncated = bytes;
+truncated.pop_back();
+expectRejected(truncated);
+auto duplicate = bytes;
+duplicate.insert(duplicate.end(), bytes.begin() + 9, bytes.begin() + 37);
+expectRejected(duplicate);
+auto reservedOffset = bytes;
+reservedOffset[40] = (reservedOffset[40] & ~3) | 2;
+expectRejected(reservedOffset);
+auto invalidTxMcs = bytes;
+invalidTxMcs[26] = 0x02; // Tx undefined while Tx/Rx unequal is set
+expectRejected(invalidTxMcs);
+
+auto invalidRequest = makeShared<Ieee80211AssociationRequestFrame>();
+invalidRequest->setSSID("h");
+invalidRequest->setSupportedRates(original->getSupportedRates());
+invalidRequest->setHtOperationPresent(true);
+invalidRequest->setHtOperation(original->getHtOperation());
+invalidRequest->setChunkLength(B(34));
+bool invalidSubtypeRejected = false;
+try {
+    Packet packet("invalid-subtype", invalidRequest);
+    packet.peekAllAsBytes();
+}
+catch (const cRuntimeError&) {
+    invalidSubtypeRejected = true;
+}
+ASSERT(invalidSubtypeRejected);
+
+auto expectSerializationRejected = [](const auto& frame) {
+    bool rejected = false;
+    try {
+        Packet packet("forbidden-elements", frame);
+        packet.peekAllAsBytes();
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+};
+
+auto authentication = makeShared<Ieee80211AuthenticationFrame>();
+authentication->setHtCapabilitiesPresent(true);
+authentication->setHtCapabilities(original->getHtCapabilities());
+authentication->setChunkLength(B(34));
+expectSerializationRejected(authentication);
+
+auto deauthentication = makeShared<Ieee80211DeauthenticationFrame>();
+deauthentication->setHtCapabilitiesPresent(true);
+deauthentication->setHtCapabilities(original->getHtCapabilities());
+deauthentication->setChunkLength(B(30));
+expectSerializationRejected(deauthentication);
+
+auto disassociation = makeShared<Ieee80211DisassociationFrame>();
+disassociation->setHtOperationPresent(true);
+disassociation->setHtOperation(original->getHtOperation());
+disassociation->setChunkLength(B(26));
+expectSerializationRejected(disassociation);
+
+auto probeRequest = makeShared<Ieee80211ProbeRequestFrame>();
+probeRequest->setSSID("h");
+probeRequest->setSupportedRates(original->getSupportedRates());
+probeRequest->setHtOperationPresent(true);
+probeRequest->setHtOperation(original->getHtOperation());
+probeRequest->setChunkLength(B(30));
+expectSerializationRejected(probeRequest);
+
+auto reassociationRequest = makeShared<Ieee80211ReassociationRequestFrame>();
+reassociationRequest->setSSID("h");
+reassociationRequest->setSupportedRates(original->getSupportedRates());
+reassociationRequest->setHtOperationPresent(true);
+reassociationRequest->setHtOperation(original->getHtOperation());
+reassociationRequest->setChunkLength(B(40));
+expectSerializationRejected(reassociationRequest);
+
+auto allowedProbeRequest = makeShared<Ieee80211ProbeRequestFrame>();
+allowedProbeRequest->setSSID("h");
+allowedProbeRequest->setSupportedRates(original->getSupportedRates());
+allowedProbeRequest->setHtCapabilitiesPresent(true);
+allowedProbeRequest->setHtCapabilities(original->getHtCapabilities());
+allowedProbeRequest->setChunkLength(B(34));
+Packet allowedProbeRequestPacket("allowed-probe-request", allowedProbeRequest);
+ASSERT(allowedProbeRequestPacket.peekAllAsBytes()->getChunkLength() == B(34));
+
+for (bool probeResponse : {false, true}) {
+    Ptr<Ieee80211BeaconFrame> discovery = probeResponse ? staticPtrCast<Ieee80211BeaconFrame>(makeShared<Ieee80211ProbeResponseFrame>()) : makeShared<Ieee80211BeaconFrame>();
+    discovery->setSSID("");
+    discovery->setSupportedRates(original->getSupportedRates());
+    discovery->setHtCapabilitiesPresent(true);
+    discovery->setHtCapabilities(original->getHtCapabilities());
+    discovery->setHtOperationPresent(true);
+    discovery->setHtOperation(original->getHtOperation());
+    discovery->setChunkLength(B(69));
+    Packet discoveryPacket("allowed-discovery", discovery);
+    ASSERT(discoveryPacket.peekAllAsBytes()->getChunkLength() == B(69));
+}
+
+EV << "HT management element byte and validation checks passed.\n";
+
+%contains: stdout
+HT management element byte and validation checks passed.

--- a/tests/unit/Ieee80211HtMgmtElements_1.test
+++ b/tests/unit/Ieee80211HtMgmtElements_1.test
@@ -70,6 +70,8 @@ ASSERT(bytes.size() == 61);
 // IEEE Std 802.11-2024, 9.4.2.54: element ID 45 and fixed 26-octet body.
 ASSERT(bytes[9] == 45 && bytes[10] == 26);
 ASSERT(bytes[11] == 0x7f && bytes[12] == 0x00); // modeled flags plus SMPS=3 (disabled)
+ASSERT((bytes[11] & (1 << 5)) != 0); // Short GI for 20 MHz (HT Capabilities B5)
+ASSERT((bytes[11] & (1 << 6)) != 0); // Short GI for 40 MHz (HT Capabilities B6)
 ASSERT(bytes[13] == 0x02);
 ASSERT(bytes[14] == 0x85); // non-contiguous Rx MCS 0, 2, and 7
 ASSERT(bytes[15] == 0x80); // Rx MCS 15

--- a/tests/unit/Ieee80211HtModeSet_1.test
+++ b/tests/unit/Ieee80211HtModeSet_1.test
@@ -4,6 +4,7 @@ modes. The current VHT-only ac profile intentionally does not advertise HT.
 Also verify exact sparse HT MCS and width derivation from typed mode entries.
 
 %includes:
+#include <algorithm>
 #include <vector>
 
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
@@ -19,8 +20,8 @@ class SparseModeSet : public Ieee80211ModeSet
   public:
     using Ieee80211ModeSet::Entry;
 
-    SparseModeSet(const std::vector<Entry>& entries, bool htOperationSupported = true) :
-        Ieee80211ModeSet("sparse", entries, OperatingPhy::HT, htOperationSupported)
+    SparseModeSet(const std::vector<Entry>& entries, const IIeee80211Mode *referenceMode, bool htOperationSupported = true) :
+        Ieee80211ModeSet("sparse", entries, referenceMode, OperatingPhy::HT, htOperationSupported)
     {}
 };
 
@@ -50,7 +51,7 @@ sparseEntries.push_back({false, findHtMode(htModeSet, 10, MHz(20))});
 // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6: an ordinary HT profile
 // includes its applicable legacy operational rates in Supported Rates.
 sparseEntries.push_back({true, htModeSet->getMode(Mbps(1)), true});
-SparseModeSet sparse(sparseEntries);
+SparseModeSet sparse(sparseEntries, sparseEntries[0].mode);
 ASSERT(sparse.isHtOperationSupported());
 ASSERT(sparse.getLegacyOperationalModes().size() == 1);
 for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
@@ -68,7 +69,7 @@ for (auto& entry : htOnlyEntries)
     entry.isLegacyOperational = false;
 bool htOnlyRejected = false;
 try {
-    SparseModeSet invalid(htOnlyEntries);
+    SparseModeSet invalid(htOnlyEntries, htOnlyEntries[0].mode);
 }
 catch (const cRuntimeError&) {
     htOnlyRejected = true;
@@ -76,7 +77,7 @@ catch (const cRuntimeError&) {
 ASSERT(htOnlyRejected);
 bool nonHtOnlyRejected = false;
 try {
-    SparseModeSet invalid(htOnlyEntries, false);
+    SparseModeSet invalid(htOnlyEntries, htOnlyEntries[0].mode, false);
 }
 catch (const cRuntimeError&) {
     nonHtOnlyRejected = true;
@@ -90,12 +91,40 @@ missingMandatory.push_back({false, findHtMode(htModeSet, 8, MHz(20))});
 missingMandatory.push_back({true, htModeSet->getMode(Mbps(1)), true});
 bool missingMandatoryRejected = false;
 try {
-    SparseModeSet invalid(missingMandatory);
+    SparseModeSet invalid(missingMandatory, missingMandatory[0].mode);
 }
 catch (const cRuntimeError&) {
     missingMandatoryRejected = true;
 }
 ASSERT(missingMandatoryRejected);
+
+// The timing reference is explicit and remains stable when lookup entries are
+// reordered by bitrate. A reference must also be present exactly once.
+auto reorderedEntries = sparseEntries;
+std::swap(reorderedEntries.front(), reorderedEntries.back());
+SparseModeSet reordered(reorderedEntries, sparseEntries[0].mode);
+ASSERT(reordered.getReferenceMode() == sparseEntries[0].mode);
+ASSERT(reordered.getSifsTime() == sparseEntries[0].mode->getSifsTime());
+ASSERT(reordered.getSlotTime() == sparseEntries[0].mode->getSlotTime());
+ASSERT(reordered.getPhyRxStartDelay() == sparseEntries[0].mode->getPhyRxStartDelay());
+
+bool nullReferenceRejected = false;
+try {
+    SparseModeSet invalid(sparseEntries, nullptr);
+}
+catch (const cRuntimeError&) {
+    nullReferenceRejected = true;
+}
+ASSERT(nullReferenceRejected);
+
+bool notContainedReferenceRejected = false;
+try {
+    SparseModeSet invalid(sparseEntries, vhtOnlyModeSet->getMode(0));
+}
+catch (const cRuntimeError&) {
+    notContainedReferenceRejected = true;
+}
+ASSERT(notContainedReferenceRejected);
 
 EV << "HT mode-set capability and sparse-MCS checks verified.\n";
 

--- a/tests/unit/Ieee80211HtModeSet_1.test
+++ b/tests/unit/Ieee80211HtModeSet_1.test
@@ -1,0 +1,76 @@
+%description:
+Verify that HT operation is enabled only for a mode set with selectable HT
+modes. The current VHT-only ac profile intentionally does not advertise HT.
+Also verify exact sparse HT MCS and width derivation from typed mode entries.
+
+%includes:
+#include <vector>
+
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+
+using namespace inet;
+using namespace inet::physicallayer;
+using namespace inet::units::values;
+
+%global:
+
+class SparseModeSet : public Ieee80211ModeSet
+{
+  public:
+    using Ieee80211ModeSet::Entry;
+
+    SparseModeSet(const std::vector<Entry>& entries, bool htOperationSupported = true) :
+        Ieee80211ModeSet("sparse", entries, htOperationSupported)
+    {}
+};
+
+static const IIeee80211Mode *findHtMode(const Ieee80211ModeSet *modeSet, int mcsIndex, Hz bandwidth)
+{
+    for (int i = 0; i < modeSet->getNumModes(); i++) {
+        const auto *mode = modeSet->getMode(i);
+        if (mode->getHtMcsIndex() == mcsIndex && mode->getDataMode()->getBandwidth() == bandwidth)
+            return mode;
+    }
+    return nullptr;
+}
+
+%activity:
+
+const auto *htModeSet = Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+const auto *vhtOnlyModeSet = Ieee80211ModeSet::getModeSet("ac");
+
+ASSERT(htModeSet->isHtOperationSupported());
+ASSERT(!vhtOnlyModeSet->isHtOperationSupported());
+
+std::vector<SparseModeSet::Entry> sparseEntries;
+for (int mcsIndex = 0; mcsIndex < 8; mcsIndex++)
+    sparseEntries.push_back({true, findHtMode(htModeSet, mcsIndex, MHz(20))});
+sparseEntries.push_back({false, findHtMode(htModeSet, 8, MHz(20))});
+sparseEntries.push_back({false, findHtMode(htModeSet, 10, MHz(20))});
+SparseModeSet sparse(sparseEntries);
+ASSERT(sparse.isHtOperationSupported());
+for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
+    bool expected = mcsIndex < 8 || mcsIndex == 8 || mcsIndex == 10;
+    ASSERT(sparse.getHtMcsSupported()[mcsIndex] == expected);
+    ASSERT(sparse.getHtMcsMandatory()[mcsIndex] == (mcsIndex < 8));
+}
+ASSERT(sparse.getHtSupportedChannelWidths().size() == 1);
+ASSERT(sparse.getHtSupportedChannelWidths().count(MHz(20)) == 1);
+
+std::vector<SparseModeSet::Entry> missingMandatory;
+for (int mcsIndex = 0; mcsIndex < 7; mcsIndex++)
+    missingMandatory.push_back({true, findHtMode(htModeSet, mcsIndex, MHz(20))});
+missingMandatory.push_back({false, findHtMode(htModeSet, 8, MHz(20))});
+bool missingMandatoryRejected = false;
+try {
+    SparseModeSet invalid(missingMandatory);
+}
+catch (const cRuntimeError&) {
+    missingMandatoryRejected = true;
+}
+ASSERT(missingMandatoryRejected);
+
+EV << "HT mode-set capability and sparse-MCS checks verified.\n";
+
+%contains: stdout
+HT mode-set capability and sparse-MCS checks verified.

--- a/tests/unit/Ieee80211HtModeSet_1.test
+++ b/tests/unit/Ieee80211HtModeSet_1.test
@@ -54,6 +54,23 @@ sparseEntries.push_back({true, htModeSet->getMode(Mbps(1)), true});
 SparseModeSet sparse(sparseEntries, sparseEntries[0].mode);
 ASSERT(sparse.isHtOperationSupported());
 ASSERT(sparse.getLegacyOperationalModes().size() == 1);
+ASSERT(sparse.getFastestLegacyOperationalMode() == sparse.getLegacyOperationalModes().front());
+
+// The peer-HT fallback is the fastest mandatory legacy operational mode, not
+// merely the last rate in the complete (mandatory plus optional) list.
+SparseModeSet legacyFallback({
+        { true, findHtMode(htModeSet, 0, MHz(20)) },
+        { true, htModeSet->getMode(Mbps(1)), true },
+        { true, htModeSet->getMode(Mbps(2)), true },
+        { false, htModeSet->getMode(Mbps(5.5)), true },
+    }, findHtMode(htModeSet, 0, MHz(20)), false);
+ASSERT(legacyFallback.getFastestLegacyOperationalMode() == htModeSet->getMode(Mbps(2)));
+
+SparseModeSet optionalOnlyFallback({
+        { true, findHtMode(htModeSet, 0, MHz(20)) },
+        { false, htModeSet->getMode(Mbps(1)), true },
+    }, findHtMode(htModeSet, 0, MHz(20)), false);
+ASSERT(optionalOnlyFallback.getFastestLegacyOperationalMode() == htModeSet->getMode(Mbps(1)));
 for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
     bool expected = mcsIndex < 8 || mcsIndex == 8 || mcsIndex == 10;
     ASSERT(sparse.getHtMcsSupported()[mcsIndex] == expected);
@@ -61,6 +78,31 @@ for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
 }
 ASSERT(sparse.getHtSupportedChannelWidths().size() == 1);
 ASSERT(sparse.getHtSupportedChannelWidths().count(MHz(20)) == 1);
+ASSERT(sparse.isHtShortGuardIntervalSupported(MHz(20)));
+
+// Guard-interval support is aggregated only from typed HT mode entries. A
+// profile may therefore expose a short-GI mode independently of its mandatory
+// long-GI MCS entries, while non-HT/VHT modes cannot contribute to HT bits.
+SparseModeSet short20({
+        { false, findHtMode(htModeSet, 8, MHz(20)) },
+        { true, htModeSet->getMode(Mbps(1)), true },
+    }, findHtMode(htModeSet, 8, MHz(20)), false);
+ASSERT(short20.isHtShortGuardIntervalSupported(MHz(20)));
+ASSERT(!short20.isHtShortGuardIntervalSupported(MHz(40)));
+
+SparseModeSet short40({
+        { false, findHtMode(htModeSet, 0, MHz(40)) },
+        { true, htModeSet->getMode(Mbps(1)), true },
+    }, findHtMode(htModeSet, 0, MHz(40)), false);
+ASSERT(!short40.isHtShortGuardIntervalSupported(MHz(20)));
+ASSERT(short40.isHtShortGuardIntervalSupported(MHz(40)));
+
+SparseModeSet longOnly({
+        { false, findHtMode(htModeSet, 0, MHz(20)) },
+        { true, htModeSet->getMode(Mbps(1)), true },
+    }, findHtMode(htModeSet, 0, MHz(20)), false);
+ASSERT(!longOnly.isHtShortGuardIntervalSupported(MHz(20)));
+ASSERT(vhtOnlyModeSet->getHtShortGuardIntervalChannelWidths().empty());
 
 // All mandatory HT MCSs without an eligible legacy operational mode are
 // rejected at the mode-set boundary before management serialization.

--- a/tests/unit/Ieee80211HtModeSet_1.test
+++ b/tests/unit/Ieee80211HtModeSet_1.test
@@ -20,7 +20,7 @@ class SparseModeSet : public Ieee80211ModeSet
     using Ieee80211ModeSet::Entry;
 
     SparseModeSet(const std::vector<Entry>& entries, bool htOperationSupported = true) :
-        Ieee80211ModeSet("sparse", entries, htOperationSupported)
+        Ieee80211ModeSet("sparse", entries, OperatingPhy::HT, htOperationSupported)
     {}
 };
 
@@ -47,8 +47,12 @@ for (int mcsIndex = 0; mcsIndex < 8; mcsIndex++)
     sparseEntries.push_back({true, findHtMode(htModeSet, mcsIndex, MHz(20))});
 sparseEntries.push_back({false, findHtMode(htModeSet, 8, MHz(20))});
 sparseEntries.push_back({false, findHtMode(htModeSet, 10, MHz(20))});
+// IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6: an ordinary HT profile
+// includes its applicable legacy operational rates in Supported Rates.
+sparseEntries.push_back({true, htModeSet->getMode(Mbps(1)), true});
 SparseModeSet sparse(sparseEntries);
 ASSERT(sparse.isHtOperationSupported());
+ASSERT(sparse.getLegacyOperationalModes().size() == 1);
 for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
     bool expected = mcsIndex < 8 || mcsIndex == 8 || mcsIndex == 10;
     ASSERT(sparse.getHtMcsSupported()[mcsIndex] == expected);
@@ -57,10 +61,33 @@ for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
 ASSERT(sparse.getHtSupportedChannelWidths().size() == 1);
 ASSERT(sparse.getHtSupportedChannelWidths().count(MHz(20)) == 1);
 
+// All mandatory HT MCSs without an eligible legacy operational mode are
+// rejected at the mode-set boundary before management serialization.
+auto htOnlyEntries = sparseEntries;
+for (auto& entry : htOnlyEntries)
+    entry.isLegacyOperational = false;
+bool htOnlyRejected = false;
+try {
+    SparseModeSet invalid(htOnlyEntries);
+}
+catch (const cRuntimeError&) {
+    htOnlyRejected = true;
+}
+ASSERT(htOnlyRejected);
+bool nonHtOnlyRejected = false;
+try {
+    SparseModeSet invalid(htOnlyEntries, false);
+}
+catch (const cRuntimeError&) {
+    nonHtOnlyRejected = true;
+}
+ASSERT(nonHtOnlyRejected);
+
 std::vector<SparseModeSet::Entry> missingMandatory;
 for (int mcsIndex = 0; mcsIndex < 7; mcsIndex++)
     missingMandatory.push_back({true, findHtMode(htModeSet, mcsIndex, MHz(20))});
 missingMandatory.push_back({false, findHtMode(htModeSet, 8, MHz(20))});
+missingMandatory.push_back({true, htModeSet->getMode(Mbps(1)), true});
 bool missingMandatoryRejected = false;
 try {
     SparseModeSet invalid(missingMandatory);

--- a/tests/unit/Ieee80211MgmtApTransaction_1.test
+++ b/tests/unit/Ieee80211MgmtApTransaction_1.test
@@ -1,15 +1,13 @@
 %description:
-Verify deterministic AP association- and reassociation-response transaction
-matching and completion decisions, including the public originating-frame
-query for RTS-protected responses and pending-frame membership.
+Verify deterministic AP association- and reassociation-response result
+classification.  Matching transaction tags complete only on a final ACK,
+retain ACKed non-final fragments, and clear on a terminal retry-limit result;
+stale, missing, and malformed responses are ignored.
 
 %includes:
-#include <algorithm>
-
-#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
-#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h"
+#include "inet/common/packet/Packet.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
-#include "inet/linklayer/ieee80211/mac/queue/InProgressFrames.h"
+#include "inet/linklayer/ieee80211/mac/contract/IFrameTransmissionCallback.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 
@@ -22,26 +20,16 @@ class TestIeee80211MgmtAp : public Ieee80211MgmtAp
 {
   public:
     using Ieee80211MgmtAp::AssociationResponseDisposition;
-    using Ieee80211MgmtAp::getAssociationResponseHeader;
     using Ieee80211MgmtAp::getAssociationResponseDisposition;
-    using Ieee80211MgmtAp::getAssociationResponseFrame;
-    using Ieee80211MgmtAp::getMacHeader;
-    using Ieee80211MgmtAp::isAssociationResponseDecisionPoint;
 };
 
-class TestInProgressFrames : public InProgressFrames
+static Packet *makeAssociationResponse(uint64_t transactionId, bool moreFragments = false,
+        bool includeTag = true, Ieee80211FrameType subtype = ST_ASSOCIATIONRESPONSE)
 {
-  public:
-    void addFrame(Packet *frame) { inProgressFrames.push_back(frame); }
-    void removeFrame(Packet *frame) { inProgressFrames.erase(std::remove(inProgressFrames.begin(), inProgressFrames.end(), frame)); }
-};
-
-static Packet *makeAssociationResponse(uint64_t transactionId, bool moreFragments, bool includeTag = true,
-        Ieee80211FrameType subtype = ST_ASSOCIATIONRESPONSE)
-{
-    auto packet = new Packet("AssocResp-OK");
+    auto packet = new Packet("AssociationResponse");
     auto header = makeShared<Ieee80211MgmtHeader>();
     header->setType(subtype);
+    header->setReceiverAddress(MacAddress("02:00:00:00:00:01"));
     header->setMoreFragments(moreFragments);
     packet->insertAtBack(header);
     if (includeTag)
@@ -52,84 +40,40 @@ static Packet *makeAssociationResponse(uint64_t transactionId, bool moreFragment
 %activity:
 
 using Disposition = TestIeee80211MgmtAp::AssociationResponseDisposition;
+using Status = IFrameTransmissionCallback::Status;
 
-auto finalResponse = makeAssociationResponse(42, false);
-TransmitStep ordinaryStep(finalResponse, SIMTIME_ZERO);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseFrame(&ordinaryStep) == finalResponse);
-ASSERT(ordinaryStep.getOriginatingFrame() == finalResponse);
-ASSERT(ordinaryStep.getProtectedFrame() == finalResponse);
+auto finalResponse = makeAssociationResponse(42);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, Status::ACKNOWLEDGED) == Disposition::COMPLETE);
 
-auto pendingResponse = makeAssociationResponse(43, false);
-TestInProgressFrames pendingFrames;
-pendingFrames.addFrame(pendingResponse);
-FrameSequenceContext pendingContext(MacAddress::UNSPECIFIED_ADDRESS, nullptr, &pendingFrames, nullptr, nullptr, nullptr, nullptr);
-ASSERT(pendingContext.isFramePending(pendingResponse));
-ASSERT(!pendingContext.isFramePending(finalResponse));
-ASSERT(!pendingContext.isFramePending(nullptr));
-pendingFrames.removeFrame(pendingResponse);
-ASSERT(!pendingContext.isFramePending(pendingResponse));
-delete pendingResponse;
-
-{
-    auto rtsPacket = new Packet("RTS", makeShared<Ieee80211RtsFrame>());
-    RtsTransmitStep rtsStep(finalResponse, rtsPacket, SIMTIME_ZERO);
-    ASSERT(TestIeee80211MgmtAp::getAssociationResponseFrame(&rtsStep) == finalResponse);
-    ASSERT(rtsStep.getOriginatingFrame() == finalResponse);
-    ASSERT(rtsStep.getProtectedFrame() == finalResponse);
-
-    rtsStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
-    ReceiveStep ctsStep;
-    ctsStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
-    ctsStep.setFrameToReceive(new Packet("CTS", makeShared<Ieee80211CtsFrame>()));
-    ASSERT(!TestIeee80211MgmtAp::isAssociationResponseDecisionPoint(&rtsStep, &ctsStep));
-
-    ReceiveStep expiredCtsStep;
-    expiredCtsStep.setCompletion(IFrameSequenceStep::Completion::EXPIRED);
-    ASSERT(TestIeee80211MgmtAp::isAssociationResponseDecisionPoint(&rtsStep, &expiredCtsStep));
-    const Packet *protectedResponse = TestIeee80211MgmtAp::getAssociationResponseFrame(&rtsStep);
-    ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(protectedResponse, 42, false, true) == Disposition::RETAIN);
-    ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(protectedResponse, 42, false, false) == Disposition::COMPLETE);
-}
-
-ordinaryStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
-ReceiveStep ackStep;
-ackStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
-ackStep.setFrameToReceive(new Packet("ACK", makeShared<Ieee80211AckFrame>()));
-ASSERT(TestIeee80211MgmtAp::isAssociationResponseDecisionPoint(&ordinaryStep, &ackStep));
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, true, false) == Disposition::COMPLETE);
+auto nonFinalResponse = makeAssociationResponse(42, true);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, Status::ACKNOWLEDGED) == Disposition::RETAIN);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, Status::RETRY_LIMIT_REACHED) == Disposition::COMPLETE);
 
 auto reassociationResponse = makeAssociationResponse(42, false, true, ST_REASSOCIATIONRESPONSE);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseHeader(reassociationResponse)->getType() == ST_REASSOCIATIONRESPONSE);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(reassociationResponse, 42, true, false) == Disposition::COMPLETE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(reassociationResponse, 42, Status::ACKNOWLEDGED) == Disposition::COMPLETE);
 
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 41, true, false) == Disposition::IGNORE);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 0, true, false) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 41, Status::ACKNOWLEDGED) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 0, Status::ACKNOWLEDGED) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nullptr, 42, Status::ACKNOWLEDGED) == Disposition::IGNORE);
 
-auto zeroTokenResponse = makeAssociationResponse(0, false);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(zeroTokenResponse, 42, true, false) == Disposition::IGNORE);
+auto zeroTokenResponse = makeAssociationResponse(0);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(zeroTokenResponse, 42, Status::ACKNOWLEDGED) == Disposition::IGNORE);
 auto untaggedResponse = makeAssociationResponse(42, false, false);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(untaggedResponse, 42, true, false) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(untaggedResponse, 42, Status::ACKNOWLEDGED) == Disposition::IGNORE);
 
 auto aggregate = new Packet("A-MPDU-like");
 aggregate->insertAtBack(makeShared<Ieee80211MpduSubframeHeader>());
 aggregate->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(42);
-ASSERT(TestIeee80211MgmtAp::getMacHeader(aggregate) == nullptr);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseHeader(aggregate) == nullptr);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(aggregate, 42, true, false) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(aggregate, 42, Status::ACKNOWLEDGED) == Disposition::IGNORE);
 
-auto nonFinalResponse = makeAssociationResponse(42, true);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, true, false) == Disposition::RETAIN);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, false, true) == Disposition::RETAIN);
-ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, false, false) == Disposition::COMPLETE);
-
-delete nonFinalResponse;
+delete aggregate;
 delete untaggedResponse;
 delete zeroTokenResponse;
-delete aggregate;
 delete reassociationResponse;
+delete nonFinalResponse;
 delete finalResponse;
 
-EV << "AP association and reassociation transaction decisions verified.\n";
+EV << "AP management transmission-result classification verified.\n";
 
 %contains: stdout
-AP association and reassociation transaction decisions verified.
+AP management transmission-result classification verified.

--- a/tests/unit/Ieee80211MgmtApTransaction_1.test
+++ b/tests/unit/Ieee80211MgmtApTransaction_1.test
@@ -1,0 +1,135 @@
+%description:
+Verify deterministic AP association- and reassociation-response transaction
+matching and completion decisions, including the public originating-frame
+query for RTS-protected responses and pending-frame membership.
+
+%includes:
+#include <algorithm>
+
+#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
+#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceStep.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/queue/InProgressFrames.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+class TestIeee80211MgmtAp : public Ieee80211MgmtAp
+{
+  public:
+    using Ieee80211MgmtAp::AssociationResponseDisposition;
+    using Ieee80211MgmtAp::getAssociationResponseHeader;
+    using Ieee80211MgmtAp::getAssociationResponseDisposition;
+    using Ieee80211MgmtAp::getAssociationResponseFrame;
+    using Ieee80211MgmtAp::getMacHeader;
+    using Ieee80211MgmtAp::isAssociationResponseDecisionPoint;
+};
+
+class TestInProgressFrames : public InProgressFrames
+{
+  public:
+    void addFrame(Packet *frame) { inProgressFrames.push_back(frame); }
+    void removeFrame(Packet *frame) { inProgressFrames.erase(std::remove(inProgressFrames.begin(), inProgressFrames.end(), frame)); }
+};
+
+static Packet *makeAssociationResponse(uint64_t transactionId, bool moreFragments, bool includeTag = true,
+        Ieee80211FrameType subtype = ST_ASSOCIATIONRESPONSE)
+{
+    auto packet = new Packet("AssocResp-OK");
+    auto header = makeShared<Ieee80211MgmtHeader>();
+    header->setType(subtype);
+    header->setMoreFragments(moreFragments);
+    packet->insertAtBack(header);
+    if (includeTag)
+        packet->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
+    return packet;
+}
+
+%activity:
+
+using Disposition = TestIeee80211MgmtAp::AssociationResponseDisposition;
+
+auto finalResponse = makeAssociationResponse(42, false);
+TransmitStep ordinaryStep(finalResponse, SIMTIME_ZERO);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseFrame(&ordinaryStep) == finalResponse);
+ASSERT(ordinaryStep.getOriginatingFrame() == finalResponse);
+ASSERT(ordinaryStep.getProtectedFrame() == finalResponse);
+
+auto pendingResponse = makeAssociationResponse(43, false);
+TestInProgressFrames pendingFrames;
+pendingFrames.addFrame(pendingResponse);
+FrameSequenceContext pendingContext(MacAddress::UNSPECIFIED_ADDRESS, nullptr, &pendingFrames, nullptr, nullptr, nullptr, nullptr);
+ASSERT(pendingContext.isFramePending(pendingResponse));
+ASSERT(!pendingContext.isFramePending(finalResponse));
+ASSERT(!pendingContext.isFramePending(nullptr));
+pendingFrames.removeFrame(pendingResponse);
+ASSERT(!pendingContext.isFramePending(pendingResponse));
+delete pendingResponse;
+
+{
+    auto rtsPacket = new Packet("RTS", makeShared<Ieee80211RtsFrame>());
+    RtsTransmitStep rtsStep(finalResponse, rtsPacket, SIMTIME_ZERO);
+    ASSERT(TestIeee80211MgmtAp::getAssociationResponseFrame(&rtsStep) == finalResponse);
+    ASSERT(rtsStep.getOriginatingFrame() == finalResponse);
+    ASSERT(rtsStep.getProtectedFrame() == finalResponse);
+
+    rtsStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
+    ReceiveStep ctsStep;
+    ctsStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
+    ctsStep.setFrameToReceive(new Packet("CTS", makeShared<Ieee80211CtsFrame>()));
+    ASSERT(!TestIeee80211MgmtAp::isAssociationResponseDecisionPoint(&rtsStep, &ctsStep));
+
+    ReceiveStep expiredCtsStep;
+    expiredCtsStep.setCompletion(IFrameSequenceStep::Completion::EXPIRED);
+    ASSERT(TestIeee80211MgmtAp::isAssociationResponseDecisionPoint(&rtsStep, &expiredCtsStep));
+    const Packet *protectedResponse = TestIeee80211MgmtAp::getAssociationResponseFrame(&rtsStep);
+    ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(protectedResponse, 42, false, true) == Disposition::RETAIN);
+    ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(protectedResponse, 42, false, false) == Disposition::COMPLETE);
+}
+
+ordinaryStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
+ReceiveStep ackStep;
+ackStep.setCompletion(IFrameSequenceStep::Completion::ACCEPTED);
+ackStep.setFrameToReceive(new Packet("ACK", makeShared<Ieee80211AckFrame>()));
+ASSERT(TestIeee80211MgmtAp::isAssociationResponseDecisionPoint(&ordinaryStep, &ackStep));
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, true, false) == Disposition::COMPLETE);
+
+auto reassociationResponse = makeAssociationResponse(42, false, true, ST_REASSOCIATIONRESPONSE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseHeader(reassociationResponse)->getType() == ST_REASSOCIATIONRESPONSE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(reassociationResponse, 42, true, false) == Disposition::COMPLETE);
+
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 41, true, false) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 0, true, false) == Disposition::IGNORE);
+
+auto zeroTokenResponse = makeAssociationResponse(0, false);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(zeroTokenResponse, 42, true, false) == Disposition::IGNORE);
+auto untaggedResponse = makeAssociationResponse(42, false, false);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(untaggedResponse, 42, true, false) == Disposition::IGNORE);
+
+auto aggregate = new Packet("A-MPDU-like");
+aggregate->insertAtBack(makeShared<Ieee80211MpduSubframeHeader>());
+aggregate->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(42);
+ASSERT(TestIeee80211MgmtAp::getMacHeader(aggregate) == nullptr);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseHeader(aggregate) == nullptr);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(aggregate, 42, true, false) == Disposition::IGNORE);
+
+auto nonFinalResponse = makeAssociationResponse(42, true);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, true, false) == Disposition::RETAIN);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, false, true) == Disposition::RETAIN);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, false, false) == Disposition::COMPLETE);
+
+delete nonFinalResponse;
+delete untaggedResponse;
+delete zeroTokenResponse;
+delete aggregate;
+delete reassociationResponse;
+delete finalResponse;
+
+EV << "AP association and reassociation transaction decisions verified.\n";
+
+%contains: stdout
+AP association and reassociation transaction decisions verified.

--- a/tests/unit/Ieee80211MgmtApTransaction_1.test
+++ b/tests/unit/Ieee80211MgmtApTransaction_1.test
@@ -48,6 +48,7 @@ ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42,
 auto nonFinalResponse = makeAssociationResponse(42, true);
 ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, Status::ACKNOWLEDGED) == Disposition::RETAIN);
 ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, Status::RETRY_LIMIT_REACHED) == Disposition::COMPLETE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, Status::DROPPED_BEFORE_TRANSMISSION) == Disposition::COMPLETE);
 
 auto reassociationResponse = makeAssociationResponse(42, false, true, ST_REASSOCIATIONRESPONSE);
 ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(reassociationResponse, 42, Status::ACKNOWLEDGED) == Disposition::COMPLETE);

--- a/tests/unit/Ieee80211MgmtProtocolPrinter_1.test
+++ b/tests/unit/Ieee80211MgmtProtocolPrinter_1.test
@@ -1,0 +1,56 @@
+%description:
+Verify compact set notation for sparse, contiguous, mixed, and empty HT MCS
+bitmaps in the IEEE 802.11 management protocol printer.
+
+%includes:
+#include <initializer_list>
+#include <string>
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtProtocolPrinter.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+static Ptr<Ieee80211MgmtFrame> makeFrame(std::initializer_list<int> rxMcs, std::initializer_list<int> basicMcs)
+{
+    auto frame = makeShared<Ieee80211MgmtFrame>();
+    Ieee80211HtCapabilitiesElement capabilities;
+    for (int mcs : rxMcs)
+        capabilities.rxMcsSupported[mcs] = true;
+    frame->setHtCapabilitiesPresent(true);
+    frame->setHtCapabilities(capabilities);
+
+    Ieee80211HtOperationElement operation;
+    for (int mcs : basicMcs)
+        operation.basicMcsSupported[mcs] = true;
+    frame->setHtOperationPresent(true);
+    frame->setHtOperation(operation);
+    return frame;
+}
+
+static std::string printHtSuffix(const Ptr<const Ieee80211MgmtFrame>& frame)
+{
+    Ieee80211MgmtProtocolPrinter printer;
+    ProtocolPrinter::Context context;
+    printer.print(frame, &Protocol::ieee80211Mgmt, nullptr, context);
+    auto info = context.infoColumn.str();
+    auto suffixStart = info.find(" HT-Cap(");
+    return suffixStart == std::string::npos ? info : info.substr(suffixStart);
+}
+
+%activity:
+
+ASSERT(printHtSuffix(makeFrame({0, 2, 7, 15, 76}, {0, 2, 7, 15, 76})) ==
+        " HT-Cap(width=20MHz,rxMcs={0,2,7,15,76},tx=undefined) HT-Op(primary=0,width=20MHz,basicMcs={0,2,7,15,76})");
+ASSERT(printHtSuffix(makeFrame({0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 7, 9, 10, 11})) ==
+        " HT-Cap(width=20MHz,rxMcs={0..7},tx=undefined) HT-Op(primary=0,width=20MHz,basicMcs={0..3,7,9..11})");
+ASSERT(printHtSuffix(makeFrame({}, {})) ==
+        " HT-Cap(width=20MHz,rxMcs={},tx=undefined) HT-Op(primary=0,width=20MHz,basicMcs={})");
+
+EV << "HT MCS bitmap printer formatting verified.\n";
+
+%contains: stdout
+HT MCS bitmap printer formatting verified.

--- a/tests/unit/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/unit/Ieee80211MgmtStaDiscovery_1.test
@@ -1,0 +1,121 @@
+%description:
+Verify that serialized Beacon and Probe Response discovery preserves the HT
+Operation primary channel as the cached AP channel, while legacy discovery
+continues to use channelNumber (including channel 0).
+
+%includes:
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+using namespace inet::units::values;
+
+%global:
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  public:
+    using Ieee80211MgmtSta::lookupAP;
+    using Ieee80211MgmtSta::storeAPInfo;
+
+    int changedChannel = -1;
+
+    virtual void changeChannel(int channel) override { changedChannel = channel; }
+};
+
+static Ptr<Ieee80211BeaconFrame> makeDiscovery(bool probeResponse, int channelNumber, int primaryChannel, bool withHt)
+{
+    Ptr<Ieee80211BeaconFrame> body = probeResponse ? staticPtrCast<Ieee80211BeaconFrame>(makeShared<Ieee80211ProbeResponseFrame>()) : makeShared<Ieee80211BeaconFrame>();
+    body->setSSID("serialized");
+    Ieee80211SupportedRatesElement rates;
+    rates.numRates = 1;
+    rates.rate[0] = 6;
+    body->setSupportedRates(rates);
+    body->setBeaconInterval(SimTime(100, SIMTIME_MS));
+    body->setChannelNumber(channelNumber);
+    if (withHt) {
+        Ieee80211HtCapabilities capabilities;
+        capabilities.supportedChannelWidths.insert(MHz(20));
+        capabilities.rxMcsSupported[0] = true;
+        capabilities.txMcsNss.maxMcsPerNss[0] = 0;
+        setHtCapabilities(body, capabilities);
+        Ieee80211HtOperation operation;
+        operation.primaryChannel = primaryChannel;
+        operation.basicMcsSupported[0] = true;
+        setHtOperation(body, operation);
+    }
+    body->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(body));
+    return body;
+}
+
+static void storeSerializedDiscovery(TestIeee80211MgmtSta& sta, const Ptr<Ieee80211BeaconFrame>& original,
+        const MacAddress& address)
+{
+    Packet packet("discovery", original);
+    auto bytes = packet.peekAllAsBytes()->getBytes();
+    Packet encoded("encoded", makeShared<BytesChunk>(bytes));
+    encoded.addTag<SignalPowerInd>()->setPower(mW(1));
+    Ptr<const Ieee80211BeaconFrame> decoded;
+    if (dynamicPtrCast<const Ieee80211ProbeResponseFrame>(original) != nullptr)
+        decoded = encoded.popAtFront<Ieee80211ProbeResponseFrame>(B(bytes.size()));
+    else
+        decoded = encoded.popAtFront<Ieee80211BeaconFrame>(B(bytes.size()));
+    auto header = makeShared<Ieee80211MgmtHeader>();
+    header->setTransmitterAddress(address);
+    sta.storeAPInfo(&encoded, header, decoded);
+}
+
+static void storePacketDomainDiscovery(TestIeee80211MgmtSta& sta, const Ptr<Ieee80211BeaconFrame>& body,
+        const MacAddress& address)
+{
+    Packet packet("packet-domain-discovery", body);
+    packet.addTag<SignalPowerInd>()->setPower(mW(1));
+    auto header = makeShared<Ieee80211MgmtHeader>();
+    header->setTransmitterAddress(address);
+    sta.storeAPInfo(&packet, header, body);
+}
+
+%activity:
+
+TestIeee80211MgmtSta sta;
+const MacAddress beaconAddress("02:00:00:00:00:01");
+const MacAddress probeAddress("02:00:00:00:00:02");
+const MacAddress legacyAddress("02:00:00:00:00:03");
+
+// The serialized body has the fixed channelNumber at its default value, but
+// HT Operation carries the authoritative primary channel (Table 9-230/11.14).
+storeSerializedDiscovery(sta, makeDiscovery(false, 0, 11, true), beaconAddress);
+ASSERT(sta.lookupAP(beaconAddress)->channel == 11);
+sta.changeChannel(sta.lookupAP(beaconAddress)->channel);
+ASSERT(sta.changedChannel == 11);
+
+// Probe Response follows the same discovery rule. Its concrete subtype is
+// decoded above, and the serialized fixed channel field is ignored in favor
+// of HT Operation.
+storeSerializedDiscovery(sta, makeDiscovery(true, 3, 6, true), probeAddress);
+ASSERT(sta.lookupAP(probeAddress)->channel == 6);
+sta.changeChannel(sta.lookupAP(probeAddress)->channel);
+ASSERT(sta.changedChannel == 6);
+
+// When both packet-domain fields are available, the HT primary remains the
+// deterministic authority even if the legacy field disagrees.
+storePacketDomainDiscovery(sta, makeDiscovery(true, 3, 6, true), probeAddress);
+ASSERT(sta.lookupAP(probeAddress)->channel == 6);
+
+// Without HT Operation, preserve the packet-domain channelNumber exactly,
+// including its legal/default value of zero. The management-body serializer
+// does not encode the legacy field, so these assertions intentionally use the
+// original packet-domain body.
+storePacketDomainDiscovery(sta, makeDiscovery(false, 7, 0, false), legacyAddress);
+ASSERT(sta.lookupAP(legacyAddress)->channel == 7);
+storePacketDomainDiscovery(sta, makeDiscovery(false, 0, 0, false), legacyAddress);
+ASSERT(sta.lookupAP(legacyAddress)->channel == 0);
+
+EV << "Serialized HT discovery channel and legacy fallback checks passed.\n";
+
+%contains: stdout
+Serialized HT discovery channel and legacy fallback checks passed.

--- a/tests/unit/Ieee80211MgmtStaPrimitiveDispatch_1.test
+++ b/tests/unit/Ieee80211MgmtStaPrimitiveDispatch_1.test
@@ -1,0 +1,118 @@
+%description:
+Verify that association and reassociation management primitives are dispatched
+to their most-derived handlers, including the distinct reassociation confirm
+primitive emitted by the station agent.
+
+%includes:
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+class TestIeee80211AgentSta : public Ieee80211AgentSta
+{
+  public:
+    using Ieee80211AgentSta::handleResponse;
+
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+    int scanRequests = 0;
+
+  protected:
+    virtual void processAssociateConfirm(Ieee80211Prim_AssociateConfirm *resp) override
+    {
+        associateConfirms++;
+    }
+
+    virtual void processReassociateConfirm(Ieee80211Prim_ReassociateConfirm *resp) override
+    {
+        reassociateConfirms++;
+        Ieee80211AgentSta::processReassociateConfirm(resp);
+    }
+
+    virtual void sendScanRequest() override
+    {
+        scanRequests++;
+    }
+};
+
+class ConfirmListener : public cListener
+{
+  public:
+    int lastCode = 0;
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override
+    {
+        lastCode = value;
+    }
+};
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  public:
+    using Ieee80211MgmtSta::handleCommand;
+
+    int associateRequests = 0;
+    int reassociateRequests = 0;
+
+  protected:
+    virtual void processAssociateCommand(Ieee80211Prim_AssociateRequest *ctrl) override
+    {
+        associateRequests++;
+    }
+
+    virtual void processReassociateCommand(Ieee80211Prim_ReassociateRequest *ctrl) override
+    {
+        reassociateRequests++;
+    }
+};
+
+static void deliverConfirm(TestIeee80211AgentSta& agent, Ieee80211PrimConfirm *confirm)
+{
+    auto message = new cMessage("confirm");
+    message->setControlInfo(confirm);
+    agent.handleResponse(message);
+}
+
+%activity:
+
+TestIeee80211AgentSta agent;
+ConfirmListener listener;
+agent.subscribe("acceptConfirm", &listener);
+deliverConfirm(agent, new Ieee80211Prim_AssociateConfirm());
+ASSERT(agent.associateConfirms == 1);
+ASSERT(agent.reassociateConfirms == 0);
+
+auto reassociateConfirm = new Ieee80211Prim_ReassociateConfirm();
+reassociateConfirm->setResultCode(PRC_SUCCESS);
+deliverConfirm(agent, reassociateConfirm);
+ASSERT(agent.associateConfirms == 1);
+ASSERT(agent.reassociateConfirms == 1);
+ASSERT(listener.lastCode == PR_REASSOCIATE_CONFIRM);
+
+ConfirmListener dropListener;
+agent.subscribe("dropConfirm", &dropListener);
+auto refusedReassociateConfirm = new Ieee80211Prim_ReassociateConfirm();
+refusedReassociateConfirm->setResultCode(PRC_REFUSED);
+deliverConfirm(agent, refusedReassociateConfirm);
+ASSERT(agent.associateConfirms == 1);
+ASSERT(agent.reassociateConfirms == 2);
+ASSERT(agent.scanRequests == 1);
+ASSERT(dropListener.lastCode == PR_REASSOCIATE_CONFIRM);
+
+TestIeee80211MgmtSta mgmt;
+mgmt.handleCommand(PR_ASSOCIATE_REQUEST, new Ieee80211Prim_AssociateRequest());
+ASSERT(mgmt.associateRequests == 1);
+ASSERT(mgmt.reassociateRequests == 0);
+
+mgmt.handleCommand(PR_REASSOCIATE_REQUEST, new Ieee80211Prim_ReassociateRequest());
+ASSERT(mgmt.associateRequests == 1);
+ASSERT(mgmt.reassociateRequests == 1);
+
+EV << "Association and reassociation primitive dispatch verified.\n";
+
+%contains: stdout
+Association and reassociation primitive dispatch verified.

--- a/tests/unit/Ieee80211MgmtStaPrimitiveDispatch_1.test
+++ b/tests/unit/Ieee80211MgmtStaPrimitiveDispatch_1.test
@@ -1,7 +1,8 @@
 %description:
 Verify that association and reassociation management primitives are dispatched
 to their most-derived handlers, including the distinct reassociation confirm
-primitive emitted by the station agent.
+primitive emitted by the station agent. Verify association timeout ownership,
+confirm typing, AP-list cleanup, restart eligibility, and late-response rejection.
 
 %includes:
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h"
@@ -54,9 +55,67 @@ class TestIeee80211MgmtSta : public Ieee80211MgmtSta
 {
   public:
     using Ieee80211MgmtSta::handleCommand;
+    using Ieee80211MgmtSta::shouldDisassociateOnReassociationFailure;
 
     int associateRequests = 0;
     int reassociateRequests = 0;
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+    int reassociationFailures = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+
+    void prepareAssociationTimeout(ApInfo *ap, bool reassociation)
+    {
+        ASSERT(assocTimeoutMsg == nullptr);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+    }
+
+    void prepareAssociationTimeoutInApList(const MacAddress& address, bool reassociation)
+    {
+        apList.push_back(ApInfo());
+        apList.back().address = address;
+        prepareAssociationTimeout(&apList.back(), reassociation);
+    }
+
+    void clearKnownAccessPoints() { clearAPList(); }
+    void abandonPendingAssociation() { cancelPendingAssociation(); }
+    size_t getKnownAccessPointCount() const { return apList.size(); }
+
+    void deliverAssociationTimeout()
+    {
+        ASSERT(assocTimeoutMsg != nullptr);
+        handleTimer(assocTimeoutMsg);
+    }
+
+    bool canStartAnotherAssociation() const { return assocTimeoutMsg == nullptr; }
+    bool isReassociationInProgress() const { return reassociationInProgress; }
+
+    void deliverLateAssociationResponse(bool reassociation)
+    {
+        auto packet = new Packet("LateAssocResp");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    void deliverMismatchedAssociationResponse(const MacAddress& address, bool reassociation)
+    {
+        auto packet = new Packet("MismatchedAssocResp");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    void deliverPendingAssociationResponse(bool reassociation)
+    {
+        auto packet = new Packet("PendingAssocResp");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        auto ap = static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer());
+        header->setTransmitterAddress(ap->address);
+        processAssociationResponse(packet, header, reassociation);
+    }
 
   protected:
     virtual void processAssociateCommand(Ieee80211Prim_AssociateRequest *ctrl) override
@@ -67,6 +126,23 @@ class TestIeee80211MgmtSta : public Ieee80211MgmtSta
     virtual void processReassociateCommand(Ieee80211Prim_ReassociateRequest *ctrl) override
     {
         reassociateRequests++;
+    }
+
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associateConfirms++;
+        lastAssociationResult = resultCode;
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociateConfirms++;
+        lastReassociationResult = resultCode;
+    }
+
+    virtual void handleReassociationFailure(ApInfo *ap) override
+    {
+        reassociationFailures++;
     }
 };
 
@@ -112,7 +188,77 @@ mgmt.handleCommand(PR_REASSOCIATE_REQUEST, new Ieee80211Prim_ReassociateRequest(
 ASSERT(mgmt.associateRequests == 1);
 ASSERT(mgmt.reassociateRequests == 1);
 
-EV << "Association and reassociation primitive dispatch verified.\n";
+Ieee80211MgmtSta::ApInfo timeoutAp;
+timeoutAp.address = MacAddress("02:00:00:00:00:01");
+MacAddress otherApAddress("02:00:00:00:00:02");
+ASSERT(TestIeee80211MgmtSta::shouldDisassociateOnReassociationFailure(true, timeoutAp.address, timeoutAp.address));
+ASSERT(!TestIeee80211MgmtSta::shouldDisassociateOnReassociationFailure(true, timeoutAp.address, otherApAddress));
+ASSERT(!TestIeee80211MgmtSta::shouldDisassociateOnReassociationFailure(false, timeoutAp.address, timeoutAp.address));
+mgmt.prepareAssociationTimeout(&timeoutAp, false);
+mgmt.deliverMismatchedAssociationResponse(otherApAddress, false);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.associateConfirms == 0);
+mgmt.deliverAssociationTimeout();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 1);
+ASSERT(mgmt.reassociateConfirms == 0);
+ASSERT(mgmt.lastAssociationResult == PRC_TIMEOUT);
+ASSERT(mgmt.reassociationFailures == 0);
+
+mgmt.deliverLateAssociationResponse(false);
+ASSERT(mgmt.associateConfirms == 1);
+ASSERT(mgmt.reassociateConfirms == 0);
+
+// IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4 correlate the response
+// procedure with the corresponding association or reassociation request.
+mgmt.prepareAssociationTimeout(&timeoutAp, false);
+mgmt.deliverPendingAssociationResponse(true);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 1);
+ASSERT(mgmt.reassociateConfirms == 0);
+mgmt.deliverAssociationTimeout();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 0);
+ASSERT(mgmt.lastAssociationResult == PRC_TIMEOUT);
+
+mgmt.prepareAssociationTimeout(&timeoutAp, true);
+mgmt.deliverPendingAssociationResponse(false);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 0);
+mgmt.deliverAssociationTimeout();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 1);
+ASSERT(mgmt.lastReassociationResult == PRC_TIMEOUT);
+ASSERT(mgmt.reassociationFailures == 1);
+
+mgmt.deliverLateAssociationResponse(true);
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 1);
+
+mgmt.prepareAssociationTimeoutInApList(otherApAddress, true);
+ASSERT(mgmt.getKnownAccessPointCount() == 1);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.isReassociationInProgress());
+mgmt.clearKnownAccessPoints();
+ASSERT(mgmt.getKnownAccessPointCount() == 0);
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+
+mgmt.prepareAssociationTimeoutInApList(otherApAddress, true);
+ASSERT(!mgmt.canStartAnotherAssociation());
+mgmt.abandonPendingAssociation();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+mgmt.clearKnownAccessPoints();
+
+EV << "Association and reassociation primitive dispatch and timeout ownership verified.\n";
 
 %contains: stdout
-Association and reassociation primitive dispatch verified.
+Association and reassociation primitive dispatch and timeout ownership verified.

--- a/tests/unit/Ieee80211MgmtTransactionTag_1.test
+++ b/tests/unit/Ieee80211MgmtTransactionTag_1.test
@@ -1,0 +1,59 @@
+%description:
+Verify that the local IEEE 802.11 management transaction identity is retained
+when a management frame is replaced by fragmentation packets, and that a
+generic body region tag is clipped and rebased for each fragment.
+
+%includes:
+#include <vector>
+
+#include "inet/common/TimeTag_m.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mac/fragmentation/Fragmentation.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%activity:
+
+auto frame = new Packet("AssocResp-OK");
+frame->insertAtBack(makeShared<BytesChunk>(std::vector<uint8_t>(9, 0)));
+frame->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(42);
+frame->addRegionTag<CreationTimeTag>(B(2), B(5));
+
+auto header = makeShared<Ieee80211MgmtHeader>();
+header->setType(ST_ASSOCIATIONRESPONSE);
+header->setReceiverAddress(MacAddress("02:00:00:00:00:01"));
+frame->insertAtFront(header);
+frame->insertAtBack(makeShared<Ieee80211MacTrailer>());
+auto headerLength = header->getChunkLength();
+
+Fragmentation fragmentation;
+auto fragments = fragmentation.fragmentFrame(frame, {4, 5});
+ASSERT(fragments->size() == 2);
+for (auto fragment : *fragments) {
+    auto tag = fragment->findTag<Ieee80211MgmtTransactionTag>();
+    ASSERT(tag != nullptr);
+    ASSERT(tag->getTransactionId() == 42);
+}
+ASSERT(fragments->front()->peekAtFront<Ieee80211MgmtHeader>()->getMoreFragments());
+ASSERT(!fragments->back()->peekAtFront<Ieee80211MgmtHeader>()->getMoreFragments());
+
+auto firstRegionTags = fragments->front()->getAllRegionTags<CreationTimeTag>();
+ASSERT(firstRegionTags.size() == 1);
+ASSERT(firstRegionTags.front().getStartOffset() == headerLength + B(2));
+ASSERT(firstRegionTags.front().getLength() == B(2));
+auto secondRegionTags = fragments->back()->getAllRegionTags<CreationTimeTag>();
+ASSERT(secondRegionTags.size() == 1);
+ASSERT(secondRegionTags.front().getStartOffset() == headerLength);
+ASSERT(secondRegionTags.front().getLength() == B(3));
+
+for (auto fragment : *fragments)
+    delete fragment;
+delete fragments;
+
+EV << "Management transaction packet tag survived frame replacement.\n";
+
+%contains: stdout
+Management transaction packet tag survived frame replacement.

--- a/tests/unit/Ieee80211MibAssociationId_1.test
+++ b/tests/unit/Ieee80211MibAssociationId_1.test
@@ -1,0 +1,44 @@
+%description:
+Verify deterministic IEEE 802.11 association ID reservation, commit,
+cancellation, reuse, and lifecycle clearing.
+
+%includes:
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%activity:
+
+Ieee80211Mib mib;
+MacAddress first("02:00:00:00:00:01");
+MacAddress second("02:00:00:00:00:02");
+MacAddress third("02:00:00:00:00:03");
+MacAddress fourth("02:00:00:00:00:04");
+
+ASSERT(mib.reserveAssociationId(first) == 1);
+ASSERT(mib.reserveAssociationId(second) == 2);
+ASSERT(mib.reserveAssociationId(first) == 1);
+
+mib.cancelAssociationIdReservation(first);
+ASSERT(mib.reserveAssociationId(third) == 1);
+
+ASSERT(mib.commitAssociationId(second) == 2);
+ASSERT(mib.bssAccessPointData.associationIds.at(second) == 2);
+mib.cancelAssociationIdReservation(second);
+ASSERT(mib.bssAccessPointData.associationIds.at(second) == 2);
+
+ASSERT(mib.commitAssociationId(third) == 1);
+mib.releaseAssociationId(second);
+ASSERT(mib.bssAccessPointData.associationIds.count(second) == 0);
+ASSERT(mib.allocateAssociationId(fourth) == 2);
+
+mib.reserveAssociationId(first);
+mib.clearAssociationIds();
+ASSERT(mib.bssAccessPointData.associationIds.empty());
+ASSERT(mib.reserveAssociationId(second) == 1);
+
+EV << "Association ID ownership checks passed.\n";
+
+%contains: stdout
+Association ID ownership checks passed.

--- a/tests/unit/Ieee80211PeerModeSelection_1.test
+++ b/tests/unit/Ieee80211PeerModeSelection_1.test
@@ -1,0 +1,147 @@
+%description:
+Verify that peer HT mode selection honors negotiated MCS, channel width,
+operation width, and receiver short-guard-interval capabilities.
+
+%includes:
+#include <initializer_list>
+
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+using namespace inet::physicallayer;
+using namespace inet::units::values;
+
+%global:
+
+static const IIeee80211Mode *findHtMode(const Ieee80211ModeSet *modeSet, int mcsIndex, Hz bandwidth)
+{
+    for (int i = 0; i < modeSet->getNumModes(); i++) {
+        const auto *mode = modeSet->getMode(i);
+        if (mode->getHtMcsIndex() == mcsIndex && mode->getDataMode()->getBandwidth() == bandwidth)
+            return mode;
+    }
+    return nullptr;
+}
+
+static Ieee80211Mib::PeerHtState makePeerState(std::initializer_list<int> mcsIndexes,
+        std::initializer_list<Hz> bandwidths, Hz operatingChannelWidth, bool shortGi20 = false, bool shortGi40 = false)
+{
+    Ieee80211Mib::PeerHtState state;
+    state.valid = true;
+    auto& receiverCapabilities = state.negotiatedCapabilities.localTxPeerRx;
+    receiverCapabilities.valid = true;
+    for (int mcsIndex : mcsIndexes)
+        receiverCapabilities.supportedMcs[mcsIndex] = true;
+    for (auto bandwidth : bandwidths)
+        receiverCapabilities.supportedChannelWidths.insert(bandwidth);
+    receiverCapabilities.receiverShortGi20 = shortGi20;
+    receiverCapabilities.receiverShortGi40 = shortGi40;
+    state.negotiatedCapabilities.operation.operatingChannelWidth = operatingChannelWidth;
+    return state;
+}
+
+%activity:
+
+const auto *modeSet = Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+const auto *mcs0 = findHtMode(modeSet, 0, MHz(20));
+const auto *mcs1 = findHtMode(modeSet, 1, MHz(20));
+const auto *mcs2 = findHtMode(modeSet, 2, MHz(20));
+const auto *mcs8 = findHtMode(modeSet, 8, MHz(20));
+const auto *mcs0_40 = findHtMode(modeSet, 0, MHz(40));
+ASSERT(mcs0 != nullptr);
+ASSERT(mcs1 != nullptr);
+ASSERT(mcs2 != nullptr);
+ASSERT(mcs8 != nullptr);
+ASSERT(mcs0_40 != nullptr);
+ASSERT(mcs8->isHtShortGuardInterval());
+ASSERT(mcs8->getDataMode()->getBandwidth() == MHz(20));
+ASSERT(mcs0_40->isHtShortGuardInterval());
+ASSERT(mcs0_40->getDataMode()->getBandwidth() == MHz(40));
+
+const auto *modeOutsideSet = Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs32BW40MHz,
+        Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED,
+        Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+ASSERT(!modeSet->containsMode(modeOutsideSet));
+
+const MacAddress peer("02:00:00:00:00:01");
+
+auto shortGiPeer = makePeerState({8}, {MHz(20)}, MHz(20), true);
+const auto *shortGiSelection = selectPeerCompatibleMode(modeSet, &shortGiPeer, mcs8, peer);
+ASSERT(shortGiSelection == mcs8);
+ASSERT(shortGiSelection->isHtShortGuardInterval());
+ASSERT(shortGiSelection->getDataMode()->getBandwidth() == MHz(20));
+auto fortyMhzPeer = makePeerState({0}, {MHz(20), MHz(40)}, MHz(40), false, true);
+const auto *fortyMhzSelection = selectPeerCompatibleMode(modeSet, &fortyMhzPeer, mcs0_40, peer);
+ASSERT(fortyMhzSelection == mcs0_40);
+ASSERT(fortyMhzSelection->isHtShortGuardInterval());
+ASSERT(fortyMhzSelection->getDataMode()->getBandwidth() == MHz(40));
+
+bool outsideModeRejected = false;
+try {
+    auto compatiblePeer = makePeerState({0}, {MHz(20)}, MHz(20));
+    selectPeerCompatibleMode(modeSet, &compatiblePeer, modeOutsideSet, peer);
+}
+catch (const cRuntimeError&) {
+    outsideModeRejected = true;
+}
+ASSERT(outsideModeRejected);
+
+// The exact negotiated bitmap is not a contiguous maximum-MCS value: MCS 0
+// and 2 are usable while MCS 1 is not (IEEE Std 802.11-2024, 10.6.5.8).
+auto sparsePeer = makePeerState({0, 2}, {MHz(20)}, MHz(20));
+ASSERT(selectPeerCompatibleMode(modeSet, &sparsePeer, mcs2, peer) == mcs2);
+ASSERT(selectPeerCompatibleMode(modeSet, &sparsePeer, mcs1, peer) == mcs0);
+
+// A 20 MHz-only receiver cannot use a 40 MHz candidate, even when the BSS
+// itself permits 40 MHz operation.
+auto twentyOnlyPeer = makePeerState({0}, {MHz(20)}, MHz(40));
+const auto *twentyFallback = selectPeerCompatibleMode(modeSet, &twentyOnlyPeer, mcs0_40, peer);
+ASSERT(twentyFallback == mcs0);
+ASSERT(twentyFallback->getDataMode()->getBandwidth() == MHz(20));
+
+// The negotiated HT Operation width is an additional BSS-level limit over
+// the common capability widths.
+auto twentyOperationPeer = makePeerState({0}, {MHz(20), MHz(40)}, MHz(20));
+ASSERT(selectPeerCompatibleMode(modeSet, &twentyOperationPeer, mcs0_40, peer) == mcs0);
+
+// A short-GI mode is rejected when the peer did not advertise the matching
+// receiver capability bit.
+auto shortGiDisabledPeer = makePeerState({0, 8}, {MHz(20)}, MHz(20));
+const auto *shortGiFallback = selectPeerCompatibleMode(modeSet, &shortGiDisabledPeer, mcs8, peer);
+ASSERT(shortGiFallback == mcs0);
+ASSERT(!shortGiFallback->isHtShortGuardInterval());
+
+auto compatiblePeer = makePeerState({2}, {MHz(20)}, MHz(40));
+ASSERT(selectPeerCompatibleMode(modeSet, &compatiblePeer, mcs2, peer) == mcs2);
+
+// Missing or invalid negotiated state keeps unicast HT selection on the
+// mode-set-owned legacy operational fallback.
+ASSERT(selectPeerCompatibleMode(modeSet, nullptr, mcs2, peer) == modeSet->getFastestLegacyOperationalMode());
+auto invalidPeer = makePeerState({2}, {MHz(20)}, MHz(20));
+invalidPeer.valid = false;
+ASSERT(selectPeerCompatibleMode(modeSet, &invalidPeer, mcs2, peer) == modeSet->getFastestLegacyOperationalMode());
+auto invalidDirectionalPeer = makePeerState({2}, {MHz(20)}, MHz(20));
+invalidDirectionalPeer.negotiatedCapabilities.localTxPeerRx.valid = false;
+ASSERT(selectPeerCompatibleMode(modeSet, &invalidDirectionalPeer, mcs2, peer) == modeSet->getFastestLegacyOperationalMode());
+
+// If no compatible HT mode is at or below the candidate bitrate, the result
+// is legacy rather than an HT mode that violates the negotiated bitmap.
+auto noHtFallbackPeer = makePeerState({76}, {MHz(20)}, MHz(20));
+const auto *noHtFallback = selectPeerCompatibleMode(modeSet, &noHtFallbackPeer, mcs0, peer);
+ASSERT(noHtFallback == modeSet->getFastestLegacyOperationalMode());
+ASSERT(noHtFallback->getHtMcsIndex() < 0);
+
+// Mode-set traversal and tie-breaks are stable and never depend on pointers.
+auto deterministicPeer = makePeerState({0, 2, 8}, {MHz(20)}, MHz(20));
+const auto *firstSelection = selectPeerCompatibleMode(modeSet, &deterministicPeer, mcs8, peer);
+const auto *secondSelection = selectPeerCompatibleMode(modeSet, &deterministicPeer, mcs8, peer);
+ASSERT(firstSelection == secondSelection);
+ASSERT(firstSelection->getHtMcsIndex() == 0);
+ASSERT(!firstSelection->isHtShortGuardInterval());
+
+EV << "Peer-compatible HT mode selection checks verified.\n";
+
+%contains: stdout
+Peer-compatible HT mode selection checks verified.

--- a/tests/unit/Ieee80211ResponseTimeout_1.test
+++ b/tests/unit/Ieee80211ResponseTimeout_1.test
@@ -1,0 +1,262 @@
+%description:
+Verify the actual non-QoS ACK/CTS, QoS CTS, and QoS BlockAck response-timeout
+policies use SIFS + slot + the selected HT/VHT response PHY RX-start delay.
+The HT/VHT response delay is 24 us, independent of the transmitting mode
+set's reference profile.
+
+%includes:
+#include "inet/linklayer/ieee80211/mac/contract/IQosRateSelection.h"
+#include "inet/linklayer/ieee80211/mac/contract/IRateSelection.h"
+#include "inet/linklayer/ieee80211/mac/originator/OriginatorAckPolicy.h"
+#include "inet/linklayer/ieee80211/mac/originator/OriginatorQosAckPolicy.h"
+#include "inet/linklayer/ieee80211/mac/originator/QosRtsPolicy.h"
+#include "inet/linklayer/ieee80211/mac/originator/RtsPolicy.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+
+using namespace omnetpp;
+using namespace inet;
+using namespace inet::ieee80211;
+using namespace inet::units::values;
+
+namespace Ieee80211ResponseTimeout_1 {
+
+class TestRateSelection : public SimpleModule, public IRateSelection, public IQosRateSelection
+{
+  protected:
+    const physicallayer::IIeee80211Mode *responseMode = nullptr;
+
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_LOCAL) {
+            const auto *modeSet = physicallayer::Ieee80211ModeSet::getModeSet(par("responseModeSet"));
+            responseMode = modeSet->getMode(Mbps(6.5));
+            if (responseMode == nullptr)
+                throw cRuntimeError("Response mode set '%s' has no 6.5 Mbps mode", modeSet->getName());
+        }
+    }
+
+  public:
+    virtual const physicallayer::IIeee80211Mode *computeResponseCtsFrameMode(Packet *packet,
+            const Ptr<const Ieee80211RtsFrame>& rtsFrame) override { return responseMode; }
+    virtual const physicallayer::IIeee80211Mode *computeResponseAckFrameMode(Packet *packet,
+            const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader) override { return responseMode; }
+    virtual const physicallayer::IIeee80211Mode *computeResponseBlockAckFrameMode(Packet *packet,
+            const Ptr<const Ieee80211BlockAckReq>& blockAckReq) override { return responseMode; }
+    virtual const physicallayer::IIeee80211Mode *computeMode(Packet *packet,
+            const Ptr<const Ieee80211MacHeader>& header) override { return responseMode; }
+    virtual const physicallayer::IIeee80211Mode *computeMode(Packet *packet,
+            const Ptr<const Ieee80211MacHeader>& header, TxopProcedure *txopProcedure) override { return responseMode; }
+};
+
+Define_Module(TestRateSelection);
+
+class TestOriginatorAckPolicy : public OriginatorAckPolicy
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_LOCAL) {
+            modeSet = const_cast<physicallayer::Ieee80211ModeSet *>(physicallayer::Ieee80211ModeSet::getModeSet(par("modeSetName")));
+            rateSelection = check_and_cast<IRateSelection *>(getModuleByPath(par("rateSelectionModule")));
+            ackTimeout = -1;
+        }
+    }
+
+  public:
+    simtime_t calculateAckTimeout() const { return getAckTimeout(nullptr, Ptr<const Ieee80211DataOrMgmtHeader>()); }
+};
+
+Define_Module(TestOriginatorAckPolicy);
+
+class TestRtsPolicy : public RtsPolicy
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_LOCAL) {
+            modeSet = const_cast<physicallayer::Ieee80211ModeSet *>(physicallayer::Ieee80211ModeSet::getModeSet(par("modeSetName")));
+            rateSelection = check_and_cast<IRateSelection *>(getModuleByPath(par("rateSelectionModule")));
+            ctsTimeout = -1;
+        }
+    }
+
+  public:
+    simtime_t calculateCtsTimeout() const { return getCtsTimeout(nullptr, Ptr<const Ieee80211RtsFrame>()); }
+};
+
+Define_Module(TestRtsPolicy);
+
+class TestQosRtsPolicy : public QosRtsPolicy
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_LOCAL) {
+            modeSet = const_cast<physicallayer::Ieee80211ModeSet *>(physicallayer::Ieee80211ModeSet::getModeSet(par("modeSetName")));
+            rateSelection = check_and_cast<IQosRateSelection *>(getModuleByPath(par("rateSelectionModule")));
+            ctsTimeout = -1;
+        }
+    }
+
+  public:
+    simtime_t calculateCtsTimeout() const { return getCtsTimeout(nullptr, Ptr<const Ieee80211RtsFrame>()); }
+};
+
+Define_Module(TestQosRtsPolicy);
+
+class TestOriginatorQosAckPolicy : public OriginatorQosAckPolicy
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_LOCAL) {
+            modeSet = const_cast<physicallayer::Ieee80211ModeSet *>(physicallayer::Ieee80211ModeSet::getModeSet(par("modeSetName")));
+            rateSelection = check_and_cast<IQosRateSelection *>(getModuleByPath(par("rateSelectionModule")));
+            ackTimeout = -1;
+            blockAckTimeout = -1;
+        }
+    }
+
+  public:
+    simtime_t calculateAckTimeout() const { return getAckTimeout(nullptr, Ptr<const Ieee80211DataOrMgmtHeader>()); }
+    simtime_t calculateBlockAckTimeout() const { return getBlockAckTimeout(nullptr, Ptr<const Ieee80211BlockAckReq>()); }
+};
+
+Define_Module(TestOriginatorQosAckPolicy);
+
+} // namespace Ieee80211ResponseTimeout_1
+
+%file: TestNetwork.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mac.originator.OriginatorAckPolicy;
+import inet.linklayer.ieee80211.mac.originator.OriginatorQosAckPolicy;
+import inet.linklayer.ieee80211.mac.originator.QosRtsPolicy;
+import inet.linklayer.ieee80211.mac.originator.RtsPolicy;
+
+simple TestRateSelection extends SimpleModule
+{
+    parameters:
+        @class(TestRateSelection);
+        string responseModeSet;
+}
+
+simple TestOriginatorAckPolicy extends OriginatorAckPolicy
+{
+    parameters:
+        @class(TestOriginatorAckPolicy);
+        string modeSetName;
+}
+
+simple TestRtsPolicy extends RtsPolicy
+{
+    parameters:
+        @class(TestRtsPolicy);
+        string modeSetName;
+}
+
+simple TestQosRtsPolicy extends QosRtsPolicy
+{
+    parameters:
+        @class(TestQosRtsPolicy);
+        string modeSetName;
+}
+
+simple TestOriginatorQosAckPolicy extends OriginatorQosAckPolicy
+{
+    parameters:
+        @class(TestOriginatorQosAckPolicy);
+        string modeSetName;
+}
+
+network TestNetwork
+{
+    submodules:
+        test: Test;
+        nRateSelection: TestRateSelection {
+            parameters:
+                responseModeSet = "n(mixed-2.4Ghz)";
+        }
+        acRateSelection: TestRateSelection {
+            parameters:
+                responseModeSet = "ac";
+        }
+        nAck: TestOriginatorAckPolicy {
+            parameters:
+                modeSetName = "n(mixed-2.4Ghz)";
+                rateSelectionModule = "^.nRateSelection";
+        }
+        acAck: TestOriginatorAckPolicy {
+            parameters:
+                modeSetName = "ac";
+                rateSelectionModule = "^.acRateSelection";
+        }
+        nRts: TestRtsPolicy {
+            parameters:
+                modeSetName = "n(mixed-2.4Ghz)";
+                rateSelectionModule = "^.nRateSelection";
+        }
+        acRts: TestRtsPolicy {
+            parameters:
+                modeSetName = "ac";
+                rateSelectionModule = "^.acRateSelection";
+        }
+        nQosRts: TestQosRtsPolicy {
+            parameters:
+                modeSetName = "n(mixed-2.4Ghz)";
+                rateSelectionModule = "^.nRateSelection";
+        }
+        acQosRts: TestQosRtsPolicy {
+            parameters:
+                modeSetName = "ac";
+                rateSelectionModule = "^.acRateSelection";
+        }
+        nQosAck: TestOriginatorQosAckPolicy {
+            parameters:
+                modeSetName = "n(mixed-2.4Ghz)";
+                rateSelectionModule = "^.nRateSelection";
+        }
+        acQosAck: TestOriginatorQosAckPolicy {
+            parameters:
+                modeSetName = "ac";
+                rateSelectionModule = "^.acRateSelection";
+        }
+}
+
+%inifile: omnetpp.ini
+
+[General]
+ned-path = .;../../../../src;../../lib
+network = TestNetwork
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+%activity:
+
+auto nAck = check_and_cast<TestOriginatorAckPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("nAck"));
+auto acAck = check_and_cast<TestOriginatorAckPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("acAck"));
+auto nRts = check_and_cast<TestRtsPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("nRts"));
+auto acRts = check_and_cast<TestRtsPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("acRts"));
+auto nQosRts = check_and_cast<TestQosRtsPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("nQosRts"));
+auto acQosRts = check_and_cast<TestQosRtsPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("acQosRts"));
+auto nQosAck = check_and_cast<TestOriginatorQosAckPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("nQosAck"));
+auto acQosAck = check_and_cast<TestOriginatorQosAckPolicy *>(cSimulation::getActiveSimulation()->getModuleByPath("acQosAck"));
+
+// n uses 10 us SIFS + 20 us slot; ac uses 16 us SIFS + 9 us slot. Both
+// response modes now contribute the standard 24 us PHY RX-start delay.
+ASSERT(nAck->calculateAckTimeout() == SimTime(54, SIMTIME_US));
+ASSERT(acAck->calculateAckTimeout() == SimTime(49, SIMTIME_US));
+ASSERT(nRts->calculateCtsTimeout() == SimTime(54, SIMTIME_US));
+ASSERT(acRts->calculateCtsTimeout() == SimTime(49, SIMTIME_US));
+ASSERT(nQosRts->calculateCtsTimeout() == SimTime(54, SIMTIME_US));
+ASSERT(acQosRts->calculateCtsTimeout() == SimTime(49, SIMTIME_US));
+ASSERT(nQosAck->calculateAckTimeout() == SimTime(54, SIMTIME_US));
+ASSERT(acQosAck->calculateAckTimeout() == SimTime(49, SIMTIME_US));
+ASSERT(nQosAck->calculateBlockAckTimeout() == SimTime(54, SIMTIME_US));
+ASSERT(acQosAck->calculateBlockAckTimeout() == SimTime(49, SIMTIME_US));
+
+EV << "ACK, CTS, QoS CTS, and QoS BlockAck response timeouts use SIFS + slot + 24 us.\n";
+
+%contains: stdout
+ACK, CTS, QoS CTS, and QoS BlockAck response timeouts use SIFS + slot + 24 us.

--- a/tests/unit/Ieee80211SupportedRates_1.test
+++ b/tests/unit/Ieee80211SupportedRates_1.test
@@ -1,6 +1,6 @@
 %description:
-Verify primary Supported Rates lengths, encoded values, basic-rate membership,
-and malformed-element rejection.
+Verify Supported Rates and Extended Supported Rates lengths, basic-rate
+membership, split/merge behavior, and malformed-element rejection.
 
 %includes:
 #include <algorithm>
@@ -10,6 +10,7 @@ and malformed-element rejection.
 #include "inet/common/packet/Packet.h"
 #include "inet/common/packet/chunk/BytesChunk.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 
 using namespace inet;
 using namespace inet::ieee80211;
@@ -117,6 +118,80 @@ catch (const cRuntimeError&) {
 }
 ASSERT(truncatedPrimaryRejected);
 
+// An eight-rate primary element and a five-rate Extended Supported Rates
+// element preserve both rate values and basic membership.
+auto splitFrame = makeResponse(8, SC_SUCCESSFUL, 2007);
+Ieee80211ExtendedSupportedRatesElement extendedRates;
+extendedRates.numRates = 5;
+for (int i = 0; i < 5; i++) {
+    extendedRates.rate[i] = (i + 9) * 0.5;
+    extendedRates.basicRate[i] = i == 1 || i == 4;
+}
+splitFrame->setExtendedSupportedRatesPresent(true);
+splitFrame->setExtendedSupportedRates(extendedRates);
+splitFrame->setChunkLength(B(6) + B(2 + 8) + B(2 + 5));
+auto splitBytes = serializeFrame(splitFrame);
+ASSERT(splitBytes.size() == 23);
+ASSERT(splitBytes[4] == 0x07 && splitBytes[5] == 0xD7);
+ASSERT(splitBytes[16] == 50 && splitBytes[17] == 5);
+for (int i = 0; i < 5; i++)
+    ASSERT(splitBytes[18 + i] == (static_cast<uint8_t>(i + 9) | ((i == 1 || i == 4) ? 0x80 : 0)));
+auto splitDecoded = deserializeFrame<Ieee80211AssociationResponseFrame>(splitBytes);
+ASSERT(splitDecoded->getAid() == 2007);
+ASSERT(splitDecoded->getExtendedSupportedRatesPresent());
+ASSERT(splitDecoded->getExtendedSupportedRates().numRates == 5);
+for (int i = 0; i < 5; i++) {
+    ASSERT(splitDecoded->getExtendedSupportedRates().rate[i] == (i + 9) * 0.5);
+    ASSERT(splitDecoded->getExtendedSupportedRates().basicRate[i] == (i == 1 || i == 4));
+}
+
+auto extendedZero = makeRawResponse(1, {1});
+extendedZero.push_back(50);
+extendedZero.push_back(0);
+bool extendedZeroRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(extendedZero);
+}
+catch (const cRuntimeError&) {
+    extendedZeroRejected = true;
+}
+ASSERT(extendedZeroRejected);
+
+auto extendedTruncated = makeRawResponse(1, {1});
+extendedTruncated.push_back(50);
+extendedTruncated.push_back(2);
+extendedTruncated.push_back(2);
+bool extendedTruncatedRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(extendedTruncated);
+}
+catch (const cRuntimeError&) {
+    extendedTruncatedRejected = true;
+}
+ASSERT(extendedTruncatedRejected);
+
+auto extendedDuplicate = makeRawResponse(1, {1});
+extendedDuplicate.insert(extendedDuplicate.end(), {50, 1, 2, 50, 1, 3});
+bool extendedDuplicateRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(extendedDuplicate);
+}
+catch (const cRuntimeError&) {
+    extendedDuplicateRejected = true;
+}
+ASSERT(extendedDuplicateRejected);
+
+auto primaryDuplicate = makeRawResponse(1, {1});
+primaryDuplicate.insert(primaryDuplicate.end(), {1, 1, 2});
+bool primaryDuplicateRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(primaryDuplicate);
+}
+catch (const cRuntimeError&) {
+    primaryDuplicateRejected = true;
+}
+ASSERT(primaryDuplicateRejected);
+
 // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6 encode legacy rates in 500 kb/s
 // units up to 63.5 Mb/s. HT MCS 7 is 65 Mb/s and remains an HT MCS.
 auto maximumRateFrame = makeResponse(1);
@@ -150,6 +225,70 @@ catch (const cRuntimeError&) {
     unrepresentableRateRejected = true;
 }
 ASSERT(unrepresentableRateRejected);
+
+const double nLegacyRates[] = {1, 2, 5.5, 6, 11, 12, 24};
+const auto *nModeSet = physicallayer::Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+const auto& nLegacyModes = nModeSet->getLegacyOperationalModes();
+ASSERT(nLegacyModes.size() == sizeof(nLegacyRates) / sizeof(nLegacyRates[0]));
+for (size_t i = 0; i < nLegacyModes.size(); i++) {
+    ASSERT(nModeSet->containsMode(nLegacyModes[i]));
+    ASSERT(nLegacyModes[i]->getDataMode()->getNetBitrate().get<Mbps>() == nLegacyRates[i]);
+    ASSERT(nModeSet->getMode(Mbps(nLegacyRates[i])) == nLegacyModes[i]);
+}
+const auto *nPrimaryMode = nModeSet->getMode(Mbps(6.5));
+ASSERT(nModeSet->getReferenceMode() == nPrimaryMode);
+ASSERT(nModeSet->getSifsTime() == nPrimaryMode->getSifsTime());
+ASSERT(nModeSet->getSlotTime() == nPrimaryMode->getSlotTime());
+ASSERT(nModeSet->getPhyRxStartDelay() == nPrimaryMode->getPhyRxStartDelay());
+ASSERT(nModeSet->getCwMin() == nPrimaryMode->getLegacyCwMin());
+ASSERT(nModeSet->getCwMax() == nPrimaryMode->getLegacyCwMax());
+ASSERT(nModeSet->getSlowestMandatoryMode() == nLegacyModes.front());
+ASSERT(nModeSet->getMode(Mbps(65))->getDataMode()->getNetBitrate().get<Mbps>() == 65);
+
+const double aLegacyRates[] = {6, 12, 24, 9, 18, 36, 48, 54};
+const auto *aModeSet = physicallayer::Ieee80211ModeSet::getModeSet("a");
+const auto& aLegacyModes = aModeSet->getLegacyOperationalModes();
+ASSERT(aLegacyModes.size() == sizeof(aLegacyRates) / sizeof(aLegacyRates[0]));
+for (size_t i = 0; i < aLegacyModes.size(); i++) {
+    ASSERT(aModeSet->containsMode(aLegacyModes[i]));
+    ASSERT(aLegacyModes[i]->getDataMode()->getNetBitrate().get<Mbps>() == aLegacyRates[i]);
+}
+
+const double pLegacyRates[] = {3, 6, 12, 4.5, 9, 18, 24, 27};
+const auto *pModeSet = physicallayer::Ieee80211ModeSet::getModeSet("p");
+const auto& pLegacyModes = pModeSet->getLegacyOperationalModes();
+ASSERT(pLegacyModes.size() == sizeof(pLegacyRates) / sizeof(pLegacyRates[0]));
+for (size_t i = 0; i < pLegacyModes.size(); i++) {
+    ASSERT(pModeSet->containsMode(pLegacyModes[i]));
+    ASSERT(pLegacyModes[i]->getDataMode()->getNetBitrate().get<Mbps>() == pLegacyRates[i]);
+}
+
+const double gLegacyRates[] = {1, 2, 5.5, 6, 11, 12, 24, 9, 18, 36, 48, 54};
+const auto *gModeSet = physicallayer::Ieee80211ModeSet::getModeSet("g(mixed)");
+const auto& gLegacyModes = gModeSet->getLegacyOperationalModes();
+ASSERT(gLegacyModes.size() == sizeof(gLegacyRates) / sizeof(gLegacyRates[0]));
+for (size_t i = 0; i < gLegacyModes.size(); i++) {
+    ASSERT(gModeSet->containsMode(gLegacyModes[i]));
+    ASSERT(gLegacyModes[i]->getDataMode()->getNetBitrate().get<Mbps>() == gLegacyRates[i]);
+}
+
+const double acLegacyRates[] = {6, 12, 24};
+const auto *acModeSet = physicallayer::Ieee80211ModeSet::getModeSet("ac");
+const auto& acLegacyModes = acModeSet->getLegacyOperationalModes();
+ASSERT(acLegacyModes.size() == sizeof(acLegacyRates) / sizeof(acLegacyRates[0]));
+for (size_t i = 0; i < acLegacyModes.size(); i++) {
+    ASSERT(acModeSet->containsMode(acLegacyModes[i]));
+    ASSERT(acLegacyModes[i]->getDataMode()->getNetBitrate().get<Mbps>() == acLegacyRates[i]);
+    ASSERT(acModeSet->getMode(Mbps(acLegacyRates[i])) == acLegacyModes[i]);
+}
+const auto *acPrimaryMode = acModeSet->getMode(Mbps(6.5));
+ASSERT(acModeSet->getReferenceMode() == acPrimaryMode);
+ASSERT(acModeSet->getSifsTime() == acPrimaryMode->getSifsTime());
+ASSERT(acModeSet->getSlotTime() == acPrimaryMode->getSlotTime());
+ASSERT(acModeSet->getPhyRxStartDelay() == acPrimaryMode->getPhyRxStartDelay());
+ASSERT(acModeSet->getCwMin() == acPrimaryMode->getLegacyCwMin());
+ASSERT(acModeSet->getCwMax() == acPrimaryMode->getLegacyCwMax());
+ASSERT(acModeSet->getSlowestMandatoryMode() == acLegacyModes.front());
 
 EV << "Supported Rates validation checks passed.\n";
 

--- a/tests/unit/Ieee80211SupportedRates_1.test
+++ b/tests/unit/Ieee80211SupportedRates_1.test
@@ -1,0 +1,157 @@
+%description:
+Verify primary Supported Rates lengths, encoded values, basic-rate membership,
+and malformed-element rejection.
+
+%includes:
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+static Ptr<Ieee80211AssociationResponseFrame> makeResponse(short numRates,
+        Ieee80211StatusCode statusCode = SC_SUCCESSFUL, short aid = 1)
+{
+    auto frame = makeShared<Ieee80211AssociationResponseFrame>();
+    frame->setStatusCode(statusCode);
+    frame->setAid(aid);
+
+    Ieee80211SupportedRatesElement rates;
+    rates.numRates = numRates;
+    for (int i = 0; i < 8; i++) {
+        rates.rate[i] = (i + 1) * 0.5;
+        rates.basicRate[i] = i % 2 == 0;
+    }
+    frame->setSupportedRates(rates);
+    frame->setChunkLength(B(8 + std::max(0, (int)numRates)));
+    return frame;
+}
+
+template<typename Frame>
+static std::vector<uint8_t> serializeFrame(const Ptr<Frame>& frame)
+{
+    Packet packet("response", frame);
+    return packet.peekAllAsBytes()->getBytes();
+}
+
+static std::vector<uint8_t> makeRawResponse(uint16_t wireAid, const std::vector<uint8_t>& rates,
+        uint16_t statusCode = SC_SUCCESSFUL)
+{
+    std::vector<uint8_t> bytes = {
+        0, 0, // Capability
+        static_cast<uint8_t>(statusCode >> 8), static_cast<uint8_t>(statusCode),
+        static_cast<uint8_t>(wireAid >> 8), static_cast<uint8_t>(wireAid),
+        1, static_cast<uint8_t>(rates.size())};
+    bytes.insert(bytes.end(), rates.begin(), rates.end());
+    return bytes;
+}
+
+template<typename Frame>
+static Ptr<const Frame> deserializeFrame(const std::vector<uint8_t>& bytes)
+{
+    Packet packet("response", makeShared<BytesChunk>(bytes));
+    return packet.popAtFront<Frame>(B(bytes.size()));
+}
+
+%activity:
+
+// Primary Supported Rates accepts exactly one through eight octets.
+auto oneRateFrame = makeResponse(1);
+auto oneRateBytes = serializeFrame(oneRateFrame);
+ASSERT(oneRateBytes.size() == 9);
+ASSERT(oneRateBytes[6] == 1 && oneRateBytes[7] == 1);
+ASSERT(oneRateBytes[8] == (0x80 | 1));
+auto oneRateDecoded = deserializeFrame<Ieee80211AssociationResponseFrame>(oneRateBytes);
+ASSERT(oneRateDecoded->getAid() == 1);
+ASSERT(oneRateDecoded->getSupportedRates().numRates == 1);
+ASSERT(oneRateDecoded->getSupportedRates().basicRate[0]);
+
+auto eightRateFrame = makeResponse(8);
+auto eightRateBytes = serializeFrame(eightRateFrame);
+ASSERT(eightRateBytes.size() == 16);
+ASSERT(eightRateBytes[6] == 1 && eightRateBytes[7] == 8);
+for (int i = 0; i < 8; i++)
+    ASSERT(eightRateBytes[8 + i] == (static_cast<uint8_t>(i + 1) | (i % 2 == 0 ? 0x80 : 0)));
+auto eightRateDecoded = deserializeFrame<Ieee80211AssociationResponseFrame>(eightRateBytes);
+ASSERT(eightRateDecoded->getSupportedRates().numRates == 8);
+for (int i = 0; i < 8; i++) {
+    ASSERT(eightRateDecoded->getSupportedRates().rate[i] == (i + 1) * 0.5);
+    ASSERT(eightRateDecoded->getSupportedRates().basicRate[i] == (i % 2 == 0));
+}
+
+auto zeroRateFrame = makeResponse(0);
+bool zeroRateSerializationRejected = false;
+try {
+    serializeFrame(zeroRateFrame);
+}
+catch (const cRuntimeError&) {
+    zeroRateSerializationRejected = true;
+}
+ASSERT(zeroRateSerializationRejected);
+
+auto nineRateRaw = makeRawResponse(1, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+bool nineRateDeserializationRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(nineRateRaw);
+}
+catch (const cRuntimeError&) {
+    nineRateDeserializationRejected = true;
+}
+ASSERT(nineRateDeserializationRejected);
+
+auto truncatedPrimary = makeRawResponse(1, {1});
+truncatedPrimary[7] = 2;
+bool truncatedPrimaryRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(truncatedPrimary);
+}
+catch (const cRuntimeError&) {
+    truncatedPrimaryRejected = true;
+}
+ASSERT(truncatedPrimaryRejected);
+
+// IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6 encode legacy rates in 500 kb/s
+// units up to 63.5 Mb/s. HT MCS 7 is 65 Mb/s and remains an HT MCS.
+auto maximumRateFrame = makeResponse(1);
+auto maximumRates = maximumRateFrame->getSupportedRates();
+maximumRates.rate[0] = 63.5;
+maximumRateFrame->setSupportedRates(maximumRates);
+auto maximumRateBytes = serializeFrame(maximumRateFrame);
+ASSERT(maximumRateBytes[8] == 0xFF);
+auto decodedMaximumRate = deserializeFrame<Ieee80211AssociationResponseFrame>(maximumRateBytes);
+ASSERT(decodedMaximumRate->getSupportedRates().rate[0] == 63.5);
+ASSERT(decodedMaximumRate->getSupportedRates().basicRate[0]);
+
+auto roundedRateFrame = makeResponse(1);
+auto roundedRates = roundedRateFrame->getSupportedRates();
+roundedRates.rate[0] = 2.25;
+roundedRateFrame->setSupportedRates(roundedRates);
+auto roundedRateBytes = serializeFrame(roundedRateFrame);
+ASSERT(roundedRateBytes[8] == 0x85);
+auto decodedRoundedRate = deserializeFrame<Ieee80211AssociationResponseFrame>(roundedRateBytes);
+ASSERT(decodedRoundedRate->getSupportedRates().rate[0] == 2.5);
+
+auto unrepresentableRateFrame = makeResponse(1);
+auto unrepresentableRates = unrepresentableRateFrame->getSupportedRates();
+unrepresentableRates.rate[0] = 65;
+unrepresentableRateFrame->setSupportedRates(unrepresentableRates);
+bool unrepresentableRateRejected = false;
+try {
+    serializeFrame(unrepresentableRateFrame);
+}
+catch (const cRuntimeError&) {
+    unrepresentableRateRejected = true;
+}
+ASSERT(unrepresentableRateRejected);
+
+EV << "Supported Rates validation checks passed.\n";
+
+%contains: stdout
+Supported Rates validation checks passed.

--- a/tests/unit/Ieee80211SupportedRates_1.test
+++ b/tests/unit/Ieee80211SupportedRates_1.test
@@ -1,6 +1,7 @@
 %description:
 Verify Supported Rates and Extended Supported Rates lengths, basic-rate
-membership, split/merge behavior, and malformed-element rejection.
+membership, split/merge behavior, malformed-element rejection, and logical
+Association/Reassociation Response AID encoding.
 
 %includes:
 #include <algorithm>
@@ -32,6 +33,21 @@ static Ptr<Ieee80211AssociationResponseFrame> makeResponse(short numRates,
     }
     frame->setSupportedRates(rates);
     frame->setChunkLength(B(8 + std::max(0, (int)numRates)));
+    return frame;
+}
+
+static Ptr<Ieee80211ReassociationResponseFrame> makeReassociationResponse(short aid,
+        Ieee80211StatusCode statusCode = SC_SUCCESSFUL)
+{
+    auto frame = makeShared<Ieee80211ReassociationResponseFrame>();
+    frame->setStatusCode(statusCode);
+    frame->setAid(aid);
+    Ieee80211SupportedRatesElement rates;
+    rates.numRates = 1;
+    rates.rate[0] = 0.5;
+    rates.basicRate[0] = true;
+    frame->setSupportedRates(rates);
+    frame->setChunkLength(B(9));
     return frame;
 }
 
@@ -67,6 +83,7 @@ static Ptr<const Frame> deserializeFrame(const std::vector<uint8_t>& bytes)
 auto oneRateFrame = makeResponse(1);
 auto oneRateBytes = serializeFrame(oneRateFrame);
 ASSERT(oneRateBytes.size() == 9);
+ASSERT(oneRateBytes[4] == 0xC0 && oneRateBytes[5] == 1);
 ASSERT(oneRateBytes[6] == 1 && oneRateBytes[7] == 1);
 ASSERT(oneRateBytes[8] == (0x80 | 1));
 auto oneRateDecoded = deserializeFrame<Ieee80211AssociationResponseFrame>(oneRateBytes);
@@ -97,7 +114,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(zeroRateSerializationRejected);
 
-auto nineRateRaw = makeRawResponse(1, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+auto nineRateRaw = makeRawResponse(0xC001, {1, 2, 3, 4, 5, 6, 7, 8, 9});
 bool nineRateDeserializationRejected = false;
 try {
     deserializeFrame<Ieee80211AssociationResponseFrame>(nineRateRaw);
@@ -107,7 +124,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(nineRateDeserializationRejected);
 
-auto truncatedPrimary = makeRawResponse(1, {1});
+auto truncatedPrimary = makeRawResponse(0xC001, {1});
 truncatedPrimary[7] = 2;
 bool truncatedPrimaryRejected = false;
 try {
@@ -132,7 +149,7 @@ splitFrame->setExtendedSupportedRates(extendedRates);
 splitFrame->setChunkLength(B(6) + B(2 + 8) + B(2 + 5));
 auto splitBytes = serializeFrame(splitFrame);
 ASSERT(splitBytes.size() == 23);
-ASSERT(splitBytes[4] == 0x07 && splitBytes[5] == 0xD7);
+ASSERT(splitBytes[4] == 0xC7 && splitBytes[5] == 0xD7);
 ASSERT(splitBytes[16] == 50 && splitBytes[17] == 5);
 for (int i = 0; i < 5; i++)
     ASSERT(splitBytes[18 + i] == (static_cast<uint8_t>(i + 9) | ((i == 1 || i == 4) ? 0x80 : 0)));
@@ -145,7 +162,7 @@ for (int i = 0; i < 5; i++) {
     ASSERT(splitDecoded->getExtendedSupportedRates().basicRate[i] == (i == 1 || i == 4));
 }
 
-auto extendedZero = makeRawResponse(1, {1});
+auto extendedZero = makeRawResponse(0xC001, {1});
 extendedZero.push_back(50);
 extendedZero.push_back(0);
 bool extendedZeroRejected = false;
@@ -157,7 +174,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(extendedZeroRejected);
 
-auto extendedTruncated = makeRawResponse(1, {1});
+auto extendedTruncated = makeRawResponse(0xC001, {1});
 extendedTruncated.push_back(50);
 extendedTruncated.push_back(2);
 extendedTruncated.push_back(2);
@@ -170,7 +187,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(extendedTruncatedRejected);
 
-auto extendedDuplicate = makeRawResponse(1, {1});
+auto extendedDuplicate = makeRawResponse(0xC001, {1});
 extendedDuplicate.insert(extendedDuplicate.end(), {50, 1, 2, 50, 1, 3});
 bool extendedDuplicateRejected = false;
 try {
@@ -181,7 +198,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(extendedDuplicateRejected);
 
-auto primaryDuplicate = makeRawResponse(1, {1});
+auto primaryDuplicate = makeRawResponse(0xC001, {1});
 primaryDuplicate.insert(primaryDuplicate.end(), {1, 1, 2});
 bool primaryDuplicateRejected = false;
 try {
@@ -191,6 +208,76 @@ catch (const cRuntimeError&) {
     primaryDuplicateRejected = true;
 }
 ASSERT(primaryDuplicateRejected);
+
+// Successful Association and Reassociation Responses use logical AIDs 1..2007
+// in the model and the marked value on the wire.
+for (short aid : {short(1), short(2007)}) {
+    auto association = makeResponse(1, SC_SUCCESSFUL, aid);
+    auto associationBytes = serializeFrame(association);
+    ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(associationBytes)->getAid() == aid);
+    auto reassociation = makeReassociationResponse(aid);
+    auto reassociationBytes = serializeFrame(reassociation);
+    ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(reassociationBytes)->getAid() == aid);
+}
+
+auto unsuccessful = makeResponse(1, SC_DATARATE_UNSUP, 0);
+auto unsuccessfulBytes = serializeFrame(unsuccessful);
+ASSERT(unsuccessfulBytes[4] == 0 && unsuccessfulBytes[5] == 0);
+ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(unsuccessfulBytes)->getAid() == 0);
+auto unsuccessfulReassociation = makeReassociationResponse(0, SC_DATARATE_UNSUP);
+auto unsuccessfulReassociationBytes = serializeFrame(unsuccessfulReassociation);
+ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(unsuccessfulReassociationBytes)->getAid() == 0);
+
+for (uint16_t invalidWireAid : {uint16_t(1), uint16_t(0x8001), uint16_t(0xC000), uint16_t(0xC7D8)}) {
+    auto invalidWire = makeRawResponse(invalidWireAid, {1});
+    bool rejected = false;
+    try {
+        deserializeFrame<Ieee80211AssociationResponseFrame>(invalidWire);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+    rejected = false;
+    try {
+        deserializeFrame<Ieee80211ReassociationResponseFrame>(invalidWire);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+}
+
+for (short invalidLogicalAid : {short(0), short(2008)}) {
+    auto invalidAssociation = makeResponse(1, SC_SUCCESSFUL, invalidLogicalAid);
+    bool rejected = false;
+    try {
+        serializeFrame(invalidAssociation);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+    auto invalidReassociation = makeReassociationResponse(invalidLogicalAid);
+    rejected = false;
+    try {
+        serializeFrame(invalidReassociation);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+}
+
+auto unsuccessfulWithAid = makeRawResponse(1, {1}, SC_DATARATE_UNSUP);
+bool unsuccessfulAidRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(unsuccessfulWithAid);
+}
+catch (const cRuntimeError&) {
+    unsuccessfulAidRejected = true;
+}
+ASSERT(unsuccessfulAidRejected);
 
 // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6 encode legacy rates in 500 kb/s
 // units up to 63.5 Mb/s. HT MCS 7 is 65 Mb/s and remains an HT MCS.
@@ -290,7 +377,7 @@ ASSERT(acModeSet->getCwMin() == acPrimaryMode->getLegacyCwMin());
 ASSERT(acModeSet->getCwMax() == acPrimaryMode->getLegacyCwMax());
 ASSERT(acModeSet->getSlowestMandatoryMode() == acLegacyModes.front());
 
-EV << "Supported Rates validation checks passed.\n";
+EV << "Supported Rates and AID validation checks passed.\n";
 
 %contains: stdout
-Supported Rates validation checks passed.
+Supported Rates and AID validation checks passed.

--- a/tests/unit/Ieee80211SupportedRates_1.test
+++ b/tests/unit/Ieee80211SupportedRates_1.test
@@ -64,7 +64,7 @@ static std::vector<uint8_t> makeRawResponse(uint16_t wireAid, const std::vector<
     std::vector<uint8_t> bytes = {
         0, 0, // Capability
         static_cast<uint8_t>(statusCode >> 8), static_cast<uint8_t>(statusCode),
-        static_cast<uint8_t>(wireAid >> 8), static_cast<uint8_t>(wireAid),
+        static_cast<uint8_t>(wireAid), static_cast<uint8_t>(wireAid >> 8),
         1, static_cast<uint8_t>(rates.size())};
     bytes.insert(bytes.end(), rates.begin(), rates.end());
     return bytes;
@@ -83,7 +83,7 @@ static Ptr<const Frame> deserializeFrame(const std::vector<uint8_t>& bytes)
 auto oneRateFrame = makeResponse(1);
 auto oneRateBytes = serializeFrame(oneRateFrame);
 ASSERT(oneRateBytes.size() == 9);
-ASSERT(oneRateBytes[4] == 0xC0 && oneRateBytes[5] == 1);
+ASSERT(oneRateBytes[4] == 1 && oneRateBytes[5] == 0xC0);
 ASSERT(oneRateBytes[6] == 1 && oneRateBytes[7] == 1);
 ASSERT(oneRateBytes[8] == (0x80 | 1));
 auto oneRateDecoded = deserializeFrame<Ieee80211AssociationResponseFrame>(oneRateBytes);
@@ -149,7 +149,7 @@ splitFrame->setExtendedSupportedRates(extendedRates);
 splitFrame->setChunkLength(B(6) + B(2 + 8) + B(2 + 5));
 auto splitBytes = serializeFrame(splitFrame);
 ASSERT(splitBytes.size() == 23);
-ASSERT(splitBytes[4] == 0xC7 && splitBytes[5] == 0xD7);
+ASSERT(splitBytes[4] == 0xD7 && splitBytes[5] == 0xC7);
 ASSERT(splitBytes[16] == 50 && splitBytes[17] == 5);
 for (int i = 0; i < 5; i++)
     ASSERT(splitBytes[18 + i] == (static_cast<uint8_t>(i + 9) | ((i == 1 || i == 4) ? 0x80 : 0)));
@@ -209,16 +209,31 @@ catch (const cRuntimeError&) {
 }
 ASSERT(primaryDuplicateRejected);
 
-// Successful Association and Reassociation Responses use logical AIDs 1..2007
-// in the model and the marked value on the wire.
+// IEEE Std 802.11-2024, 9.2.2, 9.3.3.6/Table 9-65,
+// 9.3.3.8/Table 9-67, and 9.4.1.8/Figure 9-146 require the marked
+// multi-octet AID to be transmitted least-significant octet first.
+// Decode independently supplied compliant vectors so a reciprocal
+// serializer/deserializer bug cannot pass.
 for (short aid : {short(1), short(2007)}) {
     auto association = makeResponse(1, SC_SUCCESSFUL, aid);
     auto associationBytes = serializeFrame(association);
+    uint16_t wireAid = static_cast<uint16_t>(0xC000 | aid);
+    ASSERT(associationBytes[4] == static_cast<uint8_t>(wireAid));
+    ASSERT(associationBytes[5] == static_cast<uint8_t>(wireAid >> 8));
     ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(associationBytes)->getAid() == aid);
     auto reassociation = makeReassociationResponse(aid);
     auto reassociationBytes = serializeFrame(reassociation);
+    ASSERT(reassociationBytes[4] == static_cast<uint8_t>(wireAid));
+    ASSERT(reassociationBytes[5] == static_cast<uint8_t>(wireAid >> 8));
     ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(reassociationBytes)->getAid() == aid);
 }
+
+const std::vector<uint8_t> compliantAidOne = {0, 0, 0, 0, 0x01, 0xC0, 1, 1, 1};
+ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(compliantAidOne)->getAid() == 1);
+ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(compliantAidOne)->getAid() == 1);
+const std::vector<uint8_t> compliantAid2007 = {0, 0, 0, 0, 0xD7, 0xC7, 1, 1, 1};
+ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(compliantAid2007)->getAid() == 2007);
+ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(compliantAid2007)->getAid() == 2007);
 
 auto unsuccessful = makeResponse(1, SC_DATARATE_UNSUP, 0);
 auto unsuccessfulBytes = serializeFrame(unsuccessful);

--- a/tests/unit/Ieee80211SupportedRates_1.test
+++ b/tests/unit/Ieee80211SupportedRates_1.test
@@ -377,6 +377,26 @@ ASSERT(acModeSet->getCwMin() == acPrimaryMode->getLegacyCwMin());
 ASSERT(acModeSet->getCwMax() == acPrimaryMode->getLegacyCwMax());
 ASSERT(acModeSet->getSlowestMandatoryMode() == acLegacyModes.front());
 
+// Mode-set timing is anchored to the explicitly configured reference mode.
+// Keep the legacy profiles literal here so a reference-mode change cannot
+// silently alter their established contention behavior.
+auto assertTiming = [](const physicallayer::Ieee80211ModeSet *modeSet,
+        simtime_t sifsTime, simtime_t slotTime, simtime_t phyRxStartDelay,
+        int cwMin, int cwMax) {
+    ASSERT(modeSet->getSifsTime() == sifsTime);
+    ASSERT(modeSet->getSlotTime() == slotTime);
+    ASSERT(modeSet->getPhyRxStartDelay() == phyRxStartDelay);
+    ASSERT(modeSet->getCwMin() == cwMin);
+    ASSERT(modeSet->getCwMax() == cwMax);
+};
+assertTiming(physicallayer::Ieee80211ModeSet::getModeSet("a"), SimTime(16, SIMTIME_US), SimTime(9, SIMTIME_US), SimTime(25, SIMTIME_US), 15, 1023);
+assertTiming(physicallayer::Ieee80211ModeSet::getModeSet("b"), SimTime(10, SIMTIME_US), SimTime(20, SIMTIME_US), SimTime(192, SIMTIME_US), 31, 1023);
+assertTiming(gModeSet, SimTime(10, SIMTIME_US), SimTime(20, SIMTIME_US), SimTime(192, SIMTIME_US), 31, 1023);
+assertTiming(physicallayer::Ieee80211ModeSet::getModeSet("g(erp)"), SimTime(10, SIMTIME_US), SimTime(9, SIMTIME_US), SimTime(25, SIMTIME_US), 15, 1023);
+assertTiming(pModeSet, SimTime(32, SIMTIME_US), SimTime(13, SIMTIME_US), SimTime(49, SIMTIME_US), 15, 1023);
+assertTiming(nModeSet, SimTime(10, SIMTIME_US), SimTime(20, SIMTIME_US), SimTime(24, SIMTIME_US), 15, 1023);
+assertTiming(acModeSet, SimTime(16, SIMTIME_US), SimTime(9, SIMTIME_US), SimTime(24, SIMTIME_US), 15, 1023);
+
 EV << "Supported Rates and AID validation checks passed.\n";
 
 %contains: stdout

--- a/tests/unit/Ieee80211TxopProcedure_1.test
+++ b/tests/unit/Ieee80211TxopProcedure_1.test
@@ -3,6 +3,7 @@ Tests that TxopProcedure reports the remaining time until the TXOP limit.
 
 %includes:
 #include "inet/linklayer/ieee80211/mac/originator/TxopProcedure.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 
 using namespace omnetpp;
 using namespace inet;
@@ -12,6 +13,22 @@ namespace Ieee80211TxopProcedure_1 {
 
 class TestTxopProcedure : public TxopProcedure
 {
+  public:
+    void setModeSet(const char *name)
+    {
+        modeSet = const_cast<physicallayer::Ieee80211ModeSet *>(physicallayer::Ieee80211ModeSet::getModeSet(name));
+    }
+
+    void resetTxopLimit()
+    {
+        limit = -1;
+    }
+
+    void setTxopLimit(simtime_t value)
+    {
+        limit = value;
+    }
+
   protected:
     virtual void initialize(int stage) override
     {
@@ -51,7 +68,7 @@ network = TestNetwork
 
 %activity:
 
-auto txop = check_and_cast<TxopProcedure *>(cSimulation::getActiveSimulation()->getModuleByPath("txop"));
+auto txop = check_and_cast<TestTxopProcedure *>(cSimulation::getActiveSimulation()->getModuleByPath("txop"));
 
 auto getRemainingThrows = [txop]() {
     try {
@@ -65,6 +82,39 @@ auto getRemainingThrows = [txop]() {
 
 ASSERT(getRemainingThrows());
 
+auto checkDefaultLimits = [txop](const char *modeSetName, simtime_t viLimit, simtime_t voLimit) {
+    txop->setModeSet(modeSetName);
+
+    txop->resetTxopLimit();
+    txop->startTxop(AC_BK);
+    ASSERT(txop->getLimit() == SIMTIME_ZERO);
+    txop->endTxop();
+
+    txop->resetTxopLimit();
+    txop->startTxop(AC_BE);
+    ASSERT(txop->getLimit() == SIMTIME_ZERO);
+    txop->endTxop();
+
+    txop->resetTxopLimit();
+    txop->startTxop(AC_VI);
+    ASSERT(txop->getLimit() == viLimit);
+    txop->endTxop();
+
+    txop->resetTxopLimit();
+    txop->startTxop(AC_VO);
+    ASSERT(txop->getLimit() == voLimit);
+    txop->endTxop();
+};
+
+checkDefaultLimits("a", SimTime(3008, SIMTIME_US), SimTime(1504, SIMTIME_US));
+checkDefaultLimits("b", SimTime(6016, SIMTIME_US), SimTime(3264, SIMTIME_US));
+checkDefaultLimits("g(mixed)", SimTime(3008, SIMTIME_US), SimTime(1504, SIMTIME_US));
+checkDefaultLimits("g(erp)", SimTime(3008, SIMTIME_US), SimTime(1504, SIMTIME_US));
+checkDefaultLimits("p", SimTime(3008, SIMTIME_US), SimTime(1504, SIMTIME_US));
+checkDefaultLimits("n(mixed-2.4Ghz)", SimTime(3008, SIMTIME_US), SimTime(1504, SIMTIME_US));
+checkDefaultLimits("ac", SimTime(3008, SIMTIME_US), SimTime(1504, SIMTIME_US));
+
+txop->setTxopLimit(SimTime(10, SIMTIME_MS));
 txop->startTxop(AC_VI);
 ASSERT(txop->getRemaining() == SimTime(10, SIMTIME_MS));
 


### PR DESCRIPTION
## Summary

This PR adds IEEE 802.11 HT capability/operation signalling and hardens the surrounding management and association workflows.

- Preserve typed management-frame deserialization and add typed HT Capabilities/HT Operation serialization, validation, and printing.
- Model local, advertised, negotiated, and peer HT state with exact channel-width and sparse-MCS derivation.
- Advertise and negotiate HT capabilities during beacon, probe, association, and reassociation exchanges.
- Correct Supported Rates, basic-rate membership, Extended Supported Rates, and mode-set timing handling.
- Make AID allocation and AP association-response completion transactional, including retry exhaustion, failure cleanup, and recovery.
- Harden detailed and simplified association/reassociation lifecycle handling across duplicates, timeouts, teardown, restart, and stale completions.
- Preserve transaction metadata through fragmentation while removing it at the PHY receive boundary.
- Add focused IEEE 802.11 unit and module test coverage.

## Validation

- Debug build passed: `make MODE=debug -j$(nproc)`
- 9 focused unit tests passed.
- 4 focused module tests passed, including live AP retry-limit exhaustion and recovery.
- `git diff --check` passed.
- No fingerprint or statistical baselines were changed.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->