### PR TITLE
wireless: clear transmitted packet tags in layered error models

### DIFF
--- a/src/inet/physicallayer/wireless/common/base/bitlevel/LayeredErrorModelBase.cc
+++ b/src/inet/physicallayer/wireless/common/base/bitlevel/LayeredErrorModelBase.cc
@@ -6,6 +6,7 @@
 
 #include "inet/physicallayer/wireless/common/base/bitlevel/LayeredErrorModelBase.h"
 
+#include "inet/common/ProtocolTag_m.h"
 #include "inet/physicallayer/wireless/common/modulation/ApskSymbol.h"
 #include "inet/physicallayer/wireless/common/base/packetlevel/ApskModulationBase.h"
 #include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
@@ -28,6 +29,8 @@ const IReceptionPacketModel *LayeredErrorModelBase::computePacketModel(const ITr
     auto transmissionPacketModel = check_and_cast<const TransmissionPacketModel *>(transmission->getPacketModel());
     auto transmittedPacket = transmissionPacketModel->getPacket();
     auto receivedPacket = transmittedPacket->dup();
+    receivedPacket->clearTags();
+    receivedPacket->addTag<PacketProtocolTag>()->setProtocol(transmittedPacket->getTag<PacketProtocolTag>()->getProtocol());
     if (packetErrorRate != 0 && uniform(0, 1) < packetErrorRate)
         receivedPacket->setBitError(true);
     receivedPacket->addTagIfAbsent<ErrorRateInd>()->setPacketErrorRate(packetErrorRate);

--- a/src/inet/physicallayer/wireless/ieee80211/bitlevel/errormodel/Ieee80211OfdmErrorModel.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/bitlevel/errormodel/Ieee80211OfdmErrorModel.cc
@@ -7,6 +7,7 @@
 
 #include "inet/physicallayer/wireless/ieee80211/bitlevel/errormodel/Ieee80211OfdmErrorModel.h"
 
+#include "inet/common/ProtocolTag_m.h"
 #include "inet/physicallayer/wireless/common/analogmodel/dimensional/DimensionalSnir.h"
 #include "inet/physicallayer/wireless/common/analogmodel/scalar/ScalarSignalAnalogModel.h"
 #include "inet/physicallayer/wireless/common/contract/packetlevel/IApskModulation.h"
@@ -58,6 +59,8 @@ const IReceptionPacketModel *Ieee80211OfdmErrorModel::computePacketModel(const I
     auto transmissionPacketModel = check_and_cast<const TransmissionPacketModel *>(transmission->getPacketModel());
     auto transmittedPacket = transmissionPacketModel->getPacket();
     auto receivedPacket = transmittedPacket->dup();
+    receivedPacket->clearTags();
+    receivedPacket->addTag<PacketProtocolTag>()->setProtocol(transmittedPacket->getTag<PacketProtocolTag>()->getProtocol());
     if (packetErrorRate != 0 && uniform(0, 1) < packetErrorRate)
         receivedPacket->setBitError(true);
     receivedPacket->addTagIfAbsent<ErrorRateInd>()->setPacketErrorRate(packetErrorRate);


### PR DESCRIPTION
### Topic and Summary

In INET's physical layer architecture (`AR-PKT-TAGS`), packet metadata tags model in-node state and must not cross the physical transmission boundary. In packet-level reception models (`ReceiverBase` and `ErrorModelBase`), received packets are created by duplicating the transmitted packet, clearing all tags, and copying only `PacketProtocolTag`.

However, the bit-level/layered error models `LayeredErrorModelBase` and `Ieee80211OfdmErrorModel` previously duplicated the transmitted packet in `computePacketModel` without clearing tags. This allowed transmitter-side request and indication tags to leak into the received packet during packet-domain layered simulations.

This pull request aligns both layered error models with `ReceiverBase` and `ErrorModelBase` by clearing tags on the duplicated packet and copying only `PacketProtocolTag`.

### Reading Order

This series contains a single self-contained commit:
1. `wireless: clear transmitted packet tags in layered error models`

### Architectural Surface

- **Rule**: `AR-PKT-TAGS` (Physical protocols strip tags at the transmission boundary; received packets only retain the protocol tag and derive receiver-side indication tags).
- **Contracts**: None modified.
- **Packet representation**: Transmitted tags are cleared; only `PacketProtocolTag` is retained on `receivedPacket`.
- **Configuration surface**: None modified.
- **Seals**: None touched (verified with `check-source-seals.sh`).
- **Exceptions**: No new exceptions introduced.

### Verification and Test Evidence

- **Compilation**:
  - `make -j$(nproc) MODE=debug`: Clean build, no warnings.
  - Release-mode compilation verified on modified files with `clang++ -c -std=c++17 -O2 -DNDEBUG`.

- **Enforcement Gates**:
  - `doc/project/enforcement/check-commits.sh origin/master..HEAD`: PASS (clean).
  - `doc/project/enforcement/check-source-seals.sh --base origin/master`: PASS (all checked files unsealed).
  - `doc/project/enforcement/check-architecture.sh src/inet/physicallayer/wireless`: PASS.
  - `doc/project/enforcement/check-naming.sh --base origin/master`: PASS (0 applicable NED/MSG files, no new naming candidates).

- **Regression Tests**:
  - `tests/fingerprint/fingerprinttest -d -m 'layered' tests/fingerprint/examples.csv`:
    - `/examples/wireless/layeredapsk/ -f omnetpp.ini -c General -r 0`: PASS
    - `/examples/wireless/layered80211/ -f omnetpp.ini -c LayeredNonCompliant80211Ping -r 0`: PASS
    - `/examples/wireless/layered80211/ -f omnetpp.ini -c LayeredCompliant80211Ping -r 0`: PASS
    - Total: 3/3 PASS.
  - `tests/fingerprint/fingerprinttest -d -m 'ieee80211levelofdetail' tests/fingerprint/examples.csv`:
    - Total: 8/8 PASS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->