### PR TITLE
ModuleMixin: export the internal helpers from the library

### DIFF
--- a/src/inet/common/ModuleMixin.cc
+++ b/src/inet/common/ModuleMixin.cc
@@ -36,7 +36,7 @@ class cCollectObjectsVisitor : public cVisitor
 
 namespace internal {
 
-void refreshDisplayString(cModule *thisModule, const StringFormat::IResolver *thisModuleAsResolver)
+INET_API void refreshDisplayString(cModule *thisModule, const StringFormat::IResolver *thisModuleAsResolver)
 {
     if (thisModule->hasPar("displayStringTextFormat")) {
         try {
@@ -53,7 +53,7 @@ void refreshDisplayString(cModule *thisModule, const StringFormat::IResolver *th
     }
 }
 
-std::string doResolveExpression(cModule *thisModule, const char *expression)
+INET_API std::string doResolveExpression(cModule *thisModule, const char *expression)
 {
     const char *lastDot = strrchr(expression, '.');
 

--- a/src/inet/common/ModuleMixin.h
+++ b/src/inet/common/ModuleMixin.h
@@ -17,8 +17,8 @@
 namespace inet {
 
 namespace internal {
-void refreshDisplayString(cModule *thisModule, const StringFormat::IResolver *thisModuleAsResolver);
-std::string doResolveExpression(cModule *targetModule, const char *expression);
+INET_API void refreshDisplayString(cModule *thisModule, const StringFormat::IResolver *thisModuleAsResolver);
+INET_API std::string doResolveExpression(cModule *targetModule, const char *expression);
 }
 
 /**


### PR DESCRIPTION
Two helpers in `namespace internal` are used by the `ModuleMixin<T>` class template but are not exported from the library, so code outside INET that derives from an INET module class does not link on Windows. This marks both the declarations and the definitions with `INET_API`.

Architectural surface: none. No contract, packet content, configuration parameter, NED interface or feature descriptor changes. The change affects symbol visibility only; behavior inside INET is unchanged, since those calls already resolved locally.

Tests: the INET test suite was not run, as the change cannot alter simulation behavior. Verified by build and link on Windows with INET 4.7.0 and OMNeT++ 6.3.0: before the change an external project that derives from an INET module class fails with the two undefined symbols; after rebuilding the library the same project links and its simulation runs. Not verified on Linux, where the default symbol visibility would plausibly hide the problem.

Fixes #1137
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->