### PR TITLE
ipv6: source a Router Solicitation from the link-local address during Duplicate Address Detection

### DIFF
--- a/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
+++ b/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
@@ -1010,10 +1010,17 @@ void Ipv6NeighbourDiscovery::createAndSendRsPacket(NetworkInterface *ie)
     // or the unspecified address.
     Ipv6Address myIPv6Address = ie->getProtocolData<Ipv6InterfaceData>()->getPreferredAddress();
 
-    if (myIPv6Address.isUnspecified())
-        myIPv6Address = ie->getProtocolData<Ipv6InterfaceData>()->getLinkLocalAddress(); // so we use the link local address instead
+    // getPreferredAddress() returns the default source address for off-link destinations,
+    // and deliberately prefers a global address even while Duplicate Address Detection (DAD)
+    // is still running for it. A solicitation only has to reach the link-local all-routers
+    // multicast address, so fall back to the link-local address rather than straight to the
+    // unspecified address: a tentative address is not assigned to the interface yet
+    // (RFC 4862 Section 5.4), and Ipv6 would substitute it on transmission, releasing the
+    // solicitation with a source address that contradicts the option chosen below.
+    if (myIPv6Address.isUnspecified() || ie->getProtocolData<Ipv6InterfaceData>()->isTentativeAddress(myIPv6Address))
+        myIPv6Address = ie->getProtocolData<Ipv6InterfaceData>()->getLinkLocalAddress();
 
-    if (ie->getProtocolData<Ipv6InterfaceData>()->isTentativeAddress(myIPv6Address))
+    if (myIPv6Address.isUnspecified() || ie->getProtocolData<Ipv6InterfaceData>()->isTentativeAddress(myIPv6Address))
         myIPv6Address = Ipv6Address::UNSPECIFIED_ADDRESS;
 
     Ipv6Address destAddr = Ipv6Address::ALL_ROUTERS_2; // all_routers multicast

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -380,9 +380,9 @@
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c MultiRadio -r 0,             20s,             ec17-5cc2/tplx;55f5-0894/~tNl, PASS,  wireless adhoc Ipv4
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c SingleRadio -r 0,            20s,             85a0-51b8/tplx;c07a-44e1/~tNl;3aa0-49ed/tyf, PASS,  wireless adhoc Ipv4
 
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             19b8-20a4/tplx;b378-071d/~tNl;d358-e3bb/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             3f0c-078d/tplx;04e1-1f03/~tNl;4199-2b15/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             0798-40c2/tplx;a682-8d0e/~tNl;cdb7-1b34/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             43f0-699e/tplx;ff9a-8dbc/~tNl;9304-d5d5/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             b457-5c37/tplx;4038-4ba8/~tNl;d2a0-90db/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             5272-c850/tplx;1d99-c152/~tNl;9ca1-b5ff/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
 /examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             f614-da0d/tplx;8b55-7191/~tNl;b490-dc09/~tND;0277-d784/tyf, PASS, wireless EthernetMac
 
 /examples/mobility/,                 -f omnetpp.ini -c AnsimMobility -r 0,          10000s,          72f8-5c0b/tplx;0000-0000/~tNl;0000-0000/~tND;7dd1-18eb/tyf, PASS,

--- a/tests/fingerprint/mipv6-refactoring.csv
+++ b/tests/fingerprint/mipv6-refactoring.csv
@@ -8,9 +8,9 @@
 # empty-shim step, which kept these fingerprints bit-for-bit identical.
 
 # MIPv6 example — the primary test
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            aa29-a8c5/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            068b-23aa/~tNlb, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            7ed8-bee3/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,            9489-e81a/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,            f670-714f/~tNlb, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,            05e6-93d0/~tNlb, PASS, wireless EthernetMac
 
 # IPv6 examples
 # MLD example — new PASS row; ~tNl locks the MLD Report/Query/Done/MAS-Query packet exchange (traffic+lengths);

--- a/tests/module/Ipv6RouterSolicitation_SourceLinkLayerAddressOption.test
+++ b/tests/module/Ipv6RouterSolicitation_SourceLinkLayerAddressOption.test
@@ -1,0 +1,75 @@
+%description:
+Tests that a Router Solicitation whose IP source address is a real (not
+unspecified) address carries the Source Link-Layer Address option, even when
+Duplicate Address Detection (DAD) is still running for the host's global
+address at the moment the solicitation is sent.
+
+RFC 4861 Section 6.3.7: "A host sends Router Solicitations to the all-routers
+multicast address.  The IP source address is set to either one of the
+interface's unicast addresses or the unspecified address.  The Source
+Link-Layer Address option SHOULD be set to the host's link-layer address, if
+the IP source address is not the unspecified address."
+
+The router logs the link-layer address it extracts from each solicitation, so
+a missing option shows up as an all-zero MAC address.
+
+%#--------------------------------------------------------------------------------------------------------------
+%file: test.ned
+import inet.networklayer.configurator.ipv6.Ipv6NetworkConfigurator;
+import inet.node.ethernet.EthernetSwitch;
+import inet.node.ipv6.Router6;
+import inet.node.ipv6.StandardHost6;
+import ned.DatarateChannel;
+
+network RsSourceLinkLayerOptionNetwork
+{
+    types:
+        channel ethline extends DatarateChannel
+        {
+            delay = 0.1us;
+            datarate = 100Mbps;
+        }
+    submodules:
+        configurator: Ipv6NetworkConfigurator;
+        router: Router6;
+        switch: EthernetSwitch;
+        host[2]: StandardHost6;
+    connections:
+        router.ethg++ <--> ethline <--> switch.ethg++;
+        for i=0..1 {
+            host[i].ethg++ <--> ethline <--> switch.ethg++;
+        }
+}
+%#--------------------------------------------------------------------------------------------------------------
+%inifile: omnetpp.ini
+[General]
+record-vector-results = false
+ned-path = ../../../../src
+network = RsSourceLinkLayerOptionNetwork
+sim-time-limit = 10s
+cmdenv-express-mode = false
+cmdenv-log-prefix = "%C: "
+
+# Stateless address autoconfiguration: the configurator only hands out the prefix
+**.ipv6.configurator.networkConfiguratorModule = "configurator"
+*.configurator.assignAddressesToHosts = false
+*.configurator.config = xml("<config><interface among='host[*] router' prefix='2001:db8:1:1::/64'/></config>")
+
+# Advertise often, so that a host holds a tentative global address by the time
+# its own Router Solicitation is due
+*.router.ipv6.neighbourDiscovery.minIntervalBetweenRAs = 0.1s
+*.router.ipv6.neighbourDiscovery.maxIntervalBetweenRAs = 0.2s
+
+%#--------------------------------------------------------------------------------------------------------------
+%subst: /omnetpp:://
+%#--------------------------------------------------------------------------------------------------------------
+%not-contains: stdout
+MAC Address '00-00-00-00-00-00' extracted
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+MAC Address '0A-AA-
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: grep "undisposed object:" test.out > test_undisposed.out || true
+%not-contains: test_undisposed.out
+undisposed object: (
+%#--------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A Router Solicitation that a host sends while Duplicate Address Detection (DAD) is still
running for its autoconfigured global address leaves the node with a real source address
and no Source Link-Layer Address option, which RFC 4861 Section 6.3.7 says it SHOULD carry.
The repair is to source the solicitation from the interface's link-local address instead of
from the default off-link source address, which also stops router discovery waiting for a
DAD it does not depend on.

Closes #1156

## The problem

`Ipv6NeighbourDiscovery::createAndSendRsPacket()` chooses the source address with
`getPreferredAddress()`. That is the default source address for **off-link** destinations,
and `Ipv6InterfaceData::choosePreferredAddress()` deliberately prefers a *tentative* global
address over a *permanent* link-local one, because a link-local source would not be routable
off-link. A Router Solicitation goes to `ff02::2` — link-local scope — and never needs a
routable source, so that preference is the wrong one for it.

The link-local fallback in `createAndSendRsPacket()` was reached only when there was no
preferred address at all, never when the preferred address was tentative. So during global
DAD the function used the unspecified address and, correctly for an unspecified source,
omitted the option — although a permanent link-local address was sitting on the same
interface.

The solicitation did not go out with an unspecified source, though.
`Ipv6::fragmentPostRouting()` fills in `getPreferredAddress()` for a datagram from the higher
layer whose source address is unspecified, unless the destination is a solicited-node
multicast address. That carve-out covers a DAD Neighbour Solicitation but not a Router
Solicitation, so the solicitation was queued on `pendingDadQueue` and released after DAD with
the global address and no option.

Measured in `showcases/general/ipv6autoconfiguration` (`topic/gy/ipv6-nd-showcase`):

| Event | Before | After |
| --- | --- | --- |
| solicitation built, `host[0]` | 2.380967 s | 2.380967 s |
| IPv6 source address | `2001:db8:1:1:8aa:ff:fe00:9` | `fe80::8aa:ff:fe00:9` |
| ICMPv6 payload | 8 B (header only) | 16 B (header + 8 B option) |
| reaches the router | 3.157715 s | 2.380980 s |
| link-layer address the router reads | `00-00-00-00-00-00` | `0A-AA-00-00-00-09` |

## The defect

One defect, one commit. `createAndSendRsPacket()` now falls back to the link-local address
when the preferred address is tentative as well as when it is missing, and only then to the
unspecified address. Both the source address and the option are then decided from the same
state, at the same moment, and nothing downstream rewrites either.

The router discovery timer is armed in `makeTentativeAddressPermanent()` only after
*link-local* DAD has completed, so a usable link-local address is always present when a
solicitation is built. A solicitation from a host that has no address at all still goes out
with the unspecified source and without the option, as RFC 4861 Section 4.1 requires.

## Verification

Built at `MODE=release`. Suites run at the merge base (unmodified `origin/master`) and again
with the change, and diffed:

```
make MODE=release -j$(nproc) && make MODE=debug -j$(nproc)
cd tests/fingerprint && ./fingerprinttest -s examples.csv mipv6-refactoring.csv
cd tests/module      && inet_run_module_tests -m release -f v6
cd tests/module      && inet_run_module_tests -m debug   -f v6
```

Both build modes are clean. The debug run is worth its time here: it compiles the `ASSERT`s
back in, including `ASSERT(!srcAddr.isUnspecified())` in `Ipv6::fragmentPostRouting()` on the
very path this change alters, and none fires — all 39 IPv6 and MIPv6 module tests pass.

Results, merge base versus the change:

| Suite | At the merge base | With the change |
| --- | --- | --- |
| fingerprint, 538 cases | 22 failures, 3 errors | 22 failures, 3 errors |
| module, IPv6 and MIPv6, 47 cases | 44 PASS, 3 FAIL | **45 PASS, 2 FAIL** |
| the same 47, `MODE=debug` | — | **47 PASS** |

The failing sets are identical element for element, apart from the new test flipping to PASS.
The third failure at the merge base is that new test itself.
Every one of the 22 fingerprint failures is a `/tyf` graphical mismatch, the ingredient
`fingerprinttest` itself warns is not kept up to date. The 3 errors are `examples/diffserv`
VoIP configurations that need the VoIPStream feature, which is not enabled in this build. Both
sets fail identically on unmodified master, so they are pre-existing and out of scope. The two
pre-existing module failures are `MIPv6_tcp_handover.test` and `IPv6_packet_too_big.test`.

Six fingerprint values are re-recorded, in three configurations — the MIPv6 handover and
roaming examples, where a mobile node autoconfigures an address and solicits a router while
Duplicate Address Detection is still running for it:

| Configuration | File | Re-recorded | Left alone |
| --- | --- | --- | --- |
| `/examples/ipv6/mipv6/ -c Handover` | examples.csv | `tplx`, `~tNl`, `~tND` | `tyf` |
| `/examples/ipv6/mipv6/ -c RouteOptimizationTwoCNs` | examples.csv | `tplx`, `~tNl`, `~tND` | `tyf` |
| `/examples/ipv6/mipv6roaming/ -c Roaming` | examples.csv | `tplx`, `~tNl`, `~tND` | `tyf` |
| the same three | mipv6-refactoring.csv | `~tNlb` | — |

Per ingredient: `l` and `b`/`D` move because the solicitation grows from an 8-byte to a
16-byte ICMPv6 payload and its source address changes; `t` moves because it is no longer held
until DAD completes; `p` and `N` move because the earlier solicitation reorders the events
around it; `x` follows the trajectory. The `tyf` values are deliberately **not** re-recorded:
they were already failing against unmodified master, and re-recording them would fold a
pre-existing, uninvestigated failure into this change.

`/examples/ipv6/pmipv6/` does not move — its `tplx`, `~tNl` and `~tND` are bit-identical
before and after, so no Router Solicitation in it was deferred. Every other IPv6 configuration
(`nclients`, `hierarchical99`, MLD, `udpclientserver`, DYMO, EIGRP) uses
`Ipv6FlatNetworkConfigurator`, which assigns permanent addresses, so a solicitation is never
built from a tentative one.

`tests/module/IPv6_RS_source_link_layer_option.test` is new: one `Router6` and two
`StandardHost6` nodes on an `EthernetSwitch`, addresses from Stateless Address
Autoconfiguration, the router advertising every 0.1–0.2 s so that both hosts hold a tentative
global address when their solicitations are due. It asserts that the router never reads
`00-00-00-00-00-00` from a solicitation and does read a real address. It fails on unmodified
master — both hosts are caught, so it does not depend on a single lucky random draw.

Its name follows [NR-TEST](doc/project/rule/naming.md#nr-test) and
[NR-WORD](doc/project/rule/naming.md#nr-word) — `PascalCase` subject, acronym as a word —
rather than the `IPv6_*` shape of its twenty siblings, which is the open ledger row `NV-16`.
One consequence worth knowing: the module test filter is case-sensitive, so this test is
picked up by `-f Ipv6` or `-f v6`, not by `-f IPv6`.

## Not addressed here

`Ipv6::fragmentPostRouting()` still overwrites a source address that the upper layer set to
the unspecified address on purpose, whenever the destination is not a solicited-node multicast
address. Router Solicitations were the only Neighbour Discovery message that could reach that
path, and after this change they no longer do, so the remaining exposure is theoretical.
Repairing it needs a tag that marks a source address as deliberate, in the shape of the
`NextHopAddressReq` discriminator added by #1152.

The file cites RFC 2461 throughout, which RFC 4861 obsoletes. Correcting that is a mechanical
sweep over about fifty comments and belongs in its own commit (PR-SPLIT-MECHANICAL).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->