### PR TITLE
architecture: define behavioral signal notification contracts

### DIFF
--- a/doc/project/audit/seal-list.md
+++ b/doc/project/audit/seal-list.md
@@ -70,7 +70,7 @@ section indexes them so the registry stays one place to look.
 | --- | --- | ---: | ---: | ---: |
 | `audit/architecture-exceptions.md` | by row | 0 | 0 | 0 |
 | `audit/naming-exceptions.md` | by row | 0 | 0 | 0 |
-| `design/decisions.md` | by decision | 0 | 0 | 17 |
+| `design/decisions.md` | by decision | 0 | 0 | 18 |
 | `design/node-anatomy.md` | by section | 0 | 0 | 6 |
 | `design/packet-anatomy.md` | by section | 0 | 0 | 5 |
 | `design/protocol-anatomy.md` | by section | 0 | 0 | 5 |
@@ -78,7 +78,7 @@ section indexes them so the registry stays one place to look.
 | `design/test-anatomy.md` | by section | 0 | 0 | 5 |
 | `domain/ieee80211.md` | by rule | 0 | 0 | 14 |
 | `requirement/accepted-requirements.md` | by requirement, complete | 0 | 27 | 0 |
-| `rule/architecture.md` | by rule | 0 | 0 | 40 |
+| `rule/architecture.md` | by rule | 0 | 0 | 41 |
 | `rule/documentation.md` | whole | 0 | 0 | 1 |
 | `rule/naming.md` | by rule | 0 | 0 | 23 |
 | `rule/pull-request.md` | by rule | 0 | 0 | 20 |

--- a/doc/project/design/decisions.md
+++ b/doc/project/design/decisions.md
@@ -45,7 +45,8 @@ Every decision in document order. The identifier links to the decision; the stat
 | [D-SIGNAL](#d-signal) | A physical transmission is a Signal, distinct from the packet it carries |
 | [D-REGISTRY](#d-registry) | Peers are addressed by protocol and service, not by wiring |
 | [D-SOCKETS](#d-sockets) | Applications talk to transports through socket-style APIs |
-| [D-DIRECT](#d-direct) | Same-instant, same-node coordination is a direct C++ call |
+| [D-DIRECT](#d-direct) | Required same-instant, same-node coordination is a direct C++ call |
+| [D-NOTIFY](#d-notify) | Signals publish completed facts to independent consumers |
 | [D-QUEUEING](#d-queueing) | A datapath is a chain of push and pull elements |
 | [D-FIDELITY](#d-fidelity) | One concern is offered at several levels of detail, in one contractual slot |
 | [D-OBSERVE](#d-observe) | Observation is one way: the model emits, the observer subscribes |
@@ -193,16 +194,36 @@ messages.** The socket owns the message shapes.
 
 ### D-DIRECT
 
-**Same-instant, same-node coordination is a direct C++ call**
+**Required same-instant, same-node coordination is a direct C++ call**
 
-**Two submodules of one node that must agree at one instant call each other; they do not exchange a
-zero-time message.** A message means an event, and an event means time passes or the medium is
-crossed.
+**When one submodule requires another to perform a command or answer a query at the same instant,
+they interact through a typed C++ call; they do not exchange a zero-time message.** The caller names
+the required peer and the interaction has a defined completion. Announcing a completed fact to
+independent consumers instead follows [D-NOTIFY](#d-notify).
 
 - *Serves* `R-RUN-REPRO`, and the quality of every event trace and fingerprint.
 - *Costs* a compile-time coupling where a message would have been anonymous, and the loss of that
   interaction from the event log.
 - *Kept true by* [AR-COM-DIRECT](../rule/architecture.md#ar-com-direct).
+
+### D-NOTIFY
+
+**Signals publish completed facts to independent consumers**
+
+**A module announces a completed occurrence or state change with a declared signal when zero or more
+decoupled consumers may react synchronously without a reply or dependence on their relative
+invocation order.** A behavioral listener may drive its own reaction through the ordinary model
+contracts; recording, visualization and analysis remain passive observers under
+[D-OBSERVE](#d-observe).
+
+- *Serves* `R-COMPOSE-NODES`, `R-SCOPE-CROSSCUT`. Independently authored behavior can attach without
+  making the publisher know its consumers.
+- *Costs* a relationship that is weaker at compile time and harder to follow than a direct call.
+  Signal names are global, subscription scope is hierarchical, pointer-payload lifetime must be
+  known, and invocation order among listeners to one emission is undefined; behavior that needs
+  stronger guarantees must use another contract.
+- *Kept true by* [AR-COM-NOTIFY](../rule/architecture.md#ar-com-notify),
+  [AR-OBS-NED-TRUTH](../rule/architecture.md#ar-obs-ned-truth).
 
 ### D-QUEUEING
 
@@ -237,6 +258,8 @@ study chooses in configuration.** A large scenario buys abstraction; a focused s
 
 **A model declares signals and emits them; recording, visualization and analysis subscribe from
 outside and never call back in.** Visualization and instrumentation live in their own packages.
+Behavioral listeners are a separate role governed by [D-NOTIFY](#d-notify); adding or removing an
+observer cannot alter them or the modeled result.
 
 - *Serves* `R-VIS-NEUTRAL`, `R-RESULT-BUILTIN`, `R-RUN-REPRO`. Turning observation on cannot change
   the result.
@@ -309,12 +332,13 @@ transformation. The emergent property is *evidentiary continuity*: a field inspe
 serialized into a capture, processed by the PHY, and attributed to a flow is one representation
 throughout, so analysis tooling cannot report something the model did not actually represent.
 
-**Composable but causally explicit behavior.** AR-COM-DIRECT, AR-LIFE-STAGES, AR-LIFE-OPERATIONS,
-AR-QUEUE-ROLES, and AR-QUEUE-STREAMING each put internal cooperation at its right semantic level:
-direct calls for same-instant coordination, scheduled messages for genuine events, stages for
-initialization order, queueing contracts for datapath transfer. The result is an event trajectory
-that corresponds to modeled behavior rather than implementation plumbing — which is what makes
-debugging, performance, and fingerprint signal quality good at the same time.
+**Composable but causally explicit behavior.** AR-COM-DIRECT, AR-COM-NOTIFY, AR-LIFE-STAGES,
+AR-LIFE-OPERATIONS, AR-QUEUE-ROLES, and AR-QUEUE-STREAMING each put internal cooperation at its right
+semantic level: direct calls for required same-instant commands and queries, declared signals for
+synchronous listener-order-independent notifications, scheduled messages for genuine events,
+stages for initialization order, and queueing contracts for datapath transfer. The result is an event
+trajectory that corresponds to modeled behavior rather than implementation plumbing — which is
+what makes debugging, performance, and fingerprint signal quality good at the same time.
 
 **Observability without observer effects.** AR-ORG-VIS-SPLIT, AR-OBS-SIGNALS, AR-OBS-NED-TRUTH, and
 AR-OBS-INTROSPECTION establish a one-way path: model owner → declared signal → recorder, visualizer,
@@ -343,4 +367,3 @@ same extension, observation, testing, configuration, and build paths instead of 
 path through the core. The architecture has a rising initial discipline cost and a falling marginal
 integration cost — without it, every new feature looks locally simple while adding one more special
 case to dispatch, inspection, build selection, and tests.
-

--- a/doc/project/design/node-anatomy.md
+++ b/doc/project/design/node-anatomy.md
@@ -44,7 +44,8 @@ not rewire the node, and a module written for one node layout works in another â
 | --- | --- |
 | the packet, with its content | a pointer to a sibling module |
 | tags, which are how a layer asks and answers | a path into another node's tree |
-| a direct call, for same-instant coordination inside the node ([D-DIRECT](decisions.md#d-direct)) | a zero-time message standing in for that call |
+| a direct typed call, for a required same-instant command or query ([D-DIRECT](decisions.md#d-direct)) | a zero-time message standing in for that call |
+| a declared signal, for a completed fact announced to independent listeners ([D-NOTIFY](decisions.md#d-notify)) | a signal used as a command, query or listener-ordered coordination |
 
 ## The aspects that attach to any node
 

--- a/doc/project/design/protocol-anatomy.md
+++ b/doc/project/design/protocol-anatomy.md
@@ -55,10 +55,12 @@ clause instead of against intuition, which is the only way a protocol model can 
 
 ## What it emits
 
-A protocol declares signals and statistics in NED, and emits them. It does not record, draw or
-aggregate: an observer subscribes from outside ([D-OBSERVE](decisions.md#d-observe)). This is what
-makes turning observation on free of any effect on the result
-([R-VIS-NEUTRAL](../requirement/accepted-requirements.md#r-vis-neutral)).
+A protocol declares signals and statistics in NED and emits each fact at the state transition that
+owns it. A declared signal may notify behavioral consumers when it satisfies
+[D-NOTIFY](decisions.md#d-notify). Recording, visualization and analysis remain external observers:
+the protocol does not record, draw or aggregate, and attaching an observer has no effect on the
+result ([D-OBSERVE](decisions.md#d-observe),
+[R-VIS-NEUTRAL](../requirement/accepted-requirements.md#r-vis-neutral)).
 
 ## Fidelity
 

--- a/doc/project/design/rejected-designs.md
+++ b/doc/project/design/rejected-designs.md
@@ -46,21 +46,24 @@ Every rejected design in document order.
 
 **A zero-time message for same-instant coordination inside a node**
 
-**The option.** Two submodules of one node that must agree at one instant exchange a message with
-zero delay, instead of calling each other. Everything is then a message, the module boundary stays
-anonymous, and the interaction shows up in the event log for free.
+**The option.** Two submodules of one node that interact at one instant exchange a message with zero
+delay, instead of using a typed call for a required interaction or a signal for an independent
+notification. Everything is then a message, the module boundary stays anonymous, and the
+interaction shows up in the event log for free.
 
 **What it would buy.** One interaction mechanism instead of two, no compile-time coupling between
 sibling submodules, and a uniform trace.
 
 **Why it lost.** An event stops meaning what it means. The event log, the sequence chart and the
 fingerprint all rest on the reading that an event is *something that happened in the model*; when
-half the events are procedure calls in disguise, the trajectory describes the implementation instead
-of the behavior, and the fingerprint's signal quality falls with it. The zero-delay message also
-hides the causal order inside one instant, which is exactly the order a debugging session needs.
+half the events are procedure calls or notifications in disguise, the trajectory describes the
+implementation instead of the behavior, and the fingerprint's signal quality falls with it. A
+required command or query has a typed peer under [D-DIRECT](decisions.md#d-direct); an
+order-independent announcement has no scheduler event under [D-NOTIFY](decisions.md#d-notify).
 
-*Beaten by* [D-DIRECT](decisions.md#d-direct),
-kept in force by [AR-COM-DIRECT](../rule/architecture.md#ar-com-direct).
+*Beaten by* [D-DIRECT](decisions.md#d-direct) and [D-NOTIFY](decisions.md#d-notify),
+kept in force by [AR-COM-DIRECT](../rule/architecture.md#ar-com-direct) and
+[AR-COM-NOTIFY](../rule/architecture.md#ar-com-notify).
 
 ### REJ-02
 

--- a/doc/project/enforcement/checklist/general.md
+++ b/doc/project/enforcement/checklist/general.md
@@ -50,10 +50,26 @@ responsibilities. *Not a violation:* extending a `*Base` for genuine shared mach
 FLAG an app that hand-rolls command/indication messages instead of using `UdpSocket`/`TcpSocket`/peer.
 *Not a violation:* a new protocol implementing the socket-facing side.
 
-**[AR-COM-DIRECT] Is a zero-time message standing in for a direct call?**
-FLAG `scheduleAt(simTime(), …)` or a zero-delay `send()` used for same-instant, same-node coordination
-between sibling submodules. *Not a violation:* a message that advances simulation time or crosses the
-medium.
+**[AR-COM-DIRECT] Is a zero-time message standing in for a required direct call?**
+FLAG `scheduleAt(simTime(), …)` or a zero-delay `send()` used for a same-instant command, query,
+return value or required handshake between sibling submodules. *Not a violation:* a message that
+represents a modeled delivery or explicit event boundary, including at the same simulation time; a
+message that crosses the medium; or a fire-and-forget signal that satisfies AR-COM-NOTIFY.
+
+**[AR-COM-NOTIFY] Is a behavior-driving signal really an independent notification?**
+FLAG a publisher that depends on a particular listener, reply or relative invocation order among
+listeners; a signal used for ownership transfer, buffering, modeled delay or listener-ordered
+coordination; emission before the publisher restores its invariants; a behavioral module listener
+that omits `Enter_Method`/`Enter_Method_Silent`, retains a pointer beyond its declared lifetime,
+mutates a borrowed payload, or modifies the currently firing subscription list; or a broad ancestor
+subscription that fails to filter unrelated sources. *Not a violation:* an independent consumer
+reacting synchronously to completed facts in emission order without participating in the
+publisher's operation.
+
+**[AR-OBS-SIGNALS] Can attaching an observer change modeled behavior?**
+FLAG a recorder, visualizer or analyzer that mutates modeled state, schedules a modeled action, or
+calls back into the producer. *Not a violation:* a separate behavioral listener that satisfies
+AR-COM-NOTIFY, even when it consumes a signal that is also recorded or visualized.
 
 **[AR-OBS-NED-TRUTH] Does prose/code duplicate what a NED declaration owns?**
 FLAG doc text that restates parameters/gates/signals/statistics already in NED, or C++ that hardcodes a

--- a/doc/project/rule/architecture.md
+++ b/doc/project/rule/architecture.md
@@ -67,7 +67,8 @@ Every rule in document order. The identifier links to the rule; the statement is
 | [AR-COM-REGISTRY](#ar-com-registry) | Modules declare the protocols and services they provide in a global registry |
 | [AR-COM-DISPATCH](#ar-com-dispatch) | Address peers by protocol/service, not by wiring topology |
 | [AR-COM-SOCKETS](#ar-com-sockets) | Applications use socket-style callback APIs, not raw message exchange |
-| [AR-COM-DIRECT](#ar-com-direct) | Same-instant, same-node coordination uses direct C++ calls, not zero-time messages |
+| [AR-COM-DIRECT](#ar-com-direct) | Required same-instant, same-node coordination uses direct typed calls, not zero-time messages |
+| [AR-COM-NOTIFY](#ar-com-notify) | Behavior-driving signals publish completed facts, not commands or listener-ordered coordination |
 
 **Initialization & Lifecycle (AR-LIFE)**
 
@@ -445,25 +446,51 @@ protocol behavior but makes the common case of *using* a protocol far simpler an
 
 ### AR-COM-DIRECT
 
-**Same-instant, same-node coordination uses direct C++ calls, not zero-time messages**
+**Required same-instant, same-node coordination uses direct typed calls, not zero-time messages**
 
-Coordination between submodules of the same node that happens at the same simulation instant is
-expressed as direct, typed C++ calls, not as messages sent with zero delay.
+When one submodule requires another to perform a command or answer a query at the same simulation
+instant, the interaction is expressed as a direct, typed C++ call, not as a message sent with zero
+delay.
 
-Message passing models communication that takes simulation time or crosses the physical medium;
-using `send()` or `scheduleAt(simTime())` for control flow that occurs at the same instant between
-sibling submodules is a category error that inflates the event count, obscures causality, and
-forces even trivial passthroughs to carry message classes and dispatch code they do not need. For
-same-instant intra-node coordination INET uses direct calls through typed references and the
-service/socket and queueing APIs, with `Enter_Method` establishing the correct module context,
-reserving genuine events for things that actually advance simulation time. This keeps the event
-trajectory meaningful — each event corresponds to something that "happens" in the network — so
-that fingerprints reflect real behavior rather than internal plumbing, and it avoids the
-boilerplate of turning a direct call into a round-trip through the scheduler.
-
-## Initialization & Lifecycle (AR-LIFE)
+Message passing models an interaction whose delivery is itself a simulator event, whether because
+time passes, the physical medium is crossed, or an explicit event boundary matters. Using `send()`
+or `scheduleAt(simTime())` merely to disguise same-instant control flow between sibling submodules
+is a category error that inflates the event count, obscures causality, and forces even trivial
+passthroughs to carry message classes and dispatch code they do not need. For required same-instant
+intra-node coordination INET uses direct calls through typed references and the service/socket and
+queueing APIs, with `Enter_Method` establishing the correct module context. A fire-and-forget
+announcement of a completed fact to independent consumers follows AR-COM-NOTIFY. This separation
+reserves scheduler events for modeled deliveries and event boundaries, keeps the event trajectory
+meaningful, and avoids turning procedure calls into scheduler plumbing.
 
 *Enforced at T3+T4 — lint for `scheduleAt(simTime())`/zero-delay send + agent review; runtime zero-delay hook (T2).*
+
+### AR-COM-NOTIFY
+
+**Behavior-driving signals publish completed facts, not commands or listener-ordered coordination**
+
+A module may emit a declared signal to announce a completed occurrence or state change to zero or
+more independent consumers. Emission is synchronous and fire-and-forget: the publisher restores its
+own invariants before `emit()`, completes its operation without requiring a particular listener,
+reply or acknowledgement, and does not transfer ownership. A behavioral listener may drive its own
+reaction through the ordinary model contracts; when that listener is a module, it establishes its
+module context with `Enter_Method` or `Enter_Method_Silent`. It treats object and details payloads
+as borrowed and immutable, does not retain them beyond the callback unless the declared contract
+guarantees a longer lifetime, and does not depend on its position in the listener invocation order
+or on replay. Successive emissions retain normal simulator causality and may form an ordered stream
+of facts.
+
+The signal name and payload type are declared in NED, and the subscription source, scope and
+lifecycle are explicit in configuration or initialization. Because names are global and signals
+propagate through the module hierarchy, a listener subscribes at the narrowest useful scope and
+filters the source wherever unrelated emitters can merge. A command, query, return value, required
+handshake, ownership transfer, buffering, modeled delay, or coordination whose correctness depends
+on relative invocation order among consumers uses a typed direct or service API, or messages and
+gates when it belongs to the simulated event trajectory.
+
+*Enforced at T1/T2+T4 — NED signal/type checking + kernel listener-list checks + agent review of notification semantics.*
+
+## Initialization & Lifecycle (AR-LIFE)
 
 ### AR-LIFE-STAGES
 
@@ -555,6 +582,10 @@ producer of an event is decoupled from every consumer of it, so adding a new sta
 visualizer requires no change to the protocol, and — crucially — the act of observing is guaranteed
 not to perturb the simulation. This one-way, subscribe-from-outside discipline is the mechanism
 behind both AR-ORG-VIS-SPLIT and the user-facing neutrality guarantee.
+
+This rule governs observational consumers. The same declared signal may also have behavioral
+listeners under AR-COM-NOTIFY, but attaching or removing a recorder, visualizer or analyzer must not
+alter those listeners or any modeled state transition.
 
 *Enforced at T1/T2 — NED `@signal`/`@statistic` (compiler) + fingerprint neutrality.*
 
@@ -897,4 +928,3 @@ judgment (is a fidelity level worth adding?) to a human. Which gate covers which
 inventory of [enforcement/README.md](../enforcement/README.md).
 
 *Enforced at T3 — the gate inventory itself; measured by how many rules above reach T1 to T4.*
-


### PR DESCRIPTION
## Summary

Define the behavioral signal notification contract (`AR-COM-NOTIFY` / `D-COM-NOTIFY`) within the INET architecture rules, design decisions, and review checklists.

- Define signal publication as an announcement of a completed fact to zero or more independent consumers requiring no reply, acknowledgement, or listener ordering.
- Require publishers to restore invariants before `emit()`, listeners to establish module context via `Enter_Method` / `Enter_Method_Silent`, and object payloads to remain borrowed and immutable.
- Define constraints on subscription scope, source filtering, ownership transfer, buffering, and modeled delays.
- Clarify the boundary between direct typed calls (`AR-COM-DIRECT`) for required same-instant commands/queries and messages/gates for simulated event delivery.
- Align `doc/project/rule/architecture.md`, `doc/project/design/decisions.md`, `doc/project/design/node-anatomy.md`, `doc/project/design/protocol-anatomy.md`, `doc/project/design/rejected-designs.md`, `doc/project/enforcement/checklist/general.md`, and `doc/project/audit/seal-list.md`.

## Architectural Surface

- **Rules**: Added `AR-COM-NOTIFY` and clarified `AR-COM-DIRECT`, `AR-OBS-SIGNALS` in `doc/project/rule/architecture.md`.
- **Design Decisions**: Added `D-COM-NOTIFY` in `doc/project/design/decisions.md` and updated `doc/project/design/rejected-designs.md`, `doc/project/design/node-anatomy.md`, `doc/project/design/protocol-anatomy.md`.
- **Enforcement & Audit**: Added review check for `AR-COM-NOTIFY` in `doc/project/enforcement/checklist/general.md` and updated registry counts in `doc/project/audit/seal-list.md`.

## Validation

- **Build**: `make -j$(nproc) MODE=debug` (pass)
- **Commit gate**: `doc/project/enforcement/check-commits.sh upstream/master..HEAD` (pass)
- **Seals gate**: `doc/project/enforcement/check-seals.sh` (pass)
- **Links gate**: `doc/project/enforcement/check-links.sh` (pass: 43 files, 0 broken links)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->