### PR TITLE
IEEE 802.11: negotiate and maintain STA HT associations

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
@@ -30,9 +30,11 @@ module Dcf extends Module like IDcf
     parameters:
         string rxModule;
         string txModule;
+        string mibModule = default("^.^.mib");
 
         *.rateSelectionModule = "^.rateSelection";
         *.rxModule = "^." + this.rxModule;
+        *.mibModule = default(absPath(this.mibModule));
 
         @class(Dcf);
         displayStringTextFormat = default("{frameSequenceInfo}");

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.ned
@@ -32,9 +32,11 @@ module Hcf extends Module like IHcf
 
         string rxModule;
         string txModule;
+        string mibModule = default("^.^.mib");
 
         *.rateSelectionModule = "^.rateSelection";
         *.rxModule = "^." + this.rxModule;
+        *.mibModule = default(absPath(this.mibModule));
         *.*.originatorMacDataServiceModule = "^.^.originatorMacDataService";
 
         @class(Hcf);

--- a/src/inet/linklayer/ieee80211/mac/fragmentation/Fragmentation.cc
+++ b/src/inet/linklayer/ieee80211/mac/fragmentation/Fragmentation.cc
@@ -27,7 +27,8 @@ std::vector<Packet *> *Fragmentation::fragmentFrame(Packet *frame, const std::ve
         auto fragment = new Packet(name.c_str());
         B length = B(fragmentSizes.at(i));
         fragment->insertAtBack(frame->peekDataAt(offset, length));
-        fragment->getRegionTags().copyTags(frame->getRegionTags(), offset, frame->getFrontOffset(), frame->getDataLength());
+        fragment->copyTags(*frame);
+        fragment->getRegionTags().copyTags(frame->getRegionTags(), frame->getFrontOffset() + offset, fragment->getFrontOffset(), length);
         offset += length;
         const auto& fragmentHeader = staticPtrCast<Ieee80211DataOrMgmtHeader>(frameHeader->dupShared());
         fragmentHeader->setSequenceNumber(frameHeader->getSequenceNumber());

--- a/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.cc
@@ -1,0 +1,138 @@
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+
+#include <cstring>
+
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
+
+namespace inet {
+namespace ieee80211 {
+
+using namespace inet::physicallayer;
+
+namespace {
+
+static const IIeee80211Mode *getLegacyFallback(const Ieee80211ModeSet *modeSet,
+        const IIeee80211Mode *upperBoundMode, const MacAddress& peerAddress)
+{
+    auto upperBoundBitrate = upperBoundMode->getDataMode()->getNetBitrate();
+    const IIeee80211Mode *legacyMode = nullptr;
+    for (const auto *candidate : modeSet->getLegacyOperationalModes()) {
+        if (!modeSet->getIsMandatory(candidate) || candidate->getDataMode()->getNetBitrate() > upperBoundBitrate)
+            continue;
+        if (legacyMode == nullptr ||
+                candidate->getDataMode()->getNetBitrate() > legacyMode->getDataMode()->getNetBitrate())
+            legacyMode = candidate;
+    }
+    // Preserve mode sets whose legacy operational set contains no mandatory
+    // entry, while keeping the caller's rate as an upper bound.
+    if (legacyMode == nullptr) {
+        for (const auto *candidate : modeSet->getLegacyOperationalModes()) {
+            if (candidate->getDataMode()->getNetBitrate() > upperBoundBitrate)
+                continue;
+            if (legacyMode == nullptr ||
+                    candidate->getDataMode()->getNetBitrate() > legacyMode->getDataMode()->getNetBitrate())
+                legacyMode = candidate;
+        }
+    }
+    if (legacyMode == nullptr)
+        throw cRuntimeError("No legacy operational mode at or below '%s' is available for peer %s",
+                upperBoundMode->getName(), peerAddress.str().c_str());
+    return legacyMode;
+}
+
+// IEEE Std 802.11-2024, 10.6.5.8: an individually addressed frame shall use
+// a receiver-supported MCS/rate and CH_BANDWIDTH permitted by the BSS HT
+// Operation. The directional negotiated state is the model's source of the
+// receiver's capability advertisement.
+static bool isCompatibleHtMode(const IIeee80211Mode *mode, const Ieee80211Mib::PeerHtState *peerHtState)
+{
+    if (mode == nullptr || peerHtState == nullptr || !peerHtState->valid)
+        return false;
+
+    const auto& negotiated = peerHtState->negotiatedCapabilities;
+    const auto& receiverCapabilities = negotiated.localTxPeerRx;
+    if (!receiverCapabilities.valid)
+        return false;
+
+    int mcsIndex = mode->getHtMcsIndex();
+    if (mcsIndex < 0 || mcsIndex >= 77 || !receiverCapabilities.supportedMcs[mcsIndex])
+        return false;
+
+    auto bandwidth = mode->getDataMode()->getBandwidth();
+    if (receiverCapabilities.supportedChannelWidths.count(bandwidth) == 0 ||
+            bandwidth > negotiated.operation.operatingChannelWidth)
+        return false;
+
+    // IEEE Std 802.11-2024, 10.17 and Table 9-224: a short guard interval
+    // is usable only when the receiver advertised it for this channel width.
+    if (mode->isHtShortGuardInterval()) {
+        if (bandwidth == MHz(20))
+            return receiverCapabilities.receiverShortGi20;
+        if (bandwidth == MHz(40))
+            return receiverCapabilities.receiverShortGi40;
+        return false;
+    }
+    return true;
+}
+
+static bool isBetterHtMode(const IIeee80211Mode *candidate, const IIeee80211Mode *current)
+{
+    auto candidateBitrate = candidate->getDataMode()->getNetBitrate();
+    auto currentBitrate = current->getDataMode()->getNetBitrate();
+    if (candidateBitrate != currentBitrate)
+        return candidateBitrate > currentBitrate;
+
+    // The remaining tie-breaks are deliberately based only on the mode
+    // contract, never on pointer identity or allocation order.
+    if (candidate->isHtShortGuardInterval() != current->isHtShortGuardInterval())
+        return !candidate->isHtShortGuardInterval();
+    auto candidateBandwidth = candidate->getDataMode()->getBandwidth();
+    auto currentBandwidth = current->getDataMode()->getBandwidth();
+    if (candidateBandwidth != currentBandwidth)
+        return candidateBandwidth < currentBandwidth;
+    if (candidate->getHtMcsIndex() != current->getHtMcsIndex())
+        return candidate->getHtMcsIndex() < current->getHtMcsIndex();
+    // A mode set normally contains unique MCS/width/GI entries, but keeping a
+    // final value-based key makes the choice total even for custom mode sets.
+    return std::strcmp(candidate->getName(), current->getName()) < 0;
+}
+
+} // namespace
+
+const IIeee80211Mode *selectPeerCompatibleMode(const Ieee80211ModeSet *modeSet,
+        const Ieee80211Mib::PeerHtState *peerHtState, const IIeee80211Mode *mode, const MacAddress& peerAddress)
+{
+    if (mode == nullptr || mode->getHtMcsIndex() < 0)
+        return mode;
+    if (modeSet == nullptr)
+        throw cRuntimeError("Cannot select a peer-compatible HT mode without an IEEE 802.11 mode set");
+    if (!modeSet->containsMode(mode))
+        throw cRuntimeError("HT mode '%s' is not contained in IEEE 802.11 mode set '%s'",
+                mode->getName(), modeSet->getName());
+
+    if (peerHtState == nullptr || !peerHtState->valid || !peerHtState->negotiatedCapabilities.localTxPeerRx.valid)
+        return getLegacyFallback(modeSet, mode, peerAddress);
+    if (isCompatibleHtMode(mode, peerHtState))
+        return mode;
+
+    auto candidateBitrate = mode->getDataMode()->getNetBitrate();
+    const IIeee80211Mode *bestMode = nullptr;
+    for (int i = 0; i < modeSet->getNumModes(); i++) {
+        const auto *candidate = modeSet->getMode(i);
+        if (candidate->getHtMcsIndex() < 0 ||
+                candidate->getDataMode()->getNetBitrate() > candidateBitrate ||
+                !isCompatibleHtMode(candidate, peerHtState))
+            continue;
+        if (bestMode == nullptr || isBetterHtMode(candidate, bestMode))
+            bestMode = candidate;
+    }
+    return bestMode != nullptr ? bestMode : getLegacyFallback(modeSet, mode, peerAddress);
+}
+
+} // namespace ieee80211
+} // namespace inet

--- a/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+
+#ifndef __INET_IEEE80211PEERMODESELECTION_H
+#define __INET_IEEE80211PEERMODESELECTION_H
+
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+
+namespace inet {
+namespace ieee80211 {
+
+/**
+ * Selects a mode that is compatible with the negotiated receive capabilities
+ * of a peer. Non-HT modes are returned unchanged. A null peer state denotes
+ * that HT negotiation is unavailable and selects a legacy operational
+ * fallback whose bitrate does not exceed the requested HT mode.
+ */
+INET_API const physicallayer::IIeee80211Mode *selectPeerCompatibleMode(
+        const physicallayer::Ieee80211ModeSet *modeSet,
+        const Ieee80211Mib::PeerHtState *peerHtState,
+        const physicallayer::IIeee80211Mode *mode,
+        const MacAddress& peerAddress);
+
+} // namespace ieee80211
+} // namespace inet
+
+#endif

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.cc
@@ -9,6 +9,7 @@
 
 #include "inet/common/ModuleAccess.h"
 #include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
@@ -22,6 +23,8 @@ Define_Module(QosRateSelection);
 void QosRateSelection::initialize(int stage)
 {
     ModeSetListener::initialize(stage);
+    if (stage == INITSTAGE_LOCAL)
+        mib.reference(this, "mibModule", true);
     if (stage == INITSTAGE_LINK_LAYER) {
         dataOrMgmtRateControl = dynamic_cast<IRateControl *>(findModuleByPath(par("rateControlModule")));
         double multicastFrameBitrate = par("multicastFrameBitrate");
@@ -96,16 +99,18 @@ const IIeee80211Mode *QosRateSelection::computeResponseAckFrameMode(Packet *pack
     // TODO BSSBasicRateSet, alternate rate
     auto mode = getMode(packet, dataOrMgmtHeader);
     ASSERT(modeSet->containsMode(mode));
+    const IIeee80211Mode *responseMode;
     if (!responseAckFrameMode) {
         if (modeSet->getIsMandatory(mode))
-            return mode;
+            responseMode = mode;
         else if (auto slowerMode = modeSet->getSlowerMandatoryMode(mode))
-            return slowerMode;
+            responseMode = slowerMode;
         else
             throw cRuntimeError("Mandatory mode not found");
     }
     else
-        return responseAckFrameMode;
+        responseMode = responseAckFrameMode;
+    return getPeerCompatibleMode(dataOrMgmtHeader->getTransmitterAddress(), responseMode);
 }
 
 const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *packet, const Ptr<const Ieee80211RtsFrame>& rtsFrame)
@@ -113,16 +118,18 @@ const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *pack
     // TODO BSSBasicRateSet, alternate rate
     auto mode = getMode(packet, rtsFrame);
     ASSERT(modeSet->containsMode(mode));
+    const IIeee80211Mode *responseMode;
     if (!responseCtsFrameMode) {
         if (modeSet->getIsMandatory(mode))
-            return mode;
+            responseMode = mode;
         else if (auto slowerMode = modeSet->getSlowerMandatoryMode(mode))
-            return slowerMode;
+            responseMode = slowerMode;
         else
             throw cRuntimeError("Mandatory mode not found");
     }
     else
-        return responseCtsFrameMode;
+        responseMode = responseCtsFrameMode;
+    return getPeerCompatibleMode(rtsFrame->getTransmitterAddress(), responseMode);
 }
 
 //
@@ -133,8 +140,10 @@ const IIeee80211Mode *QosRateSelection::computeResponseCtsFrameMode(Packet *pack
 //
 const IIeee80211Mode *QosRateSelection::computeResponseBlockAckFrameMode(Packet *packet, const Ptr<const Ieee80211BlockAckReq>& blockAckReq)
 {
-    if (dynamicPtrCast<const Ieee80211BasicBlockAckReq>(blockAckReq))
-        return responseBlockAckFrameMode ? responseBlockAckFrameMode : getMode(packet, blockAckReq);
+    if (dynamicPtrCast<const Ieee80211BasicBlockAckReq>(blockAckReq)) {
+        auto mode = responseBlockAckFrameMode ? responseBlockAckFrameMode : getMode(packet, blockAckReq);
+        return getPeerCompatibleMode(blockAckReq->getTransmitterAddress(), mode);
+    }
     else
         throw cRuntimeError("Unknown BlockAckReq frame type");
 }
@@ -148,12 +157,12 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         ensurePerReceiverModesResolved();
         auto it = perReceiverDataFrameMode.find(dataOrMgmtHeader->getReceiverAddress());
         if (it != perReceiverDataFrameMode.end())
-            return it->second;
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), it->second);
     }
     if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && dataFrameMode)
-        return dataFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataFrameMode);
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)
-        return mgmtFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), mgmtFrameMode);
     // This subclause describes the rate selection rules for group addressed data and management frames, excluding
     // the following:
     //   — Non-STBC Beacon and non-STBC PSMP frames
@@ -190,9 +199,9 @@ const IIeee80211Mode *QosRateSelection::computeDataOrMgmtFrameMode(const Ptr<con
         // TODO Supported Rates element, Extended Supported Rates element
         // TODO OperationalRateSet or the HTOperationalMCSset
         if (dataOrMgmtRateControl)
-            return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress()));
         else
-            return fastestMandatoryMode;
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), fastestMandatoryMode);
     }
 }
 
@@ -258,7 +267,7 @@ const IIeee80211Mode *QosRateSelection::computeMode(Packet *packet, const Ptr<co
     if (auto dataOrMgmtHeader = dynamicPtrCast<const Ieee80211DataOrMgmtHeader>(header))
         return computeDataOrMgmtFrameMode(dataOrMgmtHeader);
     else
-        return computeControlFrameMode(header, txopProcedure);
+        return getPeerCompatibleMode(header->getReceiverAddress(), computeControlFrameMode(header, txopProcedure));
 }
 
 void QosRateSelection::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
@@ -275,6 +284,13 @@ void QosRateSelection::frameTransmitted(Packet *packet, const Ptr<const Ieee8021
 {
     auto receiverAddr = header->getReceiverAddress();
     lastTransmittedFrameMode[receiverAddr] = getMode(packet, header);
+}
+
+const IIeee80211Mode *QosRateSelection::getPeerCompatibleMode(const MacAddress& peerAddress, const IIeee80211Mode *mode) const
+{
+    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0)
+        return mode;
+    return selectPeerCompatibleMode(modeSet, mib->findPeerHtState(peerAddress), mode, peerAddress);
 }
 
 } /* namespace ieee80211 */

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h
@@ -8,9 +8,11 @@
 #ifndef __INET_QOSRATESELECTION_H
 #define __INET_QOSRATESELECTION_H
 
+#include "inet/common/ModuleRefByPar.h"
 #include "inet/linklayer/ieee80211/mac/common/ModeSetListener.h"
 #include "inet/linklayer/ieee80211/mac/contract/IQosRateSelection.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -32,6 +34,7 @@ class INET_API QosRateSelection : public IQosRateSelection, public ModeSetListen
 {
   protected:
     IRateControl *dataOrMgmtRateControl = nullptr;
+    ModuleRefByPar<Ieee80211Mib> mib;
 
     const physicallayer::Ieee80211ModeSet *modeSet = nullptr;
     std::map<MacAddress, const physicallayer::IIeee80211Mode *> lastTransmittedFrameMode;
@@ -65,6 +68,8 @@ class INET_API QosRateSelection : public IQosRateSelection, public ModeSetListen
     virtual const physicallayer::IIeee80211Mode *getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header, TxopProcedure *txopProcedure);
     virtual const physicallayer::IIeee80211Mode *computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader);
+    virtual const physicallayer::IIeee80211Mode *getPeerCompatibleMode(const MacAddress& peerAddress,
+            const physicallayer::IIeee80211Mode *mode) const;
 
     virtual bool isControlResponseFrame(const Ptr<const Ieee80211MacHeader>& header, TxopProcedure *txopProcedure);
 

--- a/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.ned
@@ -23,6 +23,7 @@ simple QosRateSelection extends SimpleModule
     parameters:
         @class(QosRateSelection);
         string rateControlModule;
+        string mibModule = default("^.^.^.mib");
 
         double multicastFrameBitrate @unit(bps) = default(-1bps);
 

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.cc
@@ -10,6 +10,7 @@
 #include "inet/common/ModuleAccess.h"
 #include "inet/common/Simsignals.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
 #include "inet/networklayer/common/L3AddressResolver.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/IIeee80211Mode.h"
@@ -26,6 +27,7 @@ Define_Module(RateSelection);
 void RateSelection::initialize(int stage)
 {
     if (stage == INITSTAGE_LOCAL) {
+        mib.reference(this, "mibModule", true);
         getContainingNicModule(this)->subscribe(modesetChangedSignal, this);
     }
     else if (stage == INITSTAGE_LINK_LAYER) {
@@ -102,22 +104,24 @@ const IIeee80211Mode *RateSelection::getMode(Packet *packet, const Ptr<const Iee
 const IIeee80211Mode *RateSelection::computeResponseAckFrameMode(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader)
 {
     if (responseAckFrameMode)
-        return responseAckFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getTransmitterAddress(), responseAckFrameMode);
     else {
         auto mode = getMode(packet, dataOrMgmtHeader);
         ASSERT(modeSet->containsMode(mode));
-        return modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        auto responseMode = modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        return getPeerCompatibleMode(dataOrMgmtHeader->getTransmitterAddress(), responseMode);
     }
 }
 
 const IIeee80211Mode *RateSelection::computeResponseCtsFrameMode(Packet *packet, const Ptr<const Ieee80211RtsFrame>& rtsFrame)
 {
     if (responseCtsFrameMode)
-        return responseCtsFrameMode;
+        return getPeerCompatibleMode(rtsFrame->getTransmitterAddress(), responseCtsFrameMode);
     else {
         auto mode = getMode(packet, rtsFrame);
         ASSERT(modeSet->containsMode(mode));
-        return modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        auto responseMode = modeSet->getIsMandatory(mode) ? mode : modeSet->getSlowerMandatoryMode(mode); // TODO BSSBasicRateSet
+        return getPeerCompatibleMode(rtsFrame->getTransmitterAddress(), responseMode);
     }
 }
 
@@ -143,21 +147,21 @@ const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const 
         ensurePerReceiverModesResolved();
         auto it = perReceiverDataFrameMode.find(dataOrMgmtHeader->getReceiverAddress());
         if (it != perReceiverDataFrameMode.end())
-            return it->second;
+            return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), it->second);
     }
     if (dataOrMgmtHeader->getReceiverAddress().isMulticast() && multicastFrameMode)
-        return multicastFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), multicastFrameMode);
     if (dynamicPtrCast<const Ieee80211DataHeader>(dataOrMgmtHeader) && dataFrameMode)
-        return dataFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataFrameMode);
     if (dynamicPtrCast<const Ieee80211MgmtHeader>(dataOrMgmtHeader) && mgmtFrameMode)
-        return mgmtFrameMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), mgmtFrameMode);
     // Rate control adapts to the feedback of one peer, and a group-addressed frame has no peer:
     // it is never acknowledged, so nothing would ever correct a rate chosen for it. Group-addressed
     // frames therefore take a mandatory rate, as the clause above requires.
     if (dataOrMgmtRateControl && !dataOrMgmtHeader->getReceiverAddress().isMulticast())
-        return dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress());
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), dataOrMgmtRateControl->getRate(dataOrMgmtHeader->getReceiverAddress()));
     else
-        return fastestMandatoryMode;
+        return getPeerCompatibleMode(dataOrMgmtHeader->getReceiverAddress(), fastestMandatoryMode);
 }
 
 // 802.11-1999 Std.
@@ -169,7 +173,7 @@ const IIeee80211Mode *RateSelection::computeDataOrMgmtFrameMode(const Ptr<const 
 const IIeee80211Mode *RateSelection::computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header)
 {
     // TODO BSSBasicRateSet
-    return fastestMandatoryMode;
+    return getPeerCompatibleMode(header->getReceiverAddress(), fastestMandatoryMode);
 }
 
 const IIeee80211Mode *RateSelection::computeMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header)
@@ -213,6 +217,13 @@ void RateSelection::emitDatarateSelected(cComponent *emitter, const Ptr<const Ie
     }
     else
         emitter->emit(IRateSelection::datarateSelectedSignal, rate);
+}
+
+const IIeee80211Mode *RateSelection::getPeerCompatibleMode(const MacAddress& peerAddress, const IIeee80211Mode *mode) const
+{
+    if (mode == nullptr || peerAddress.isMulticast() || !mib || mode->getHtMcsIndex() < 0)
+        return mode;
+    return selectPeerCompatibleMode(modeSet, mib->findPeerHtState(peerAddress), mode, peerAddress);
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.h
@@ -8,10 +8,12 @@
 #ifndef __INET_RATESELECTION_H
 #define __INET_RATESELECTION_H
 
+#include "inet/common/ModuleRefByPar.h"
 #include "inet/common/SimpleModule.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateControl.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRateSelection.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -33,6 +35,7 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
 {
   protected:
     IRateControl *dataOrMgmtRateControl = nullptr;
+    ModuleRefByPar<Ieee80211Mib> mib;
     const physicallayer::IIeee80211Mode *fastestMandatoryMode = nullptr;
 
     const physicallayer::Ieee80211ModeSet *modeSet = nullptr;
@@ -65,6 +68,8 @@ class INET_API RateSelection : public IRateSelection, public SimpleModule, publi
     virtual const physicallayer::IIeee80211Mode *getMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeControlFrameMode(const Ptr<const Ieee80211MacHeader>& header);
     virtual const physicallayer::IIeee80211Mode *computeDataOrMgmtFrameMode(const Ptr<const Ieee80211DataOrMgmtHeader>& dataOrMgmtHeader);
+    virtual const physicallayer::IIeee80211Mode *getPeerCompatibleMode(const MacAddress& peerAddress,
+            const physicallayer::IIeee80211Mode *mode) const;
 
   public:
     static void setFrameMode(Packet *packet, const Ptr<const Ieee80211MacHeader>& header, const physicallayer::IIeee80211Mode *mode);

--- a/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
+++ b/src/inet/linklayer/ieee80211/mac/rateselection/RateSelection.ned
@@ -19,6 +19,7 @@ simple RateSelection extends SimpleModule like IRateSelection
     parameters:
         @class(RateSelection);
         string rateControlModule;
+        string mibModule = default("^.^.^.mib");
 
         double multicastFrameBitrate @unit(bps) = default(-1bps);
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.cc
@@ -98,10 +98,10 @@ void Ieee80211AgentSta::handleResponse(cMessage *msg)
         processScanConfirm(ptr);
     else if (auto ptr = dynamic_cast<Ieee80211Prim_AuthenticateConfirm *>(ctrl))
         processAuthenticateConfirm(ptr);
-    else if (auto ptr = dynamic_cast<Ieee80211Prim_AssociateConfirm *>(ctrl))
-        processAssociateConfirm(ptr);
     else if (auto ptr = dynamic_cast<Ieee80211Prim_ReassociateConfirm *>(ctrl))
         processReassociateConfirm(ptr);
+    else if (auto ptr = dynamic_cast<Ieee80211Prim_AssociateConfirm *>(ctrl))
+        processAssociateConfirm(ptr);
     else if (ctrl)
         throw cRuntimeError("handleResponse(): unrecognized control info class `%s'", ctrl->getClassName());
     else

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.cc
@@ -30,6 +30,8 @@ void Ieee80211AgentSta::initialize(int stage)
     SimpleModule::initialize(stage);
 
     if (stage == INITSTAGE_LOCAL) {
+        mib.reference(this, "mibModule", true);
+
         // read parameters
         activeScan = par("activeScan");
         probeDelay = par("probeDelay");
@@ -288,13 +290,14 @@ void Ieee80211AgentSta::processAssociateConfirm(Ieee80211Prim_AssociateConfirm *
     }
     else {
         EV << "Association successful\n";
+        bool newAp = prevAP.isUnspecified() || prevAP != resp->getAddress();
+        if (newAp)
+            prevAP = resp->getAddress();
         emit(acceptConfirmSignal, PR_ASSOCIATE_CONFIRM);
         // we are happy!
         getContainingNode(this)->bubble("Associated with AP");
-        if (prevAP.isUnspecified() || prevAP != resp->getAddress()) {
+        if (newAp)
             emit(l2AssociatedNewApSignal, myIface); // TODO detail: NetworkInterface?
-            prevAP = resp->getAddress();
-        }
         else
             emit(l2AssociatedOldApSignal, myIface);
     }
@@ -302,17 +305,25 @@ void Ieee80211AgentSta::processAssociateConfirm(Ieee80211Prim_AssociateConfirm *
 
 void Ieee80211AgentSta::processReassociateConfirm(Ieee80211Prim_ReassociateConfirm *resp)
 {
-    // treat the same way as AssociateConfirm
     if (resp->getResultCode() != PRC_SUCCESS) {
         EV << "Reassociation error\n";
+        bool isAssociated = mib->bssStationData.isAssociated;
         emit(dropConfirmSignal, PR_REASSOCIATE_CONFIRM);
-        EV << "Going back to scanning\n";
-        sendScanRequest();
+        if (!isAssociated) {
+            EV << "Going back to scanning\n";
+            sendScanRequest();
+        }
     }
     else {
         EV << "Reassociation successful\n";
-        emit(l2AssociatedOldApSignal, myIface); // TODO detail: NetworkInterface?
+        bool newAp = prevAP.isUnspecified() || prevAP != resp->getAddress();
+        if (newAp)
+            prevAP = resp->getAddress();
         emit(acceptConfirmSignal, PR_REASSOCIATE_CONFIRM);
+        if (newAp)
+            emit(l2AssociatedNewApSignal, myIface); // TODO detail: NetworkInterface?
+        else
+            emit(l2AssociatedOldApSignal, myIface);
         // we are happy!
     }
 }

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h
@@ -8,10 +8,12 @@
 #ifndef __INET_IEEE80211AGENTSTA_H
 #define __INET_IEEE80211AGENTSTA_H
 
+#include "inet/common/ModuleRefByPar.h"
 #include "inet/common/SimpleModule.h"
 #include <vector>
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211Primitives_m.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 #include "inet/networklayer/common/InterfaceTable.h"
 
 namespace inet {
@@ -30,6 +32,7 @@ class INET_API Ieee80211AgentSta : public SimpleModule, public cListener // TODO
 {
   protected:
     NetworkInterface *myIface = nullptr;
+    ModuleRefByPar<Ieee80211Mib> mib;
     MacAddress prevAP;
     bool activeScan = false;
     std::vector<int> channelsToScan;

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -61,8 +61,6 @@ void Ieee80211MgmtAp::initialize(int stage)
         // TODO fill in supportedRates
 
         // subscribe for notifications
-        cModule *radioModule = getModuleFromPar<cModule>(par("radioModule"), this);
-        radioModule->subscribe(Ieee80211Radio::radioChannelChangedSignal, this);
         getContainingNicModule(this)->subscribe(IFrameSequenceHandler::frameSequenceFinishedSignal, this);
 
         // start beacon timer (randomize startup time)
@@ -94,6 +92,7 @@ void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, in
         EV << "updating channel number\n";
         channelNumber = value;
     }
+    Ieee80211MgmtApBase::receiveSignal(source, signalID, value, details);
 }
 
 void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.cc
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "inet/common/ProtocolTag_m.h"
+#include "inet/common/ModuleAccess.h"
 #include "inet/linklayer/common/MacAddressTag_m.h"
 
 #ifdef INET_WITH_ETHERNET
@@ -15,8 +16,17 @@
 #endif // ifdef INET_WITH_ETHERNET
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/IRadio.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Channel.h"
 
 namespace inet {
+
+namespace {
+
+const simsignal_t ieee80211RadioChannelChangedSignal = cComponent::registerSignal("radioChannelChanged");
+
+}
 
 namespace ieee80211 {
 
@@ -27,9 +37,44 @@ void Ieee80211MgmtApBase::initialize(int stage)
         mib->mode = Ieee80211Mib::INFRASTRUCTURE;
         mib->bssStationData.stationType = Ieee80211Mib::ACCESS_POINT;
         mib->bssData.ssid = par("ssid").stdstringValue();
+        radio = getModuleFromPar<cModule>(par("radioModule"), this);
+        radio->subscribe(ieee80211RadioChannelChangedSignal, this);
     }
     else if (stage == INITSTAGE_LINK_LAYER)
         mib->bssData.bssid = mib->address;
+    else if (stage == INITSTAGE_LAST && mib->isHtOperationSupported()) {
+        const auto& operation = mib->getHtOperation();
+        if (operation.operatingChannelWidth == MHz(40) &&
+                !getHtOperationBand()->isHt40OperationSupported(operation.primaryChannel, operation.secondaryChannelOffset))
+            throw cRuntimeError("Invalid 40 MHz HT operation for band '%s', primary channel index %d, secondary channel offset %d",
+                    getHtOperationBand()->getName(), operation.primaryChannel, operation.secondaryChannelOffset);
+    }
+}
+
+void Ieee80211MgmtApBase::receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details)
+{
+    Enter_Method("%s", cComponent::getSignalName(signalID));
+
+    if (source == radio && signalID == ieee80211RadioChannelChangedSignal) {
+        EV << "Updating AP primary channel to " << value << ".\n";
+        mib->setPrimaryChannel(value);
+    }
+}
+
+const physicallayer::IIeee80211Band *Ieee80211MgmtApBase::getHtOperationBand() const
+{
+    if (radio == nullptr)
+        throw cRuntimeError("HT Operation channel conversion requires a configured radioModule");
+    const auto *radioContract = dynamic_cast<const physicallayer::IRadio *>(radio);
+    if (radioContract == nullptr)
+        throw cRuntimeError("HT Operation channel conversion requires radioModule to reference a radio, got %s", radio->getClassName());
+    const auto *transmitter = dynamic_cast<const physicallayer::Ieee80211Transmitter *>(radioContract->getTransmitter());
+    if (transmitter == nullptr)
+        throw cRuntimeError("HT Operation channel conversion requires radioModule's transmitter to provide an IEEE 802.11 channel");
+    const auto *channel = transmitter->getChannel();
+    if (channel == nullptr || channel->getBand() == nullptr)
+        throw cRuntimeError("HT Operation channel conversion requires radioModule's IEEE 802.11 transmitter to have a configured channel and band");
+    return channel->getBand();
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h
@@ -15,6 +15,10 @@ namespace inet {
 
 class EtherFrame;
 
+namespace physicallayer {
+class IIeee80211Band;
+}
+
 namespace ieee80211 {
 
 /**
@@ -26,8 +30,14 @@ namespace ieee80211 {
 class INET_API Ieee80211MgmtApBase : public Ieee80211MgmtBase
 {
   protected:
+    cModule *radio = nullptr;
+
+    const physicallayer::IIeee80211Band *getHtOperationBand() const;
+
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int) override;
+    using Ieee80211MgmtBase::receiveSignal;
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
 };
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApSimplified.ned
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApSimplified.ned
@@ -22,6 +22,7 @@ simple Ieee80211MgmtApSimplified extends SimpleModule like IIeee80211Mgmt
         string interfaceTableModule;
         string mibModule;
         string macModule;               // The path to the MAC module
+        string radioModule = default("^.radio");
         string ssid = default("SSID");
         @display("i=block/cogwheel");
     gates:

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -191,6 +191,7 @@ void Ieee80211MgmtBase::start()
 
 void Ieee80211MgmtBase::stop()
 {
+    mib->clearPeerHtCapabilities();
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.cc
@@ -80,6 +80,12 @@ void Ieee80211MgmtBase::addHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame) 
         setHtCapabilities(frame, mib->localHtCapabilities);
 }
 
+void Ieee80211MgmtBase::addHtOperation(const Ptr<Ieee80211MgmtFrame>& frame, const physicallayer::IIeee80211Band *band) const
+{
+    if (mib->isHtOperationSupported())
+        setHtOperation(frame, band, mib->getHtOperation());
+}
+
 void Ieee80211MgmtBase::handleMessageWhenUp(cMessage *msg)
 {
     if (msg->isSelfMessage()) {

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtBase.h
@@ -17,6 +17,7 @@
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
 #include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
 #include "inet/networklayer/contract/IInterfaceTable.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Band.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 
 namespace inet {
@@ -81,7 +82,9 @@ class INET_API Ieee80211MgmtBase : public OperationalBase, public cListener
         return length;
     }
 
-      virtual void addHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame) const;
+    /** Adds the local HT advertisement to a frame when the authoritative PHY profile supports HT operation. */
+    virtual void addHtCapabilities(const Ptr<Ieee80211MgmtFrame>& frame) const;
+    virtual void addHtOperation(const Ptr<Ieee80211MgmtFrame>& frame, const physicallayer::IIeee80211Band *band) const;
 
     /** Dispatch to frame processing methods according to frame type */
     virtual void processFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtHeader>& header);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrameSerializer.cc
@@ -18,6 +18,8 @@ namespace inet {
 
 namespace ieee80211 {
 
+// IEEE Std 802.11-2024, 9.2.2: fixed-width numeric management fields use least-significant octet first.
+
 Register_Serializer(Ieee80211AssociationRequestFrame, Ieee80211MgmtFrameSerializer);
 Register_Serializer(Ieee80211AssociationResponseFrame, Ieee80211MgmtFrameSerializer);
 Register_Serializer(Ieee80211AuthenticationFrame, Ieee80211MgmtFrameSerializer);
@@ -37,6 +39,9 @@ static constexpr uint8_t MAX_SUPPORTED_RATES = 8;
 static constexpr uint16_t MAX_EXTENDED_SUPPORTED_RATES = 255;
 static constexpr double SUPPORTED_RATE_UNIT = 0.5;
 static constexpr double MAX_SUPPORTED_RATE_UNITS = 127;
+static constexpr uint16_t ASSOCIATION_ID_MARKER = 0xC000;
+static constexpr uint16_t ASSOCIATION_ID_MASK = 0x3FFF;
+static constexpr int MAX_LOGICAL_ASSOCIATION_ID = 2007;
 
 static void validateSupportedRatesCount(int numRates)
 {
@@ -433,6 +438,35 @@ static void deserializeSupportedRates(MemoryInputStream& stream, Ieee80211MgmtFr
     }
 }
 
+static uint16_t encodeAssociationId(Ieee80211StatusCode statusCode, int aid)
+{
+    if (statusCode == SC_SUCCESSFUL) {
+        if (aid < 1 || aid > MAX_LOGICAL_ASSOCIATION_ID)
+            throw cRuntimeError("Malformed successful Association Response AID: %d", aid);
+        return ASSOCIATION_ID_MARKER | static_cast<uint16_t>(aid);
+    }
+    // This model uses zero for unsuccessful response AIDs. Keep that
+    // policy explicit at the wire boundary instead of accepting a stale ID.
+    if (aid != 0)
+        throw cRuntimeError("Malformed unsuccessful Association Response AID: %d", aid);
+    return 0;
+}
+
+static int decodeAssociationId(Ieee80211StatusCode statusCode, uint16_t wireAid)
+{
+    if (statusCode == SC_SUCCESSFUL) {
+        if ((wireAid & ASSOCIATION_ID_MARKER) != ASSOCIATION_ID_MARKER)
+            throw cRuntimeError("Malformed successful Association Response AID: missing marker 0xC000");
+        const int aid = wireAid & ASSOCIATION_ID_MASK;
+        if (aid < 1 || aid > MAX_LOGICAL_ASSOCIATION_ID)
+            throw cRuntimeError("Malformed successful Association Response AID: %d", aid);
+        return aid;
+    }
+    if (wireAid != 0)
+        throw cRuntimeError("Malformed unsuccessful Association Response AID: expected zero, got 0x%04x", wireAid);
+    return 0;
+}
+
 } // namespace
 
 // IEEE Std 802.11-2024, 9.2.2: octets in multi-octet numeric fields are transmitted
@@ -530,7 +564,7 @@ void Ieee80211MgmtFrameSerializer::serializeFields(MemoryOutputStream& stream, c
         // 2    Status code
         stream.writeUint16Le(associationResponseFrame->getStatusCode());
         // 3    AID
-        stream.writeUint16Le(associationResponseFrame->getAid());
+        stream.writeUint16Le(encodeAssociationId(associationResponseFrame->getStatusCode(), associationResponseFrame->getAid()));
         // 4    Supported rates
         writeSupportedRateElements(stream, associationResponseFrame);
         writeHtElements(stream, associationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -545,7 +579,7 @@ void Ieee80211MgmtFrameSerializer::serializeFields(MemoryOutputStream& stream, c
         // 2    Status code
         stream.writeUint16Le(reassociationResponseFrame->getStatusCode());
         // 3    AID
-        stream.writeUint16Le(reassociationResponseFrame->getAid());
+        stream.writeUint16Le(encodeAssociationId(reassociationResponseFrame->getStatusCode(), reassociationResponseFrame->getAid()));
         // 4    Supported rates
         writeSupportedRateElements(stream, reassociationResponseFrame);
         writeHtElements(stream, reassociationResponseFrame, HT_CAPABILITIES_ALLOWED | HT_OPERATION_ALLOWED | EXTENDED_SUPPORTED_RATES_ALLOWED);
@@ -701,7 +735,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFields(MemoryInputStre
         auto frame = makeShared<Ieee80211AssociationResponseFrame>();
         stream.readUint16Le();
         frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Le());
-        frame->setAid(stream.readUint16Le());
+        frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Le()));
 
         Ieee80211SupportedRatesElement supRat;
         deserializeSupportedRates(stream, *frame, supRat);
@@ -713,7 +747,7 @@ const Ptr<Chunk> Ieee80211MgmtFrameSerializer::deserializeFields(MemoryInputStre
         auto frame = makeShared<Ieee80211ReassociationResponseFrame>();
         stream.readUint16Le();
         frame->setStatusCode((Ieee80211StatusCode)stream.readUint16Le());
-        frame->setAid(stream.readUint16Le());
+        frame->setAid(decodeAssociationId(frame->getStatusCode(), stream.readUint16Le()));
 
         Ieee80211SupportedRatesElement supRat;
         deserializeSupportedRates(stream, *frame, supRat);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -120,11 +120,22 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
     }
     else if (msg->getKind() == MK_ASSOC_TIMEOUT) {
         // association timed out
+        ASSERT(msg == assocTimeoutMsg);
         ApInfo *ap = (ApInfo *)msg->getContextPointer();
+        bool reassociation = reassociationInProgress;
         EV << "Association timed out, AP address = " << ap->address << "\n";
 
+        assocTimeoutMsg = nullptr;
+        reassociationInProgress = false;
+        delete msg;
+
         // send back failure report to agent
-        sendAssociationConfirm(ap, PRC_TIMEOUT);
+        if (reassociation) {
+            handleReassociationFailure(ap);
+            sendReassociationConfirm(ap, PRC_TIMEOUT);
+        }
+        else
+            sendAssociationConfirm(ap, PRC_TIMEOUT);
     }
     else if (msg->getKind() == MK_SCAN_MAXCHANNELTIME) {
         // go to next channel during scanning
@@ -172,10 +183,10 @@ void Ieee80211MgmtSta::handleCommand(int msgkind, cObject *ctrl)
         processAuthenticateCommand(cmd);
     else if (auto cmd = dynamic_cast<Ieee80211Prim_DeauthenticateRequest *>(ctrl))
         processDeauthenticateCommand(cmd);
-    else if (auto cmd = dynamic_cast<Ieee80211Prim_AssociateRequest *>(ctrl))
-        processAssociateCommand(cmd);
     else if (auto cmd = dynamic_cast<Ieee80211Prim_ReassociateRequest *>(ctrl))
         processReassociateCommand(cmd);
+    else if (auto cmd = dynamic_cast<Ieee80211Prim_AssociateRequest *>(ctrl))
+        processAssociateCommand(cmd);
     else if (auto cmd = dynamic_cast<Ieee80211Prim_DisassociateRequest *>(ctrl))
         processDisassociateCommand(cmd);
     else if (ctrl)
@@ -196,11 +207,20 @@ Ieee80211MgmtSta::ApInfo *Ieee80211MgmtSta::lookupAP(const MacAddress& address)
 
 void Ieee80211MgmtSta::clearAPList()
 {
+    cancelPendingAssociation();
+
     for (auto& elem : apList)
         if (elem.authTimeoutMsg)
             cancelAndDelete(elem.authTimeoutMsg);
 
     apList.clear();
+}
+
+void Ieee80211MgmtSta::cancelPendingAssociation()
+{
+    cancelAndDelete(assocTimeoutMsg);
+    assocTimeoutMsg = nullptr;
+    reassociationInProgress = false;
 }
 
 void Ieee80211MgmtSta::changeChannel(int channelNum)
@@ -271,9 +291,29 @@ void Ieee80211MgmtSta::startAssociation(ApInfo *ap, simtime_t timeout)
     setSupportedRateElements(body);
     body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
     sendManagementFrame("Assoc", body, ST_ASSOCIATIONREQUEST, ap->address);
+    reassociationInProgress = false;
 
     // schedule timeout
     ASSERT(assocTimeoutMsg == nullptr);
+    assocTimeoutMsg = new cMessage("assocTimeout", MK_ASSOC_TIMEOUT);
+    assocTimeoutMsg->setContextPointer(ap);
+    scheduleAfter(timeout, assocTimeoutMsg);
+}
+
+void Ieee80211MgmtSta::startReassociation(ApInfo *ap, simtime_t timeout)
+{
+    if (!mib->bssStationData.isAssociated || assocTimeoutMsg)
+        throw cRuntimeError("startReassociation: not associated or association currently in progress");
+    if (!ap->isAuthenticated)
+        throw cRuntimeError("startReassociation: not authenticated with AP address='%s'", ap->address.str().c_str());
+    changeChannel(ap->channel);
+    const auto& body = makeShared<Ieee80211ReassociationRequestFrame>();
+    body->setCurrentAP(assocAP.address);
+    body->setSSID(ap->ssid.c_str());
+    setSupportedRateElements(body);
+    body->setChunkLength(B(2 + 2 + 6 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
+    sendManagementFrame("Reassoc", body, ST_REASSOCIATIONREQUEST, ap->address);
+    reassociationInProgress = true;
     assocTimeoutMsg = new cMessage("assocTimeout", MK_ASSOC_TIMEOUT);
     assocTimeoutMsg->setContextPointer(ap);
     scheduleAfter(timeout, assocTimeoutMsg);
@@ -299,14 +339,8 @@ void Ieee80211MgmtSta::processScanCommand(Ieee80211Prim_ScanRequest *ctrl)
 
     if (isScanning)
         throw cRuntimeError("processScanCommand: scanning already in progress");
-    if (mib->bssStationData.isAssociated) {
+    if (mib->bssStationData.isAssociated)
         disassociate();
-    }
-    else if (assocTimeoutMsg) {
-        EV << "Cancelling ongoing association process\n";
-        cancelAndDelete(assocTimeoutMsg);
-        assocTimeoutMsg = nullptr;
-    }
 
     // clear existing AP list (and cancel any pending authentications) -- we want to start with a clean page
     clearAPList();
@@ -420,6 +454,8 @@ void Ieee80211MgmtSta::processDeauthenticateCommand(Ieee80211Prim_Deauthenticate
 
     if (mib->bssStationData.isAssociated && assocAP.address == address)
         disassociate();
+    else if (assocTimeoutMsg && assocTimeoutMsg->getContextPointer() == ap)
+        cancelPendingAssociation();
 
     if (ap->isAuthenticated)
         ap->isAuthenticated = false;
@@ -447,9 +483,17 @@ void Ieee80211MgmtSta::processAssociateCommand(Ieee80211Prim_AssociateRequest *c
 
 void Ieee80211MgmtSta::processReassociateCommand(Ieee80211Prim_ReassociateRequest *ctrl)
 {
-    // treat the same way as association
-    // TODO refine
-    processAssociateCommand(ctrl);
+    const MacAddress& address = ctrl->getAddress();
+    if (!mib->bssStationData.isAssociated) {
+        auto confirm = new Ieee80211Prim_ReassociateConfirm();
+        confirm->setAddress(address);
+        sendConfirm(confirm, PRC_REFUSED);
+        return;
+    }
+    ApInfo *ap = lookupAP(address);
+    if (!ap)
+        throw cRuntimeError("processReassociateCommand: AP not known: address = %s", address.str().c_str());
+    startReassociation(ap, ctrl->getTimeout());
 }
 
 void Ieee80211MgmtSta::processDisassociateCommand(Ieee80211Prim_DisassociateRequest *ctrl)
@@ -459,11 +503,8 @@ void Ieee80211MgmtSta::processDisassociateCommand(Ieee80211Prim_DisassociateRequ
     if (mib->bssStationData.isAssociated && address == assocAP.address) {
         disassociate();
     }
-    else if (assocTimeoutMsg) {
-        // pending association
-        cancelAndDelete(assocTimeoutMsg);
-        assocTimeoutMsg = nullptr;
-    }
+    else
+        cancelPendingAssociation();
 
     // create and send disassociation request
     const auto& body = makeShared<Ieee80211DisassociationFrame>();
@@ -475,6 +516,7 @@ void Ieee80211MgmtSta::disassociate()
 {
     EV << "Disassociating from AP address=" << assocAP.address << "\n";
     ASSERT(mib->bssStationData.isAssociated);
+    cancelPendingAssociation();
     mib->bssStationData.isAssociated = false;
     cancelAndDelete(assocAP.beaconTimeoutMsg);
     assocAP.beaconTimeoutMsg = nullptr;
@@ -490,7 +532,16 @@ void Ieee80211MgmtSta::sendAuthenticationConfirm(ApInfo *ap, Ieee80211PrimResult
 
 void Ieee80211MgmtSta::sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode)
 {
-    sendConfirm(new Ieee80211Prim_AssociateConfirm(), resultCode);
+    auto confirm = new Ieee80211Prim_AssociateConfirm();
+    confirm->setAddress(ap->address);
+    sendConfirm(confirm, resultCode);
+}
+
+void Ieee80211MgmtSta::sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode)
+{
+    auto confirm = new Ieee80211Prim_ReassociateConfirm();
+    confirm->setAddress(ap->address);
+    sendConfirm(confirm, resultCode);
 }
 
 void Ieee80211MgmtSta::sendConfirm(Ieee80211PrimConfirm *confirm, Ieee80211PrimResultCode resultCode)
@@ -610,7 +661,12 @@ void Ieee80211MgmtSta::handleAssociationRequestFrame(Packet *packet, const Ptr<c
 
 void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
-    EV << "Received Association Response frame\n";
+    processAssociationResponse(packet, header, false);
+}
+
+void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation)
+{
+    EV << "Received Association or Reassociation Response frame\n";
 
     if (!assocTimeoutMsg) {
         EV << "No association in progress, ignoring frame\n";
@@ -618,35 +674,47 @@ void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<
         return;
     }
 
-    // extract frame contents
-    const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
-    MacAddress address = header->getTransmitterAddress();
-    int statusCode = responseBody->getStatusCode();
-    // TODO short aid;
-    // TODO Ieee80211SupportedRatesElement supportedRates;
-    delete packet;
-
-    // look up AP data structure
-    ApInfo *ap = lookupAP(address);
-    if (!ap)
-        throw cRuntimeError("handleAssociationResponseFrame: AP not known: address=%s", address.str().c_str());
-
-    if (mib->bssStationData.isAssociated) {
-        EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
-        mib->bssStationData.isAssociated = false;
-        cancelAndDelete(assocAP.beaconTimeoutMsg);
-        assocAP.beaconTimeoutMsg = nullptr;
-        assocAP = AssociatedApInfo();
+    // IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4: process only the response
+    // corresponding to the association or reassociation procedure in progress.
+    if (reassociation != reassociationInProgress) {
+        EV_INFO << "Association response subtype does not match the pending "
+                << (reassociationInProgress ? "reassociation" : "association")
+                << " attempt, ignoring frame\n";
+        delete packet;
+        return;
     }
 
-    cancelAndDelete(assocTimeoutMsg);
-    assocTimeoutMsg = nullptr;
+    MacAddress address = header->getTransmitterAddress();
+    ApInfo *ap = static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer());
+    if (ap == nullptr || ap->address != address) {
+        EV << "Association response is not from the pending AP, ignoring frame\n";
+        delete packet;
+        return;
+    }
+
+    // extract frame contents
+    const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
+    int statusCode = responseBody->getStatusCode();
+
+    delete packet;
+
+    cancelPendingAssociation();
 
     if (statusCode != SC_SUCCESSFUL) {
         EV << "Association failed with AP address=" << ap->address << "\n";
+        if (reassociation)
+            handleReassociationFailure(ap);
     }
     else {
         EV << "Association successful, AP address=" << ap->address << "\n";
+
+        if (mib->bssStationData.isAssociated) {
+            EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
+            mib->bssStationData.isAssociated = false;
+            cancelAndDelete(assocAP.beaconTimeoutMsg);
+            assocAP.beaconTimeoutMsg = nullptr;
+            assocAP = AssociatedApInfo();
+        }
 
         // change our state to "associated"
         mib->bssData.ssid = ap->ssid;
@@ -661,7 +729,26 @@ void Ieee80211MgmtSta::handleAssociationResponseFrame(Packet *packet, const Ptr<
     }
 
     // report back to agent
-    sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
+    if (reassociation)
+        sendReassociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
+    else
+        sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
+}
+
+void Ieee80211MgmtSta::handleReassociationFailure(ApInfo *ap)
+{
+    // IEEE Std 802.11-2024, 11.3.5.4(f): failed or timed-out reassociation
+    // disassociates the STA only when the target is its current AP.
+    if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address))
+        disassociate();
+    else if (mib->bssStationData.isAssociated)
+        changeChannel(assocAP.channel);
+}
+
+bool Ieee80211MgmtSta::shouldDisassociateOnReassociationFailure(bool isAssociated,
+        const MacAddress& associatedApAddress, const MacAddress& targetApAddress)
+{
+    return isAssociated && associatedApAddress == targetApAddress;
 }
 
 void Ieee80211MgmtSta::handleReassociationRequestFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -671,8 +758,7 @@ void Ieee80211MgmtSta::handleReassociationRequestFrame(Packet *packet, const Ptr
 
 void Ieee80211MgmtSta::handleReassociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
-    EV << "Received Reassociation Response frame\n";
-    // TODO handle with the same code as Association Response?
+    processAssociationResponse(packet, header, true);
 }
 
 void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -680,11 +766,7 @@ void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const
     EV << "Received Disassociation frame\n";
     const MacAddress& address = header->getAddress3(); // source address
 
-    if (assocTimeoutMsg) {
-        // pending association
-        cancelAndDelete(assocTimeoutMsg);
-        assocTimeoutMsg = nullptr;
-    }
+    cancelPendingAssociation();
     if (!mib->bssStationData.isAssociated || address != assocAP.address) {
         EV << "Not associated with that AP -- ignoring frame\n";
         delete packet;

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -94,6 +94,15 @@ static bool validateHtOperation(const IIeee80211Band *band, const Ieee80211HtOpe
     return true;
 }
 
+Ieee80211MgmtSta::~Ieee80211MgmtSta()
+{
+    cancelAndDelete(scanTimer);
+    cancelAndDelete(assocTimeoutMsg);
+    for (auto& ap : apList)
+        cancelAndDelete(ap.authTimeoutMsg);
+    cancelAndDelete(assocAP.beaconTimeoutMsg);
+}
+
 std::ostream& operator<<(std::ostream& os, const Ieee80211MgmtSta::ScanningInfo& scanning)
 {
     os << "activeScan=" << scanning.activeScan
@@ -190,6 +199,8 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
             sendAssociationConfirm(ap, PRC_TIMEOUT);
     }
     else if (msg->getKind() == MK_SCAN_MAXCHANNELTIME) {
+        ASSERT(msg == scanTimer);
+        scanTimer = nullptr;
         // go to next channel during scanning
         bool done = scanNextChannel();
         if (done)
@@ -197,19 +208,25 @@ void Ieee80211MgmtSta::handleTimer(cMessage *msg)
         delete msg;
     }
     else if (msg->getKind() == MK_SCAN_SENDPROBE) {
+        ASSERT(msg == scanTimer);
+        scanTimer = nullptr;
         // Active Scan: send a probe request, then wait for minChannelTime (11.1.3.2.2)
         delete msg;
         sendProbeRequest();
-        cMessage *timerMsg = new cMessage("minChannelTime", MK_SCAN_MINCHANNELTIME);
-        scheduleAfter(scanning.minChannelTime, timerMsg); // TODO actually, we should start waiting after ProbeReq actually got transmitted
+        ASSERT(scanTimer == nullptr);
+        scanTimer = new cMessage("minChannelTime", MK_SCAN_MINCHANNELTIME);
+        scheduleAfter(scanning.minChannelTime, scanTimer); // TODO actually, we should start waiting after ProbeReq actually got transmitted
     }
     else if (msg->getKind() == MK_SCAN_MINCHANNELTIME) {
+        ASSERT(msg == scanTimer);
+        scanTimer = nullptr;
         // Active Scan: after minChannelTime, possibly listen for the remaining time until maxChannelTime
         delete msg;
         if (scanning.busyChannelDetected) {
             EV << "Busy channel detected during minChannelTime, continuing listening until maxChannelTime elapses\n";
-            cMessage *timerMsg = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
-            scheduleAfter(scanning.maxChannelTime - scanning.minChannelTime, timerMsg);
+            ASSERT(scanTimer == nullptr);
+            scanTimer = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
+            scheduleAfter(scanning.maxChannelTime - scanning.minChannelTime, scanTimer);
         }
         else {
             EV << "Channel was empty during minChannelTime, going to next channel\n";
@@ -273,6 +290,12 @@ void Ieee80211MgmtSta::cancelPendingAssociation()
     cancelAndDelete(assocTimeoutMsg);
     assocTimeoutMsg = nullptr;
     reassociationInProgress = false;
+}
+
+void Ieee80211MgmtSta::cancelScanTimer()
+{
+    cancelAndDelete(scanTimer);
+    scanTimer = nullptr;
 }
 
 void Ieee80211MgmtSta::changeChannel(int channelNum)
@@ -441,15 +464,17 @@ bool Ieee80211MgmtSta::scanNextChannel()
     changeChannel(newChannel);
     scanning.busyChannelDetected = false;
 
+    ASSERT(scanTimer == nullptr);
     if (scanning.activeScan) {
         // Active Scan: first wait probeDelay, then send a probe. Listening
         // for minChannelTime or maxChannelTime takes place after that. (11.1.3.2)
-        scheduleAfter(scanning.probeDelay, new cMessage("sendProbe", MK_SCAN_SENDPROBE));
+        scanTimer = new cMessage("sendProbe", MK_SCAN_SENDPROBE);
+        scheduleAfter(scanning.probeDelay, scanTimer);
     }
     else {
         // Passive Scan: spend maxChannelTime on the channel (11.1.3.1)
-        cMessage *timerMsg = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
-        scheduleAfter(scanning.maxChannelTime, timerMsg);
+        scanTimer = new cMessage("maxChannelTime", MK_SCAN_MAXCHANNELTIME);
+        scheduleAfter(scanning.maxChannelTime, scanTimer);
     }
 
     return false;
@@ -570,8 +595,14 @@ void Ieee80211MgmtSta::processDisassociateCommand(Ieee80211Prim_DisassociateRequ
     if (mib->bssStationData.isAssociated && address == assocAP.address) {
         disassociate();
     }
-    else
-        cancelPendingAssociation();
+    else if (assocTimeoutMsg) {
+        // IEEE Std 802.11-2024, 6.5.9.1.2 scopes PeerSTAAddress to the peer
+        // being disassociated; the model cancels only a matching pending
+        // transaction.
+        auto pendingAp = static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer());
+        if (pendingAp != nullptr && pendingAp->address == address)
+            cancelPendingAssociation();
+    }
 
     // create and send disassociation request
     const auto& body = makeShared<Ieee80211DisassociationFrame>();
@@ -584,10 +615,65 @@ void Ieee80211MgmtSta::disassociate()
     EV << "Disassociating from AP address=" << assocAP.address << "\n";
     ASSERT(mib->bssStationData.isAssociated);
     cancelPendingAssociation();
+    clearCurrentAssociation();
+}
+
+void Ieee80211MgmtSta::clearCurrentAssociation()
+{
+    ASSERT(mib->bssStationData.isAssociated);
     mib->bssStationData.isAssociated = false;
+    mib->removePeerHtCapabilities(assocAP.address);
     cancelAndDelete(assocAP.beaconTimeoutMsg);
     assocAP.beaconTimeoutMsg = nullptr;
     assocAP = AssociatedApInfo(); // clear it
+}
+
+bool Ieee80211MgmtSta::terminateCurrentAssociationFromPeer(const MacAddress& address)
+{
+    if (!mib->bssStationData.isAssociated || address != assocAP.address)
+        return false;
+
+    // Keep a stable AP-list object for the primitive confirmation while the
+    // association snapshot is cleared. A pending transaction for a different
+    // AP remains valid after the current association is terminated.
+    ApInfo *pendingAp = assocTimeoutMsg ? static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer()) : nullptr;
+    bool pendingReassociation = reassociationInProgress;
+    bool terminatesPendingRequest = pendingAp != nullptr && pendingAp->address == address;
+    if (terminatesPendingRequest)
+        cancelPendingAssociation();
+
+    EV << "Setting isAssociated flag to false\n";
+    clearCurrentAssociation();
+    if (terminatesPendingRequest) {
+        // The primitive API has no peer-aborted result; a termination of a
+        // same-peer pending request is reported as a refusal after teardown.
+        if (pendingReassociation)
+            sendReassociationConfirm(pendingAp, PRC_REFUSED);
+        else
+            sendAssociationConfirm(pendingAp, PRC_REFUSED);
+    }
+    return true;
+}
+
+void Ieee80211MgmtSta::stop()
+{
+    if (host != nullptr && isScanning && scanning.activeScan)
+        host->unsubscribe(IRadio::receptionStateChangedSignal, this);
+    isScanning = false;
+    cancelScanTimer();
+    scanning = ScanningInfo();
+
+    clearAPList();
+
+    if (mib->bssStationData.isAssociated)
+        clearCurrentAssociation();
+    else {
+        cancelAndDelete(assocAP.beaconTimeoutMsg);
+        assocAP.beaconTimeoutMsg = nullptr;
+        assocAP = AssociatedApInfo();
+    }
+
+    Ieee80211MgmtBase::stop();
 }
 
 void Ieee80211MgmtSta::sendAuthenticationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode)
@@ -701,8 +787,54 @@ void Ieee80211MgmtSta::handleAuthenticationFrame(Packet *packet, const Ptr<const
 void Ieee80211MgmtSta::handleDeauthenticationFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
     EV << "Received Deauthentication frame\n";
-    const MacAddress& address = header->getAddress3(); // source address
+    // IEEE Std 802.11-2024, 9.3.3.1: Address 2 is the transmitter/source
+    // address used to identify the peer that sent this frame.
+    const MacAddress& address = header->getTransmitterAddress();
     ApInfo *ap = lookupAP(address);
+    ApInfo *pendingAp = assocTimeoutMsg ? static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer()) : nullptr;
+    bool isPendingAp = pendingAp != nullptr && pendingAp->address == address;
+    bool isCurrentAp = mib->bssStationData.isAssociated && address == assocAP.address;
+
+    // IEEE Std 802.11-2024, 11.3.4.5: deauthentication from the current AP
+    // returns the STA to State 1. Do this before consulting the discovery
+    // cache: association state itself is authoritative for this transition.
+    if (isCurrentAp) {
+        // Clear the cached authentication state before the shared helper emits
+        // a possible same-peer transaction refusal, so observers see the
+        // complete State-1 transition in that callback as well.
+        if (ap != nullptr) {
+            ap->isAuthenticated = false;
+            if (ap->authTimeoutMsg) {
+                cancelAndDelete(ap->authTimeoutMsg);
+                ap->authTimeoutMsg = nullptr;
+            }
+        }
+        ASSERT(terminateCurrentAssociationFromPeer(address));
+        delete packet;
+        return;
+    }
+
+    // IEEE Std 802.11-2024, 11.3.5.1, 11.3.5.2 and 11.3.5.4: a
+    // deauthentication from the target AP terminates the pending association
+    // or reassociation, even when that AP is not the current AP.
+    if (isPendingAp) {
+        bool pendingReassociation = reassociationInProgress;
+        EV << "Cancelling pending association with deauthenticated AP\n";
+        pendingAp->isAuthenticated = false;
+        if (pendingAp->authTimeoutMsg) {
+            cancelAndDelete(pendingAp->authTimeoutMsg);
+            pendingAp->authTimeoutMsg = nullptr;
+        }
+        mib->removePeerHtCapabilities(address);
+        cancelPendingAssociation();
+        if (pendingReassociation)
+            sendReassociationConfirm(pendingAp, PRC_REFUSED);
+        else
+            sendAssociationConfirm(pendingAp, PRC_REFUSED);
+        delete packet;
+        return;
+    }
+
     if (!ap || !ap->isAuthenticated) {
         EV << "Unknown AP, or not authenticated with that AP -- ignoring frame\n";
         delete packet;
@@ -718,6 +850,7 @@ void Ieee80211MgmtSta::handleDeauthenticationFrame(Packet *packet, const Ptr<con
 
     EV << "Setting isAuthenticated flag for that AP to false\n";
     ap->isAuthenticated = false;
+    mib->removePeerHtCapabilities(address);
     delete packet;
 }
 
@@ -925,12 +1058,8 @@ void Ieee80211MgmtSta::handleReassociationFailure(ApInfo *ap)
 {
     // IEEE Std 802.11-2024, 11.3.5.4(f): failed or timed-out reassociation
     // disassociates the STA only when the target is its current AP.
-    if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address)) {
-        // This peer state belongs to the completed failed reassociation, not
-        // to the generic lifecycle reset performed by disassociate().
-        mib->removePeerHtCapabilities(ap->address);
+    if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address))
         disassociate();
-    }
     else {
         mib->removePeerHtCapabilities(ap->address);
         if (mib->bssStationData.isAssociated)
@@ -957,19 +1086,18 @@ void Ieee80211MgmtSta::handleReassociationResponseFrame(Packet *packet, const Pt
 void Ieee80211MgmtSta::handleDisassociationFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
 {
     EV << "Received Disassociation frame\n";
-    const MacAddress& address = header->getAddress3(); // source address
+    // IEEE Std 802.11-2024, 9.3.3.1: Address 2 carries the transmitter (TA/SA).
+    const MacAddress& address = header->getTransmitterAddress();
 
-    cancelPendingAssociation();
-    if (!mib->bssStationData.isAssociated || address != assocAP.address) {
+    // IEEE Std 802.11-2024, 11.3.5.7: process a Disassociation only from the
+    // AP whose peer state is State 3/4. In particular, a pending association
+    // to another AP must survive an unrelated frame.
+    if (!terminateCurrentAssociationFromPeer(address)) {
         EV << "Not associated with that AP -- ignoring frame\n";
         delete packet;
         return;
     }
-
-    EV << "Setting isAssociated flag to false\n";
-    mib->bssStationData.isAssociated = false;
-    cancelAndDelete(assocAP.beaconTimeoutMsg);
-    assocAP.beaconTimeoutMsg = nullptr;
+    delete packet;
 }
 
 void Ieee80211MgmtSta::handleBeaconFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -6,6 +6,7 @@
 
 
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 
 #include "inet/common/INETUtils.h"
 #include "inet/common/ModuleAccess.h"
@@ -18,6 +19,7 @@
 #include "inet/physicallayer/wireless/common/contract/packetlevel/RadioControlInfo_m.h"
 #include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211ControlInfo_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -31,6 +33,9 @@ using namespace physicallayer;
 // TODO mac should be able to signal when msg got transmitted
 
 Define_Module(Ieee80211MgmtSta);
+Register_Class(Ieee80211MgmtSta::HtNegotiationFailure);
+
+simsignal_t Ieee80211MgmtSta::htNegotiationFailedSignal = cComponent::registerSignal("htNegotiationFailed");
 
 // message kind values for timers
 #define MK_AUTH_TIMEOUT           1
@@ -41,6 +46,53 @@ Define_Module(Ieee80211MgmtSta);
 #define MK_BEACON_TIMEOUT         6
 
 #define MAX_BEACONS_MISSED        3.5  // beacon lost timeout, in beacon intervals (doesn't need to be integer)
+
+static bool decodeHtOperation(const IIeee80211Band *band,
+        const Ieee80211HtOperationElement& element, Ieee80211HtOperation& operation, std::string& reason)
+{
+    try {
+        operation = makeHtOperation(band, element);
+        return true;
+    }
+    catch (const cRuntimeError& error) {
+        reason = error.what();
+        return false;
+    }
+}
+
+static bool validateHtOperation(const IIeee80211Band *band, const Ieee80211HtOperation& operation,
+        std::string& reason)
+{
+    if (band == nullptr) {
+        reason = "HT Operation has no IEEE 802.11 band";
+        return false;
+    }
+
+    // IEEE Std 802.11-2024, Table 9-230 and 11.15.2: the channel width and
+    // secondary-channel offset form one tuple, and a 40 MHz tuple must name
+    // an actually supported pair in the selected band.
+    if (operation.operatingChannelWidth == MHz(20)) {
+        if (operation.secondaryChannelOffset != 0) {
+            reason = "20 MHz HT Operation has a secondary channel offset";
+            return false;
+        }
+    }
+    else if (operation.operatingChannelWidth == MHz(40)) {
+        if (operation.secondaryChannelOffset != 1 && operation.secondaryChannelOffset != 3) {
+            reason = "40 MHz HT Operation has no valid secondary channel offset";
+            return false;
+        }
+        if (!band->isHt40OperationSupported(operation.primaryChannel, operation.secondaryChannelOffset)) {
+            reason = "40 MHz HT Operation names an unsupported primary/secondary channel pair";
+            return false;
+        }
+    }
+    else {
+        reason = "HT Operation has an unsupported channel width";
+        return false;
+    }
+    return true;
+}
 
 std::ostream& operator<<(std::ostream& os, const Ieee80211MgmtSta::ScanningInfo& scanning)
 {
@@ -289,7 +341,8 @@ void Ieee80211MgmtSta::startAssociation(ApInfo *ap, simtime_t timeout)
     const auto& body = makeShared<Ieee80211AssociationRequestFrame>();
     body->setSSID(ap->ssid.c_str());
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + 2 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Assoc", body, ST_ASSOCIATIONREQUEST, ap->address);
     reassociationInProgress = false;
 
@@ -311,7 +364,8 @@ void Ieee80211MgmtSta::startReassociation(ApInfo *ap, simtime_t timeout)
     body->setCurrentAP(assocAP.address);
     body->setSSID(ap->ssid.c_str());
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + 6 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + 2 + 6 + (2 + strlen(body->getSSID()))) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Reassoc", body, ST_REASSOCIATIONREQUEST, ap->address);
     reassociationInProgress = true;
     assocTimeoutMsg = new cMessage("assocTimeout", MK_ASSOC_TIMEOUT);
@@ -407,7 +461,8 @@ void Ieee80211MgmtSta::sendProbeRequest()
     const auto& body = makeShared<Ieee80211ProbeRequestFrame>();
     body->setSSID(scanning.ssid.c_str());
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + scanning.ssid.length()) + getSupportedRateElementsLength(body));
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + scanning.ssid.length()) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("ProbeReq", body, ST_PROBEREQUEST, scanning.bssid);
 }
 
@@ -478,6 +533,12 @@ void Ieee80211MgmtSta::processAssociateCommand(Ieee80211Prim_AssociateRequest *c
     ApInfo *ap = lookupAP(address);
     if (!ap)
         throw cRuntimeError("processAssociateCommand: AP not known: address = %s", address.str().c_str());
+    std::string reason;
+    if (!isHtBssSupported(ap, reason)) {
+        EV_INFO << "Association refused before request transmission: " << reason << endl;
+        sendAssociationConfirm(ap, PRC_REFUSED);
+        return;
+    }
     startAssociation(ap, ctrl->getTimeout());
 }
 
@@ -493,6 +554,12 @@ void Ieee80211MgmtSta::processReassociateCommand(Ieee80211Prim_ReassociateReques
     ApInfo *ap = lookupAP(address);
     if (!ap)
         throw cRuntimeError("processReassociateCommand: AP not known: address = %s", address.str().c_str());
+    std::string reason;
+    if (!isHtBssSupported(ap, reason)) {
+        EV_INFO << "Reassociation refused before request transmission: " << reason << endl;
+        sendReassociationConfirm(ap, PRC_REFUSED);
+        return;
+    }
     startReassociation(ap, ctrl->getTimeout());
 }
 
@@ -696,6 +763,24 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
     const auto& responseBody = packet->peekData<Ieee80211AssociationResponseFrame>();
     int statusCode = responseBody->getStatusCode();
 
+    HtAssociationResponseStatus responseHtStatus = HtAssociationResponseStatus::LEGACY;
+    Ieee80211HtCapabilities responseHtCapabilities;
+    Ieee80211HtOperation responseHtOperation;
+    std::string responseHtReason;
+    const auto& channelInd = packet->findTag<Ieee80211ChannelInd>();
+    const auto *receivedChannel = channelInd != nullptr ? channelInd->getChannel() : nullptr;
+    const auto *band = receivedChannel != nullptr ? receivedChannel->getBand() : nullptr;
+    if (statusCode == SC_SUCCESSFUL)
+        responseHtStatus = classifyAssociationResponse(responseBody, band,
+                ap->htOperationPresent ? &ap->htOperation : nullptr,
+                responseHtCapabilities, responseHtOperation, responseHtReason);
+    if (responseHtStatus == HtAssociationResponseStatus::VALID_HT &&
+            (receivedChannel == nullptr || responseHtOperation.primaryChannel != receivedChannel->getChannelNumber())) {
+        responseHtStatus = HtAssociationResponseStatus::INVALID_HT;
+        responseHtReason = receivedChannel == nullptr ?
+                "successful HT association response has no received channel indication" :
+                "HT Operation primary channel does not match the received channel";
+    }
     delete packet;
 
     cancelPendingAssociation();
@@ -704,6 +789,8 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         EV << "Association failed with AP address=" << ap->address << "\n";
         if (reassociation)
             handleReassociationFailure(ap);
+        else if (!mib->bssStationData.isAssociated || assocAP.address != ap->address)
+            mib->removePeerHtCapabilities(ap->address);
     }
     else {
         EV << "Association successful, AP address=" << ap->address << "\n";
@@ -711,6 +798,7 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         if (mib->bssStationData.isAssociated) {
             EV << "Breaking existing association with AP address=" << assocAP.address << "\n";
             mib->bssStationData.isAssociated = false;
+            mib->removePeerHtCapabilities(assocAP.address);
             cancelAndDelete(assocAP.beaconTimeoutMsg);
             assocAP.beaconTimeoutMsg = nullptr;
             assocAP = AssociatedApInfo();
@@ -721,6 +809,21 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         mib->bssData.bssid = ap->address;
         mib->bssStationData.isAssociated = true;
         (ApInfo&)assocAP = (*ap);
+        if (responseHtStatus == HtAssociationResponseStatus::VALID_HT)
+            mib->setPeerHtCapabilities(ap->address, responseHtCapabilities, responseHtOperation);
+        else {
+            mib->removePeerHtCapabilities(ap->address);
+            if (responseHtStatus == HtAssociationResponseStatus::INVALID_HT) {
+                EV_WARN << "Association succeeded without usable HT negotiation with AP address=" << ap->address
+                        << ": " << responseHtReason << "\n";
+                HtNegotiationFailure notification;
+                notification.setPeerAddress(ap->address);
+                notification.setReassociation(reassociation);
+                notification.setStatus(responseHtStatus);
+                notification.setReason(responseHtReason);
+                emit(htNegotiationFailedSignal, &notification);
+            }
+        }
 
         emit(l2AssociatedSignal, myIface, ap);
 
@@ -735,14 +838,104 @@ void Ieee80211MgmtSta::processAssociationResponse(Packet *packet, const Ptr<cons
         sendAssociationConfirm(ap, statusCodeToPrimResultCode(statusCode));
 }
 
+Ieee80211MgmtSta::HtAssociationResponseStatus Ieee80211MgmtSta::classifyAssociationResponse(
+        const Ptr<const Ieee80211AssociationResponseFrame>& responseBody,
+        const physicallayer::IIeee80211Band *band,
+        const Ieee80211HtOperation *selectedBssHtOperation,
+        Ieee80211HtCapabilities& responseHtCapabilities, Ieee80211HtOperation& responseHtOperation,
+        std::string& reason) const
+{
+    bool responseHtCapabilitiesPresent = responseBody->getHtCapabilitiesPresent();
+    bool responseHtOperationPresent = responseBody->getHtOperationPresent();
+    // A non-HT station deliberately ignores HT elements. This preserves the
+    // genuine legacy association path even when an HT-capable AP includes its
+    // normal response elements.
+    if (!mib->isHtOperationSupported())
+        return HtAssociationResponseStatus::LEGACY;
+    if (!responseHtCapabilitiesPresent && !responseHtOperationPresent)
+        return HtAssociationResponseStatus::LEGACY;
+    if (responseHtCapabilitiesPresent != responseHtOperationPresent) {
+        reason = "association response contains only one of the HT Capabilities and HT Operation elements";
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    if (band == nullptr) {
+        reason = "successful HT association response has no received channel indication or band";
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    if (selectedBssHtOperation == nullptr) {
+        reason = "successful HT association response has no cached HT Operation from BSS discovery";
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    // The response is peer input. Keep the conversion helpers strict for
+    // local/configuration use, but turn their failures into an unusable HT
+    // negotiation at this receive boundary.
+    if (!decodeHtCapabilities(responseBody->getHtCapabilities(), responseHtCapabilities, reason)) {
+        reason = "invalid HT Capabilities in association response: " + reason;
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    if (!decodeHtOperation(band, responseBody->getHtOperation(), responseHtOperation, reason)) {
+        reason = "invalid HT Operation in association response: " + reason;
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    if (!validateHtOperation(band, responseHtOperation, reason))
+        return HtAssociationResponseStatus::INVALID_HT;
+    // Table 9-230 reserves the Basic HT-MCS Set in Association and
+    // Reassociation Responses. Use the selected BSS's Beacon/Probe Response
+    // advertisement instead of interpreting those reserved response bits.
+    responseHtOperation.basicMcsSupported = selectedBssHtOperation->basicMcsSupported;
+    auto negotiated = negotiateHtCapabilities(mib->localHtCapabilities, responseHtCapabilities, responseHtOperation);
+    if (!supportsBasicHtMcsSet(mib->localHtCapabilities, responseHtOperation) ||
+            !negotiated.localTxPeerRx.valid || !negotiated.localRxPeerTx.valid) {
+        reason = "HT capabilities and operation have no bidirectionally usable common mode";
+        return HtAssociationResponseStatus::INVALID_HT;
+    }
+    return HtAssociationResponseStatus::VALID_HT;
+}
+
+bool Ieee80211MgmtSta::isHtBssSupported(const ApInfo *ap, std::string& reason) const
+{
+    if (!mib->isHtOperationSupported())
+        return true;
+    if (!ap->htCapabilitiesPresent && !ap->htOperationPresent)
+        return true;
+    if (ap->htCapabilitiesPresent != ap->htOperationPresent) {
+        reason = "selected BSS contains only one of the HT Capabilities and HT Operation elements";
+        return false;
+    }
+    auto negotiated = negotiateHtCapabilities(mib->localHtCapabilities, ap->htCapabilities, ap->htOperation);
+    if (!supportsBasicHtMcsSet(mib->localHtCapabilities, ap->htOperation) ||
+            !negotiated.localTxPeerRx.valid || !negotiated.localRxPeerTx.valid) {
+        reason = "selected BSS HT advertisement has no bidirectionally usable common mode";
+        return false;
+    }
+    return true;
+}
+
+const char *Ieee80211MgmtSta::getHtAssociationResponseStatusName(HtAssociationResponseStatus status)
+{
+    switch (status) {
+        case HtAssociationResponseStatus::LEGACY: return "LEGACY";
+        case HtAssociationResponseStatus::VALID_HT: return "VALID_HT";
+        case HtAssociationResponseStatus::INVALID_HT: return "INVALID_HT";
+        default: return "UNKNOWN";
+    }
+}
+
 void Ieee80211MgmtSta::handleReassociationFailure(ApInfo *ap)
 {
     // IEEE Std 802.11-2024, 11.3.5.4(f): failed or timed-out reassociation
     // disassociates the STA only when the target is its current AP.
-    if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address))
+    if (shouldDisassociateOnReassociationFailure(mib->bssStationData.isAssociated, assocAP.address, ap->address)) {
+        // This peer state belongs to the completed failed reassociation, not
+        // to the generic lifecycle reset performed by disassociate().
+        mib->removePeerHtCapabilities(ap->address);
         disassociate();
-    else if (mib->bssStationData.isAssociated)
-        changeChannel(assocAP.channel);
+    }
+    else {
+        mib->removePeerHtCapabilities(ap->address);
+        if (mib->bssStationData.isAssociated)
+            changeChannel(assocAP.channel);
+    }
 }
 
 bool Ieee80211MgmtSta::shouldDisassociateOnReassociationFailure(bool isAssociated,
@@ -783,10 +976,10 @@ void Ieee80211MgmtSta::handleBeaconFrame(Packet *packet, const Ptr<const Ieee802
 {
     EV << "Received Beacon frame\n";
     const auto& beaconBody = packet->peekData<Ieee80211BeaconFrame>();
-    storeAPInfo(packet, header, beaconBody);
+    bool accepted = storeAPInfo(packet, header, beaconBody);
 
     // if it is out associate AP, restart beacon timeout
-    if (mib->bssStationData.isAssociated && header->getTransmitterAddress() == assocAP.address) {
+    if (accepted && mib->bssStationData.isAssociated && header->getTransmitterAddress() == assocAP.address) {
         EV << "Beacon is from associated AP, restarting beacon timeout timer\n";
         ASSERT(assocAP.beaconTimeoutMsg != nullptr);
         rescheduleAfter(MAX_BEACONS_MISSED * assocAP.beaconInterval, assocAP.beaconTimeoutMsg);
@@ -811,32 +1004,112 @@ void Ieee80211MgmtSta::handleProbeResponseFrame(Packet *packet, const Ptr<const 
     delete packet;
 }
 
-void Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, const Ptr<const Ieee80211BeaconFrame>& body)
+bool Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, const Ptr<const Ieee80211BeaconFrame>& body)
 {
     auto address = header->getTransmitterAddress();
     ApInfo *ap = lookupAP(address);
-    if (ap) {
-        EV << "AP address=" << address << ", SSID=" << body->getSSID() << " already in our AP list, refreshing the info\n";
-    }
-    else {
-        EV << "Inserting AP address=" << address << ", SSID=" << body->getSSID() << " into our AP list\n";
-        apList.push_back(ApInfo());
-        ap = &apList.back();
+    ApInfo candidate;
+    if (ap != nullptr) {
+        // Authentication state belongs to the cached AP record, not to one
+        // advertisement. Keep its timer and state untouched until validation
+        // has completed successfully.
+        candidate.isAuthenticated = ap->isAuthenticated;
+        candidate.authSeqExpected = ap->authSeqExpected;
+        candidate.authTimeoutMsg = ap->authTimeoutMsg;
+        candidate.rxPower = ap->rxPower;
     }
 
-    ap->channel = body->getChannelNumber();
-    ap->address = address;
-    ap->ssid = body->getSSID();
-    ap->supportedRates = body->getSupportedRates();
-    ap->extendedSupportedRatesPresent = body->getExtendedSupportedRatesPresent();
-    ap->extendedSupportedRates = body->getExtendedSupportedRates();
-    ap->beaconInterval = body->getBeaconInterval();
-    auto signalPowerInd = packet->getTag<SignalPowerInd>();
-    if (signalPowerInd != nullptr) {
-        ap->rxPower = signalPowerInd->getPower().get<W>();
-        if (ap->address == assocAP.address)
-            assocAP.rxPower = ap->rxPower;
+    candidate.address = address;
+    candidate.ssid = body->getSSID();
+    candidate.supportedRates = body->getSupportedRates();
+    candidate.extendedSupportedRatesPresent = body->getExtendedSupportedRatesPresent();
+    candidate.extendedSupportedRates = body->getExtendedSupportedRates();
+    bool htCapabilitiesPresent = body->getHtCapabilitiesPresent();
+    bool htOperationPresent = body->getHtOperationPresent();
+    bool ignoreHt = mib != nullptr && !mib->isHtOperationSupported();
+    std::string reason;
+    if (ignoreHt) {
+        // A legacy STA ignores optional HT information, including malformed
+        // typed values, and retains the legacy channel advertisement.
+        candidate.channel = body->getChannelNumber();
+        candidate.htCapabilitiesPresent = false;
+        candidate.htOperationPresent = false;
     }
+    else {
+        if (htCapabilitiesPresent != htOperationPresent) {
+            reason = "Beacon or Probe Response contains only one of the HT Capabilities and HT Operation elements";
+            EV_WARN << "Ignoring HT discovery from AP address=" << address << ": " << reason << "\n";
+            return false;
+        }
+        candidate.htCapabilitiesPresent = htCapabilitiesPresent;
+        candidate.htOperationPresent = htOperationPresent;
+        if (htCapabilitiesPresent && !decodeHtCapabilities(body->getHtCapabilities(), candidate.htCapabilities, reason)) {
+            EV_WARN << "Ignoring HT discovery from AP address=" << address
+                    << ": invalid HT Capabilities: " << reason << "\n";
+            return false;
+        }
+        if (htOperationPresent) {
+            const auto& channelInd = packet->findTag<Ieee80211ChannelInd>();
+            const auto *receivedChannel = channelInd != nullptr ? channelInd->getChannel() : nullptr;
+            if (receivedChannel == nullptr) {
+                reason = "HT Operation discovery has no received channel indication";
+                EV_WARN << "Ignoring HT discovery from AP address=" << address << ": " << reason << "\n";
+                return false;
+            }
+            if (!decodeHtOperation(receivedChannel->getBand(), body->getHtOperation(), candidate.htOperation, reason)) {
+                EV_WARN << "Ignoring HT discovery from AP address=" << address
+                        << ": invalid HT Operation: " << reason << "\n";
+                return false;
+            }
+            if (candidate.htOperation.primaryChannel != receivedChannel->getChannelNumber()) {
+                reason = "HT Operation primary channel does not match the received channel index";
+                EV_WARN << "Ignoring HT discovery from AP address=" << address << ": " << reason << "\n";
+                return false;
+            }
+            if (!validateHtOperation(receivedChannel->getBand(), candidate.htOperation, reason)) {
+                EV_WARN << "Ignoring HT discovery from AP address=" << address << ": " << reason << "\n";
+                return false;
+            }
+            // IEEE Std 802.11-2024, Table 9-230 and 11.14: the HT Operation
+            // primary channel is authoritative once converted to the
+            // received radio's internal channel index.
+            candidate.channel = candidate.htOperation.primaryChannel;
+        }
+        else
+            candidate.channel = body->getChannelNumber();
+    }
+    candidate.beaconInterval = body->getBeaconInterval();
+    auto signalPowerInd = packet->getTag<SignalPowerInd>();
+    bool currentAp = address == assocAP.address;
+    if (signalPowerInd != nullptr)
+        candidate.rxPower = signalPowerInd->getPower().get<W>();
+
+    if (ap == nullptr) {
+        apList.push_back(ApInfo());
+        ap = &apList.back();
+        EV << "Inserting AP address=" << address << ", SSID=" << body->getSSID() << " into our AP list\n";
+    }
+    else
+        EV << "AP address=" << address << ", SSID=" << body->getSSID()
+                << " already in our AP list, refreshing the info\n";
+    ap->channel = candidate.channel;
+    ap->address = candidate.address;
+    ap->ssid = candidate.ssid;
+    ap->supportedRates = candidate.supportedRates;
+    ap->extendedSupportedRatesPresent = candidate.extendedSupportedRatesPresent;
+    ap->extendedSupportedRates = candidate.extendedSupportedRates;
+    ap->htCapabilitiesPresent = candidate.htCapabilitiesPresent;
+    ap->htCapabilities = candidate.htCapabilities;
+    ap->htOperationPresent = candidate.htOperationPresent;
+    ap->htOperation = candidate.htOperation;
+    ap->beaconInterval = candidate.beaconInterval;
+    ap->rxPower = candidate.rxPower;
+    ap->isAuthenticated = candidate.isAuthenticated;
+    ap->authSeqExpected = candidate.authSeqExpected;
+    ap->authTimeoutMsg = candidate.authTimeoutMsg;
+    if (signalPowerInd != nullptr && currentAp)
+        assocAP.rxPower = candidate.rxPower;
+    return true;
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -94,6 +94,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     // associated Access Point
     cMessage *assocTimeoutMsg; // if non-nullptr: association is in progress
+    bool reassociationInProgress = false;
     AssociatedApInfo assocAP;
 
   public:
@@ -116,18 +117,30 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Utility function: sends association request */
     virtual void startAssociation(ApInfo *ap, simtime_t timeout);
+    virtual void startReassociation(ApInfo *ap, simtime_t timeout);
 
     /** Utility function: looks up AP in our AP list. Returns nullptr if not found. */
     virtual ApInfo *lookupAP(const MacAddress& address);
 
-    /** Utility function: clear the AP list, and cancel any pending authentications. */
+    /** Utility function: clear the AP list and cancel pending association and authentication transactions. */
     virtual void clearAPList();
+
+    /** Utility function: cancel any pending association or reassociation. */
+    virtual void cancelPendingAssociation();
 
     /** Utility function: switches to the given radio channel. */
     virtual void changeChannel(int channelNum);
 
     /** Stores AP info received in a beacon or probe response */
     virtual void storeAPInfo(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, const Ptr<const Ieee80211BeaconFrame>& body);
+
+    /** Processes Association and Reassociation Responses without using cached Beacon capabilities. */
+    virtual void processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation);
+
+    /** Applies the failed-reassociation state transition for the target AP. */
+    virtual void handleReassociationFailure(ApInfo *ap);
+    static bool shouldDisassociateOnReassociationFailure(bool isAssociated,
+            const MacAddress& associatedApAddress, const MacAddress& targetApAddress);
 
     /** Switches to the next channel to scan; returns true if done (there wasn't any more channel to scan). */
     virtual bool scanNextChannel();
@@ -146,6 +159,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Sends back result of association to the agent */
     virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode);
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode);
 
     /** Utility function: Cancel the existing association */
     virtual void disassociate();

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -116,6 +116,7 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     // scanning status
     bool isScanning;
+    cMessage *scanTimer;
     ScanningInfo scanning;
 
     // ApInfo list: we collect scanning results and keep track of ongoing authentications here
@@ -129,7 +130,8 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     AssociatedApInfo assocAP;
 
   public:
-    Ieee80211MgmtSta() : host(nullptr), numChannels(-1), isScanning(false), assocTimeoutMsg(nullptr) {}
+    Ieee80211MgmtSta() : host(nullptr), numChannels(-1), isScanning(false), scanTimer(nullptr), assocTimeoutMsg(nullptr) {}
+    virtual ~Ieee80211MgmtSta();
 
     virtual const ApInfo *getAssociatedAp() { return &assocAP; }
 
@@ -189,6 +191,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     /** Switches to the next channel to scan; returns true if done (there wasn't any more channel to scan). */
     virtual bool scanNextChannel();
 
+    /** Utility function: cancels and deletes the outstanding scan timer, if any. */
+    virtual void cancelScanTimer();
+
     /** Broadcasts a Probe Request */
     virtual void sendProbeRequest();
 
@@ -208,6 +213,12 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     /** Utility function: Cancel the existing association */
     virtual void disassociate();
 
+    /** Utility function: clear the existing association without touching a pending transition. */
+    virtual void clearCurrentAssociation();
+
+    /** Processes a peer-initiated termination of the current association. */
+    virtual bool terminateCurrentAssociationFromPeer(const MacAddress& address);
+
     /** Utility function: sends a confirmation to the agent */
     virtual void sendConfirm(Ieee80211PrimConfirm *confirm, Ieee80211PrimResultCode resultCode);
 
@@ -216,6 +227,9 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 
     /** Called by the signal handler whenever a change occurs we're interested in */
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
+
+    /** lifecycle support */
+    virtual void stop() override;
 
     /** Utility function: converts Ieee80211StatusCode (->frame) to Ieee80211PrimResultCode (->primitive) */
     virtual Ieee80211PrimResultCode statusCodeToPrimResultCode(int statusCode);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h
@@ -25,6 +25,33 @@ namespace ieee80211 {
 class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
 {
   public:
+    enum class HtAssociationResponseStatus {
+        LEGACY,
+        VALID_HT,
+        INVALID_HT,
+    };
+
+    /** Describes a successful association response whose HT negotiation could not be used. */
+    class INET_API HtNegotiationFailure : public cObject {
+      private:
+        MacAddress peerAddress;
+        bool reassociation = false;
+        HtAssociationResponseStatus status = HtAssociationResponseStatus::INVALID_HT;
+        std::string reason;
+
+      public:
+        void setPeerAddress(const MacAddress& address) { peerAddress = address; }
+        void setReassociation(bool value) { reassociation = value; }
+        void setStatus(HtAssociationResponseStatus value) { status = value; }
+        void setReason(const std::string& value) { reason = value; }
+        const MacAddress& getPeerAddress() const { return peerAddress; }
+        bool isReassociation() const { return reassociation; }
+        HtAssociationResponseStatus getStatus() const { return status; }
+        const std::string& getReason() const { return reason; }
+    };
+
+    static simsignal_t htNegotiationFailedSignal;
+
     //
     // Encapsulates information about the ongoing scanning process
     //
@@ -44,12 +71,16 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     // Stores AP info received during scanning
     //
     struct ApInfo : public cObject {
-        int channel;
+        int channel; // internal zero-based radio channel index
         MacAddress address; // alias bssid
         std::string ssid;
         Ieee80211SupportedRatesElement supportedRates;
         bool extendedSupportedRatesPresent = false;
         Ieee80211ExtendedSupportedRatesElement extendedSupportedRates;
+        bool htCapabilitiesPresent = false;
+        Ieee80211HtCapabilities htCapabilities;
+        bool htOperationPresent = false;
+        Ieee80211HtOperation htOperation;
         simtime_t beaconInterval;
         double rxPower;
 
@@ -132,10 +163,23 @@ class INET_API Ieee80211MgmtSta : public Ieee80211MgmtBase
     virtual void changeChannel(int channelNum);
 
     /** Stores AP info received in a beacon or probe response */
-    virtual void storeAPInfo(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, const Ptr<const Ieee80211BeaconFrame>& body);
+    virtual bool storeAPInfo(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, const Ptr<const Ieee80211BeaconFrame>& body);
 
-    /** Processes Association and Reassociation Responses without using cached Beacon capabilities. */
+    /** Processes Association and Reassociation Responses using the selected BSS discovery state. */
     virtual void processAssociationResponse(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header, bool reassociation);
+
+    /** Returns whether the selected BSS's cached HT advertisement is usable locally. */
+    virtual bool isHtBssSupported(const ApInfo *ap, std::string& reason) const;
+
+    /** Classifies the HT elements in a successful association response. */
+    virtual HtAssociationResponseStatus classifyAssociationResponse(
+            const Ptr<const Ieee80211AssociationResponseFrame>& responseBody,
+            const physicallayer::IIeee80211Band *band,
+            const Ieee80211HtOperation *selectedBssHtOperation,
+            Ieee80211HtCapabilities& responseHtCapabilities, Ieee80211HtOperation& responseHtOperation,
+            std::string& reason) const;
+
+    static const char *getHtAssociationResponseStatusName(HtAssociationResponseStatus status);
 
     /** Applies the failed-reassociation state transition for the target AP. */
     virtual void handleReassociationFailure(ApInfo *ap);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.ned
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.ned
@@ -35,6 +35,7 @@ simple Ieee80211MgmtSta extends SimpleModule like IIeee80211Mgmt
         @display("i=block/cogwheel");
         @signal[l2Associated](type=inet::NetworkInterface);
         @signal[l2BeaconLost](type=inet::NetworkInterface);
+        @signal[htNegotiationFailed](type="inet::ieee80211::Ieee80211MgmtSta::HtNegotiationFailure");
     gates:
         input macIn @labels(Ieee80211MacHeader);
         output macOut @labels(Ieee80211MacHeader);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.cc
@@ -15,6 +15,33 @@ namespace ieee80211 {
 
 Define_Module(Ieee80211MgmtStaSimplified);
 
+static Ieee80211Mib *findAccessPointMib(const MacAddress& accessPointAddress, bool required = true)
+{
+    L3AddressResolver addressResolver;
+    auto host = addressResolver.findHostWithAddress(accessPointAddress);
+    if (host == nullptr) {
+        if (required)
+            throw cRuntimeError("Access point with address %s not found", accessPointAddress.str().c_str());
+        return nullptr;
+    }
+    auto interfaceTable = addressResolver.findInterfaceTableOf(host);
+    if (interfaceTable == nullptr) {
+        if (required)
+            throw cRuntimeError("Access point interface table with address %s not found", accessPointAddress.str().c_str());
+        return nullptr;
+    }
+    auto networkInterface = interfaceTable->findInterfaceByAddress(accessPointAddress);
+    if (networkInterface == nullptr) {
+        if (required)
+            throw cRuntimeError("Access point interface with address %s not found", accessPointAddress.str().c_str());
+        return nullptr;
+    }
+    auto apMib = dynamic_cast<Ieee80211Mib *>(networkInterface->getSubmodule("mib"));
+    if (apMib == nullptr && required)
+        throw cRuntimeError("Access point MIB with address %s not found", accessPointAddress.str().c_str());
+    return apMib;
+}
+
 void Ieee80211MgmtStaSimplified::initialize(int stage)
 {
     Ieee80211MgmtBase::initialize(stage);
@@ -24,18 +51,45 @@ void Ieee80211MgmtStaSimplified::initialize(int stage)
         mib->bssStationData.isAssociated = true;
     }
     else if (stage == INITSTAGE_LINK_LAYER) {
-        L3AddressResolver addressResolver;
-        auto accessPointAddress = addressResolver.resolve(par("accessPointAddress"), L3AddressResolver::ADDR_MAC).toMac();
-        mib->bssData.bssid = accessPointAddress;
-        auto host = addressResolver.findHostWithAddress(mib->bssData.bssid);
-        if (host == nullptr)
-            throw cRuntimeError("Access point with address %s not found", mib->bssData.bssid.str().c_str());
-        auto interfaceTable = addressResolver.findInterfaceTableOf(host);
-        auto networkInterface = interfaceTable->findInterfaceByAddress(mib->bssData.bssid);
-        auto apMib = dynamic_cast<Ieee80211Mib *>(networkInterface->getSubmodule("mib"));
-        apMib->bssAccessPointData.stations[mib->address] = Ieee80211Mib::ASSOCIATED;
-        mib->bssData.ssid = apMib->bssData.ssid;
+        configureAssociation();
     }
+    else if (stage == INITSTAGE_LAST)
+        configureAssociation();
+}
+
+void Ieee80211MgmtStaSimplified::handleStartOperation(LifecycleOperation *operation)
+{
+    Ieee80211MgmtBase::handleStartOperation(operation);
+    if (operation != nullptr)
+        configureAssociation();
+}
+
+void Ieee80211MgmtStaSimplified::configureAssociation()
+{
+    L3AddressResolver addressResolver;
+    auto accessPointAddress = addressResolver.resolve(par("accessPointAddress"), L3AddressResolver::ADDR_MAC).toMac();
+    mib->bssData.bssid = accessPointAddress;
+    auto apMib = findAccessPointMib(accessPointAddress);
+    apMib->bssAccessPointData.stations[mib->address] = Ieee80211Mib::ASSOCIATED;
+    mib->bssData.ssid = apMib->bssData.ssid;
+    mib->bssStationData.isAssociated = true;
+    // Simplified management is an explicit no-air abstraction: install the state that the
+    // Association Request/Response exchange would have committed in detailed management.
+    if (mib->isHtOperationSupported() && apMib->isHtOperationSupported()) {
+        mib->setPeerHtCapabilities(apMib->address, apMib->localHtCapabilities, apMib->getHtOperation());
+        apMib->setPeerHtCapabilities(mib->address, mib->localHtCapabilities, apMib->getHtOperation());
+    }
+}
+
+void Ieee80211MgmtStaSimplified::stop()
+{
+    mib->bssStationData.isAssociated = false;
+    auto apMib = findAccessPointMib(mib->bssData.bssid, false);
+    if (apMib != nullptr) {
+        apMib->bssAccessPointData.stations.erase(mib->address);
+        apMib->removePeerHtCapabilities(mib->address);
+    }
+    Ieee80211MgmtBase::stop();
 }
 
 void Ieee80211MgmtStaSimplified::handleTimer(cMessage *msg)

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtStaSimplified.h
@@ -25,6 +25,9 @@ class INET_API Ieee80211MgmtStaSimplified : public Ieee80211MgmtBase
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
     virtual void initialize(int) override;
+    virtual void handleStartOperation(LifecycleOperation *operation) override;
+    virtual void configureAssociation();
+    virtual void stop() override;
 
     /** Implements abstract Ieee80211MgmtBase method */
     virtual void handleTimer(cMessage *msg) override;

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag.msg
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag.msg
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2026 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+import inet.common.INETDefs;
+import inet.common.TagBase;
+
+namespace inet::ieee80211;
+
+//
+// Identifies a local management transaction across packet replacement and
+// fragmentation. The physical layer removes this sender-local metadata.
+//
+class Ieee80211MgmtTransactionTag extends TagBase
+{
+    uint64_t transactionId = 0;
+}

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -24,6 +24,7 @@ void Ieee80211Mib::initialize(int stage)
         WATCH(mode);
         WATCH(qos);
         WATCH(localHtCapabilitiesValid);
+        WATCH(primaryChannelAvailable);
         WATCH(bssData.bssid);
         WATCH(bssStationData.stationType);
         WATCH(bssStationData.isAssociated);
@@ -35,7 +36,29 @@ void Ieee80211Mib::initialize(int stage)
         WATCH_EXPR("ssidStr", getSsidStr());
         WATCH_EXPR("ssid", bssData.ssid.empty() ? std::string("-") : bssData.ssid); // associated SSID ("-" if none), for node display strings
         WATCH_EXPR("associatedStr", bssStationData.stationType == STATION ? (bssStationData.isAssociated ? "\nAssociated" : "\nNot associated") : "");
+        WATCH_EXPR("primaryChannel", primaryChannelAvailable ? std::to_string(htOperation.primaryChannel) : "unavailable");
     }
+}
+
+int Ieee80211Mib::requirePrimaryChannel() const
+{
+    if (!primaryChannelAvailable)
+        throw cRuntimeError("IEEE 802.11 primary channel is unavailable");
+    return htOperation.primaryChannel;
+}
+
+void Ieee80211Mib::setPrimaryChannel(int primaryChannel)
+{
+    if (primaryChannel < 0 || primaryChannel > 255)
+        throw cRuntimeError("IEEE 802.11 primary channel must be in the range 0..255, not %d", primaryChannel);
+    htOperation.primaryChannel = primaryChannel;
+    primaryChannelAvailable = true;
+}
+
+const Ieee80211HtOperation& Ieee80211Mib::getHtOperation() const
+{
+    requirePrimaryChannel();
+    return htOperation;
 }
 
 void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet,
@@ -44,10 +67,12 @@ void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeS
     // The radio publishes its initial channel at PHYSICAL_LAYER before the MAC
     // publishes its mode set at LINK_LAYER. Preserve that independent BSS
     // operation input when rebuilding the mode-derived capability subset.
+    bool wasPrimaryChannelAvailable = primaryChannelAvailable;
     int primaryChannel = htOperation.primaryChannel;
     localHtCapabilities = Ieee80211HtCapabilities();
     htOperation = Ieee80211HtOperation();
     htOperation.primaryChannel = primaryChannel;
+    primaryChannelAvailable = wasPrimaryChannelAvailable;
     localHtCapabilitiesValid = modeSet != nullptr && modeSet->isHtOperationSupported();
     if (!localHtCapabilitiesValid) {
         clearPeerHtCapabilities();

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
@@ -78,9 +78,10 @@ class INET_API Ieee80211Mib : public SimpleModule
     // This is a deliberately model-backed subset, not a full Annex C HT MIB implementation.
     bool localHtCapabilitiesValid = false;
     Ieee80211HtCapabilities localHtCapabilities;
-    Ieee80211HtOperation htOperation;
 
   private:
+    Ieee80211HtOperation htOperation;
+    bool primaryChannelAvailable = false;
     std::map<MacAddress, PeerHtState> peerHtStates;
 
   protected:
@@ -95,6 +96,10 @@ class INET_API Ieee80211Mib : public SimpleModule
     void updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet,
             const std::set<Hz>& operationalChannelWidths, int operationalHtSpatialStreamLimit);
     bool isHtOperationSupported() const { return localHtCapabilitiesValid; }
+    bool hasPrimaryChannel() const { return primaryChannelAvailable; }
+    int requirePrimaryChannel() const;
+    void setPrimaryChannel(int primaryChannel);
+    const Ieee80211HtOperation& getHtOperation() const;
     const PeerHtState *findPeerHtState(const MacAddress& address) const;
     void setPeerHtCapabilities(const MacAddress& address, const Ieee80211HtCapabilities& capabilities, const Ieee80211HtOperation& operation);
     void removePeerHtCapabilities(const MacAddress& address);

--- a/src/inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmReceiver.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmReceiver.cc
@@ -7,6 +7,7 @@
 
 #include "inet/physicallayer/wireless/ieee80211/bitlevel/Ieee80211LayeredOfdmReceiver.h"
 
+#include "inet/common/ProtocolTag_m.h"
 #include "inet/common/packet/chunk/BytesChunk.h"
 #include "inet/physicallayer/wireless/common/analogmodel/dimensional/DimensionalReceptionAnalogModel.h"
 #include "inet/physicallayer/wireless/common/analogmodel/dimensional/DimensionalMediumAnalogModel.h"
@@ -411,6 +412,14 @@ const IReceptionResult *Ieee80211LayeredOfdmReceiver::computeReceptionResult(con
     }
     // add indications
     auto packet = const_cast<Packet *>(packetModel->getPacket());
+    // Packet-domain error models duplicate the transmitted packet, including
+    // sender-local tags.  Reception results must expose only metadata that is
+    // authoritative at this boundary, just like ReceiverBase does for flat
+    // packet-level radios.
+    auto transmittedPacket = transmission->getPacket();
+    auto transmittedProtocolTag = transmittedPacket->getTag<PacketProtocolTag>();
+    packet->clearTags();
+    packet->addTag<PacketProtocolTag>()->setProtocol(transmittedProtocolTag->getProtocol());
     auto snirInd = packet->addTagIfAbsent<SnirInd>();
     snirInd->setMinimumSnir(snir->getMin());
     snirInd->setMaximumSnir(snir->getMax());

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.cc
@@ -746,6 +746,18 @@ const IIeee80211Mode *Ieee80211ModeSet::getFastestMandatoryMode() const
     return nullptr;
 }
 
+const IIeee80211Mode *Ieee80211ModeSet::getFastestLegacyOperationalMode() const
+{
+    const IIeee80211Mode *fastestMandatoryLegacyMode = nullptr;
+    for (const auto *mode : legacyOperationalModes) {
+        if (getIsMandatory(mode))
+            fastestMandatoryLegacyMode = mode;
+    }
+    if (fastestMandatoryLegacyMode != nullptr)
+        return fastestMandatoryLegacyMode;
+    return legacyOperationalModes.empty() ? nullptr : legacyOperationalModes.back();
+}
+
 const IIeee80211Mode *Ieee80211ModeSet::getSlowerMandatoryMode(const IIeee80211Mode *mode) const
 {
     int index = findModeIndex(mode);

--- a/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
+++ b/src/inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h
@@ -72,14 +72,14 @@ class INET_API Ieee80211ModeSet : public IPrintableObject, public cObject
     int getNumModes() const { return entries.size(); }
     const IIeee80211Mode *getMode(int index) const { return entries[index].mode; }
     bool isMandatory(int index) const { return entries[index].isMandatory; }
-
+    bool isHtOperationSupported() const { return htOperationSupported; }
+    Hz getMaximumChannelWidth() const;
+    int getMaximumNumberOfSpatialStreams() const;
     // The management policy advertises all explicitly eligible representable
     // legacy modes in deterministic mandatory-first order. Overflow is split
     // into the Extended Supported Rates element by management.
     const std::vector<const IIeee80211Mode *>& getLegacyOperationalModes() const { return legacyOperationalModes; }
-    bool isHtOperationSupported() const { return htOperationSupported; }
-    Hz getMaximumChannelWidth() const;
-    int getMaximumNumberOfSpatialStreams() const;
+    const IIeee80211Mode *getFastestLegacyOperationalMode() const;
     const std::array<bool, 77>& getHtMcsSupported() const { return htMcsSupported; }
     const std::array<bool, 77>& getHtMcsMandatory() const { return htMcsMandatory; }
     const std::set<Hz>& getHtSupportedChannelWidths() const { return htSupportedChannelWidths; }

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -47,8 +47,8 @@
 /examples/communicationcache/,       -f omnetpp.ini -c VectorCommunicationCache -r 0,     10s,       4c65-91ae/tplx;72b5-8f0b/~tNl;2b5e-4ca8/~tND;40ef-e3e2/tyf, PASS, wireless Ipv4
 
 /examples/dhcp/,                     -f omnetpp.ini -c WiredDHCP -r 0,              5000s,           df67-0fe0/tplx;023a-3c37/~tNl;fdc9-84e1/~tND;8a53-9a15/tyf, PASS, EthernetMac Ipv4
-/examples/dhcp/,                     -f omnetpp.ini -c WirelessDHCP -r 0,           500s,            a931-fbf9/tplx;f19a-7352/~tNl;efdb-c86f/~tND;d3a7-5f49/tyf, PASS, wireless EthernetMac Ipv4
-/examples/dhcp/,                     -f omnetpp.ini -c Wireless2DHCP -r 0,          500s,            c440-71e7/tplx;6ca7-4ad3/~tNl;4c46-68f9/~tND;3497-9980/tyf, PASS, wireless EthernetMac Ipv4
+/examples/dhcp/,                     -f omnetpp.ini -c WirelessDHCP -r 0,           500s,            a931-fbf9/tplx;f19a-7352/~tNl;efdb-02ac/~tND;d3a7-5f49/tyf, PASS, wireless EthernetMac Ipv4
+/examples/dhcp/,                     -f omnetpp.ini -c Wireless2DHCP -r 0,          500s,            c440-71e7/tplx;6ca7-4ad3/~tNl;8dcb-e3d0/~tND;3497-9980/tyf, PASS, wireless EthernetMac Ipv4
 /examples/dhcp/,                     -f omnetpp.ini -c RebootingDHCP -r 0,          500s,            df1a-1a1e/tplx;0610-405e/~tNl;4ae3-3dec/~tND;fbd6-20e8/tyf, PASS, EthernetMac Ipv4
 
 # /examples/diffserv/onedomain/,       -f omnetpp.ini -c Apps -r 0,                  10s,             0, PASS,   # abstract-config
@@ -380,10 +380,10 @@
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c MultiRadio -r 0,             20s,             ec17-5cc2/tplx;55f5-0894/~tNl, PASS,  wireless adhoc Ipv4
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c SingleRadio -r 0,            20s,             85a0-51b8/tplx;c07a-44e1/~tNl;3aa0-49ed/tyf, PASS,  wireless adhoc Ipv4
 
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             17ac-0898/tplx;8bbc-d083/~tNl;4f51-10bf/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             19e2-a165/tplx;d96c-5e41/~tNl;30fd-3440/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             123e-b941/tplx;4e91-d6bb/~tNl;73b0-f068/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
-/examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             8bf1-01f5/tplx;c5d4-bce4/~tNl;488f-8368/~tND;0277-d784/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             17ac-0898/tplx;8bbc-d083/~tNl;fdb7-4ab1/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             19e2-a165/tplx;d96c-5e41/~tNl;ee03-5334/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             123e-b941/tplx;4e91-d6bb/~tNl;8642-5854/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
+/examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             8bf1-01f5/tplx;c5d4-bce4/~tNl;0f9a-c178/~tND;0277-d784/tyf, PASS, wireless EthernetMac
 
 /examples/mobility/,                 -f omnetpp.ini -c AnsimMobility -r 0,          10000s,          72f8-5c0b/tplx;0000-0000/~tNl;0000-0000/~tND;7dd1-18eb/tyf, PASS,
 /examples/mobility,                  -f omnetpp.ini -c AttachedMobility,            10s,             566c-6355/tplx;0000-0000/~tNl;0000-0000/~tND;fa92-f68c/tyf, PASS,
@@ -573,7 +573,7 @@
 /examples/wireless/filtering/,       -f omnetpp.ini -c ListeningFilter -r 0,          100s,         946b-6f7f/tplx;e5d7-0ef7/~tNl;5b4a-50a5/~tND;17b4-4f41/tyf, PASS, Ipv4
 /examples/wireless/filtering/,       -f omnetpp.ini -c MacAddressFilter -r 0,         100s,         d2d8-8182/tplx;d14e-6ff1/~tNl;dba4-2d05/~tND;1853-1300/tyf, PASS, Ipv4
 
-/examples/wireless/handover/,        -f omnetpp.ini -c General -r 0,                1500s,        eee3-0da3/tplx;baf5-5f0e/~tNl;622f-26b9/~tND;c710-ff2e/tyf, PASS, wireless
+/examples/wireless/handover/,        -f omnetpp.ini -c General -r 0,                1500s,        eee3-0da3/tplx;baf5-5f0e/~tNl;2d92-6c0e/~tND;c710-ff2e/tyf, PASS, wireless
 
 /examples/wireless/hiddennode/,      -f omnetpp.ini -c General -r 0,                5s,         8383-735e/tplx;8e4d-20ee/~tNl;1298-9ea7/~tND;af51-7b12/tyf, PASS, wireless
 
@@ -654,11 +654,11 @@
 
 /examples/wireless/power/,           -f omnetpp.ini -c General -r 0,                100s,            6fae-d558/tplx;b8ea-b2fc/~tNl;5ea8-2cea/~tND, PASS, wireless Ipv4
 
-/examples/wireless/qos/,             -f omnetpp.ini -c MacNonQos -r 0,                 10s,         f252-8a4b/tplx;481d-4747/~tNl;585e-760d/~tND;6097-a429/tyf, PASS, wireless Ipv4
-/examples/wireless/qos/,             -f omnetpp.ini -c MacQos -r 0,                    10s,         31b0-6212/tplx;82ec-9fde/~tNl;ca44-e8a4/~tND;9f3c-4512/tyf, PASS, wireless Ipv4
-/examples/wireless/qos/,             -f omnetpp.ini -c MacQosWithoutAggregation -r 0,                10s,         acd6-0108/tplx;b339-294a/~tNl;74e8-83a9/~tND;a4c3-19bf/tyf, PASS, wireless Ipv4
-/examples/wireless/qos/,             -f omnetpp.ini -c MacQosWithRtsCts -r 0,          10s,         9ece-fbfb/tplx;c1af-29ff/~tNl;7daa-97a2/~tND;b2d6-1329/tyf, PASS, wireless Ipv4
-/examples/wireless/qos/,             -f omnetpp.ini -c MacQosWithBlockAck -r 0,        10s,         d094-b008/tplx;173a-e3fb/~tNl;386f-4fc5/~tND;08b5-d005/tyf, PASS, wireless Ipv4
+/examples/wireless/qos/,             -f omnetpp.ini -c MacNonQos -r 0,                 10s,         f252-8a4b/tplx;481d-4747/~tNl;5962-e45d/~tND;6097-a429/tyf, PASS, wireless Ipv4
+/examples/wireless/qos/,             -f omnetpp.ini -c MacQos -r 0,                    10s,         31b0-6212/tplx;82ec-9fde/~tNl;540d-c0a4/~tND;9f3c-4512/tyf, PASS, wireless Ipv4
+/examples/wireless/qos/,             -f omnetpp.ini -c MacQosWithoutAggregation -r 0,                10s,         acd6-0108/tplx;b339-294a/~tNl;75d4-11f9/~tND;a4c3-19bf/tyf, PASS, wireless Ipv4
+/examples/wireless/qos/,             -f omnetpp.ini -c MacQosWithRtsCts -r 0,          10s,         9ece-fbfb/tplx;c1af-29ff/~tNl;8fe3-d7a6/~tND;b2d6-1329/tyf, PASS, wireless Ipv4
+/examples/wireless/qos/,             -f omnetpp.ini -c MacQosWithBlockAck -r 0,        10s,         d094-b008/tplx;173a-e3fb/~tNl;7147-4f5b/~tND;08b5-d005/tyf, PASS, wireless Ipv4
 
 /examples/wireless/ratecontrol/, -f omnetpp.ini -c Mac -r 0,                    100s,            bf30-2f13/tplx;7b2f-653d/~tNl;6e1e-3b7b/~tND;19fe-8b0e/tyf, PASS, wireless
 
@@ -678,4 +678,4 @@
 /examples/wireless/throughput/,      -f omnetpp.ini -c Throughput1 -r 0,            20s,           a4d8-abf4/tplx;f424-9aaf/~tNl;24fe-19e3/~tND;bb2f-ec63/tyf, PASS, wireless
 /examples/wireless/throughput/,      -f omnetpp.ini -c Throughput2 -r 0,            10s,         3b2b-5123/tplx;0009-ca8c/~tNl;a4a2-725a/~tND;032e-0333/tyf, PASS, wireless
 
-/examples/wireless/wiredandwirelesshostswithap/, -f omnetpp.ini -c General -r 0,                100s,      af04-d760/tplx;95c2-6625/~tNl;203c-5025/~tND;b4df-273e/tyf, PASS, wireless EthernetMac Ipv4
+/examples/wireless/wiredandwirelesshostswithap/, -f omnetpp.ini -c General -r 0,                100s,      af04-d760/tplx;95c2-6625/~tNl;90fc-5017/~tND;b4df-273e/tyf, PASS, wireless EthernetMac Ipv4

--- a/tests/fingerprint/showcases.csv
+++ b/tests/fingerprint/showcases.csv
@@ -122,10 +122,10 @@
 /showcases/visualizer/osg/environment/,  -f omnetpp.ini -c DefaultView -r 0,                                        500s,            0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,   # DefaultView extended
 /showcases/visualizer/osg/environment/,  -f omnetpp.ini -c IsometricView -r 0,                                      500s,            0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,
 
-/showcases/visualizer/canvas/ieee80211/, -f omnetpp.ini -c OneNetwork -r 0,                                  5s,            d8ed-768c/tplx;4c02-603f/~tNl;cb0e-aa7c/~tND;9c21-dd33/tyf, PASS,    wireless
-/showcases/visualizer/canvas/ieee80211/, -f omnetpp.ini -c MultipleNetworks -r 0,                            5s,            5f98-cd05/tplx;704f-4817/~tNl;932d-8e1c/~tND;3be5-9494/tyf, PASS,    wireless
-/showcases/visualizer/canvas/ieee80211/, -f omnetpp.ini -c VisualizingHandover -r 0,                         250s,            0f01-f016/tplx;6ded-d407/~tNl;7768-5488/~tND;07bb-3973/tyf, PASS,    wireless
-/showcases/visualizer/canvas/ieee80211/,    -f omnetpp.ini -c SignalLevels -r 0,           100s,         8782-6f1c/tplx;7a73-4da5/~tNl;4704-f607/~tND;c099-e5c5/tyf, PASS, Ipv4
+/showcases/visualizer/canvas/ieee80211/, -f omnetpp.ini -c OneNetwork -r 0,                                  5s,            d8ed-768c/tplx;4c02-603f/~tNl;cb02-064c/~tND;9c21-dd33/tyf, PASS,    wireless
+/showcases/visualizer/canvas/ieee80211/, -f omnetpp.ini -c MultipleNetworks -r 0,                            5s,            5f98-cd05/tplx;704f-4817/~tNl;9ed9-732b/~tND;3be5-9494/tyf, PASS,    wireless
+/showcases/visualizer/canvas/ieee80211/, -f omnetpp.ini -c VisualizingHandover -r 0,                         250s,            0f01-f016/tplx;6ded-d407/~tNl;3268-55d7/~tND;07bb-3973/tyf, PASS,    wireless
+/showcases/visualizer/canvas/ieee80211/,    -f omnetpp.ini -c SignalLevels -r 0,           100s,         8782-6f1c/tplx;7a73-4da5/~tNl;483a-1ff7/~tND;c099-e5c5/tyf, PASS, Ipv4
 
 /showcases/visualizer/canvas/submoduleinfo/,         -f omnetpp.ini -c PacketCounts -r 0,                    5s,            271c-6821/tplx;3c0c-db82/~tNl;d4d4-a4d5/~tND;b145-6576/tyf, PASS,   wireless Ipv4 # VisualizingSubmoduleInformation extended
 /showcases/visualizer/canvas/submoduleinfo/,         -f omnetpp.ini -c MACStates -r 0,                                    5s,            271c-6821/tplx;3c0c-db82/~tNl;d4d4-a4d5/~tND;4677-fc97/tyf, PASS,    wireless Ipv4
@@ -133,7 +133,7 @@
 /showcases/visualizer/canvas/instrumentfigures/,    -f omnetpp.ini -c General -r 0,                                            3s,              6622-adb9/tplx;28ca-9f8c/~tNl;adfa-1bdd/~tND;4266-0d42/tyf, PASS,    wireless Ipv4
 
 /showcases/visualizer/canvas/interfacetable/, -f omnetpp.ini -c EnablingVisualization -r 0,                  5s,            0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,
-/showcases/visualizer/canvas/interfacetable/, -f omnetpp.ini -c AdvancedFeatures -r 0,                       5s,            dfdf-7e0e/tplx;7bfc-e297/~tNl;0e06-793c/~tND;b2d8-b329/tyf, PASS,    wireless EthernetMac Ipv4
+/showcases/visualizer/canvas/interfacetable/, -f omnetpp.ini -c AdvancedFeatures -r 0,                       5s,            dfdf-7e0e/tplx;7bfc-e297/~tNl;a42e-6cc2/~tND;b2d8-b329/tyf, PASS,    wireless EthernetMac Ipv4
 
 /showcases/visualizer/canvas/mobility/,     -f omnetpp.ini -c VisualizingFeatures -r 0,                                500s,            54a1-0f8d/tplx;0000-0000/~tNl;0000-0000/~tND;df51-b287/tyf, PASS,    wireless
 
@@ -146,21 +146,21 @@
 /showcases/visualizer/canvas/networkpathactivity/, -f omnetpp.ini -c EnablingVisualization -r 0,                       500s,            456d-1982/tplx;bd58-e496/~tNl;1b76-9a17/~tND;4b2b-9088/tyf, PASS, EthernetMac Ipv4
 /showcases/visualizer/canvas/networkpathactivity/, -f omnetpp.ini -c StaticNetworkPaths -r 0,                          500s,            5995-953f/tplx;cfc6-5083/~tNl;aa2b-919c/~tND;a8ff-b27d/tyf, PASS, EthernetMac Ipv4
 /showcases/visualizer/canvas/networkpathactivity/, -f omnetpp.ini -c Mobile -r 0,                                      500s,            cbb7-c036/tplx;fdcd-ce11/~tNl;6153-9684/~tND, PASS, wireless Ipv4
-/showcases/visualizer/canvas/networkpathactivity/, -f omnetpp.ini -c ChangingPaths -r 0,                               250s,            94b6-d4ca/tplx;e466-c6f7/~tNl;d434-7f7d/~tND;eade-62dc/tyf, PASS, EthernetMac Ipv4
+/showcases/visualizer/canvas/networkpathactivity/, -f omnetpp.ini -c ChangingPaths -r 0,                               250s,            94b6-d4ca/tplx;e466-c6f7/~tNl;e32f-6d64/~tND;eade-62dc/tyf, PASS, EthernetMac Ipv4
 
 # /showcases/visualizer/canvas/obstacleloss/, -f omnetpp.ini -c EnablingVisualization -r 0,                              250s,            2410-572d/tplx;0000-0000/~tNl;0000-0000/~tND, PASS,    wireless
 # /showcases/visualizer/canvas/obstacleloss/, -f omnetpp.ini -c MultipleObstacles -r 0,                                  500s,            89ca-0f0a/tplx;0000-0000/~tNl;0000-0000/~tND, PASS,    wireless
 
 # /showcases/visualizer/osg/osgdemo/,      -f omnetpp.ini -c General -r 0,                100s,         0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND, ERROR,
 
-/showcases/visualizer/canvas/packetdrop/,   -f omnetpp.ini -c QueueOverflow -r 0,                                      2002ms,            835e-80ed/tplx;1858-ad28/~tNl;169b-9e11/~tND;dee8-a7c2/tyf, PASS,    wireless EthernetMac Ipv4
+/showcases/visualizer/canvas/packetdrop/,   -f omnetpp.ini -c QueueOverflow -r 0,                                      2002ms,            835e-80ed/tplx;1858-ad28/~tNl;1651-5d11/~tND;dee8-a7c2/tyf, PASS,    wireless EthernetMac Ipv4
 /showcases/visualizer/canvas/packetdrop/,   -f omnetpp.ini -c ArpResolutionFailed -r 0,                                500s,            9069-cca6/tplx;0000-0000/~tNl;0000-0000/~tND;db3b-e3e4/tyf, PASS,    wireless Ipv4
 /showcases/visualizer/canvas/packetdrop/,   -f omnetpp.ini -c MACRetryLimitReached -r 0,                               500s,            1f7a-e5f3/tplx;14cf-73d2/~tNl;7845-1012/~tND;24ba-9fa9/tyf, PASS,    wireless Ipv4
 /showcases/visualizer/canvas/packetdrop/,   -f omnetpp.ini -c InterfaceNotConnected -r 0,                              500s,            280f-b030/tplx;0000-0000/~tNl;0000-0000/~tND;5f21-3687/tyf, PASS, EthernetMac Ipv4
 /showcases/visualizer/canvas/packetdrop/,   -f omnetpp.ini -c NoRouteToDestination -r 0,                               500s,            4c38-3589/tplx;0000-0000/~tNl;0000-0000/~tND;2ad2-161b/tyf, PASS, Ipv4
 
 /showcases/visualizer/canvas/physicallinkactivity/, -f omnetpp.ini -c EnablingVisualization -r 0,                      500s,            a1da-0032/tplx;bde3-9c6e/~tNl;9df2-2f70/~tND;25e0-5171/tyf, PASS,    wireless Ipv4
-/showcases/visualizer/canvas/physicallinkactivity/, -f omnetpp.ini -c Filtering -r 0,                                  250s,            b91f-f443/tplx;310a-f092/~tNl;4945-d97c/~tND;5e9e-c6c7/tyf, PASS,    wireless Ipv4
+/showcases/visualizer/canvas/physicallinkactivity/, -f omnetpp.ini -c Filtering -r 0,                                  250s,            b91f-f443/tplx;310a-f092/~tNl;0f65-e91a/~tND;5e9e-c6c7/tyf, PASS,    wireless Ipv4
 /showcases/visualizer/canvas/physicallinkactivity/, -f omnetpp.ini -c Mobile -r 0,                                     500s,            a437-919f/tplx;03cf-d1b8/~tNl;bcdb-9b7b/~tND;7bf9-d50f/tyf, PASS, wireless Ipv4
 
 /showcases/visualizer/canvas/radiomediumactivity/,  -f omnetpp.ini -c DisplayingSignalsTransmissionsReceptions -r 0,       500s,            771b-bffb/tplx;ca1b-c59c/~tNl;9740-c54f/~tND, PASS, wireless # unfinished
@@ -182,7 +182,7 @@
 /showcases/visualizer/canvas/styling/,      -f omnetpp.ini -c Line -r 0,                   25s,         cb1d-a154/tplx;a565-1a98/~tNl;6950-9c50/~tND;7b44-2fb8/tyf, PASS,    wireless Ipv4
 /showcases/visualizer/canvas/styling/,      -f omnetpp.ini -c Font -r 0,                   25s,         cb1d-a154/tplx;a565-1a98/~tNl;6950-9c50/~tND;5e90-6a92/tyf, PASS,    wireless Ipv4
 /showcases/visualizer/canvas/styling/,      -f omnetpp.ini -c Icon -r 0,                   25s,         9218-0d5b/tplx;1a94-46a8/~tNl;c094-fead/~tND;62e8-28b7/tyf, PASS,    wireless Ipv4
-/showcases/visualizer/canvas/styling/,      -f omnetpp.ini -c Annotation -r 0,             25s,         9349-7ae5/tplx;5207-a7b7/~tNl;f236-346d/~tND;342b-0033/tyf, PASS,    wireless Ipv4
+/showcases/visualizer/canvas/styling/,      -f omnetpp.ini -c Annotation -r 0,             25s,         9349-7ae5/tplx;5207-a7b7/~tNl;37de-f185/~tND;342b-0033/tyf, PASS,    wireless Ipv4
 
 /showcases/visualizer/canvas/transportconnection/, -f omnetpp.ini -c EnablingVisualization -r 0,                       2s,            fc86-91c1/tplx;817d-6638/~tNl;b2d4-0aff/~tND;d5f4-f615/tyf, PASS, EthernetMac Ipv4
 /showcases/visualizer/canvas/transportconnection/, -f omnetpp.ini -c MultipleConnections -r 0,                         2s,            511a-236b/tplx;0bd4-4f1e/~tNl;050f-8d69/~tND;1584-363d/tyf, PASS, EthernetMac Ipv4
@@ -269,7 +269,7 @@
 /showcases/wireless/fragmentation/,     -f omnetpp.ini -c HCFfrag -r 0,                                         1s,            f7a5-cf0a/tplx;a24a-a070/~tNl;7743-bba4/~tND;335d-6687/tyf, PASS,    wireless Ipv4
 /showcases/wireless/fragmentation/,     -f omnetpp.ini -c HCFfragblockack -r 0,                                 1s,            0702-c692/tplx;1bf9-b035/~tNl;9a04-4420/~tND;6f6e-b101/tyf, PASS,    wireless Ipv4
 
-/showcases/wireless/handover/,       -f omnetpp.ini -c General -r 0,                                            250s,            b287-6940/tplx;45c3-a292/~tNl;a555-1c47/~tND;02e9-9ad3/tyf, PASS,    wireless
+/showcases/wireless/handover/,       -f omnetpp.ini -c General -r 0,                                            250s,            b287-6940/tplx;45c3-a292/~tNl;99ae-332d/~tND;02e9-9ad3/tyf, PASS,    wireless
 
 /showcases/wireless/hiddennode/,     -f omnetpp.ini -c WallOnRtsOff -r 0,                                       5s,            7912-bed4/tplx;c1e8-3622/~tNl;064a-ed2b/~tND;d824-8757/tyf, PASS,    wireless Ipv4
 /showcases/wireless/hiddennode/,     -f omnetpp.ini -c WallOnRtsOn -r 0,                                        5s,            321b-f7f2/tplx;75e5-07b7/~tNl;1033-6cd1/~tND;35cb-1d85/tyf, PASS,    wireless Ipv4
@@ -307,14 +307,14 @@
 # /showcases/wireless/levelofdetail/,  -f omnetpp.ini -c General -r '$detail=="bit" && $modulation=="QAM-64" && $fecType=="" && $distance==225',                      100s,            7794-9306/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,    wireless
 # /showcases/wireless/levelofdetail/,  -f omnetpp.ini -c General -r '$detail=="symbol" && $modulation=="QAM-64" && $fecType=="" && $distance==125',                   100s,            54ce-ce35/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,    wireless
 
-/showcases/wireless/multiradio/,     -f omnetpp.ini -c General -r 0,      100s,         6f2f-9b0b/tplx;6b4f-f8fd/~tNl;5255-c3e2/~tND;92c1-ccc2/tyf, PASS,    wireless Ipv4
+/showcases/wireless/multiradio/,     -f omnetpp.ini -c General -r 0,      100s,         6f2f-9b0b/tplx;6b4f-f8fd/~tNl;147a-85cd/~tND;92c1-ccc2/tyf, PASS,    wireless Ipv4
 
 /showcases/wireless/pathloss/,       -f omnetpp.ini -c General -r 0,                100s,         171a-e6eb/tplx;3466-822d/~tNl;5909-6e87/~tND;929d-03d5/tyf, PASS,    wireless Ipv4
 
 /showcases/wireless/power/,          -f omnetpp.ini -c General -r 0,                                            100s,            498f-b665/tplx;6f50-5caf/~tNl;0ad4-1089/~tND, PASS,    wireless Ipv4
 
-/showcases/wireless/qos/,     -f omnetpp.ini -c NonQos -r 0,                                       10s,            37fd-5401/tplx;92f7-198c/~tNl;5525-d5d8/~tND;093e-1ca4/tyf, PASS,    wireless Ipv4
-/showcases/wireless/qos/,     -f omnetpp.ini -c Qos -r 0,                                        10s,            1a49-72b3/tplx;e605-d79d/~tNl;1335-a1c6/~tND;bda9-15d1/tyf, PASS,    wireless Ipv4
+/showcases/wireless/qos/,     -f omnetpp.ini -c NonQos -r 0,                                       10s,            37fd-5401/tplx;92f7-198c/~tNl;955c-ee96/~tND;093e-1ca4/tyf, PASS,    wireless Ipv4
+/showcases/wireless/qos/,     -f omnetpp.ini -c Qos -r 0,                                        10s,            1a49-72b3/tplx;e605-d79d/~tNl;10fc-7bb0/~tND;bda9-15d1/tyf, PASS,    wireless Ipv4
 
 /showcases/wireless/ratecontrol/,    -f omnetpp.ini -c NoRateControl -r 0,                        14s,            7ee9-503a/tplx;0816-e58f/~tNl;648e-6e84/~tND;dad3-7f89/tyf, PASS,    wireless Ipv4
 /showcases/wireless/ratecontrol/,    -f omnetpp.ini -c AarfRateControl -r 0,                  12s,            a7bc-05bb/tplx;9de0-4dd3/~tNl;1209-101b/~tND;7539-d32d/tyf, PASS,    wireless Ipv4

--- a/tests/fingerprint/showcases.csv
+++ b/tests/fingerprint/showcases.csv
@@ -341,5 +341,5 @@
 
 /showcases/wireless/throughput/,     -f omnetpp.ini -c General -r 0,                1s,         030e-c416/tplx;66e6-0bca/~tNl;3cb6-43bd/~tND;e6a5-bde0/tyf, PASS,    wireless Ipv4
 
-/showcases/wireless/txop/,     -f omnetpp.ini -c General -r 0,                5s,         4f2b-ef23/tplx;4889-9697/~tNl;c87d-3f3a/tyf, PASS,    wireless Ipv4
+/showcases/wireless/txop/,     -f omnetpp.ini -c General -r 0,                5s,         d2b6-a5d1/tplx;3a6f-4c28/~tNl;c87d-3f3a/tyf, PASS,    wireless Ipv4
 

--- a/tests/fingerprint/tutorials.csv
+++ b/tests/fingerprint/tutorials.csv
@@ -10,15 +10,15 @@
 /tutorials/configurator/,            -f omnetpp.ini -c Step7A -r 0,                             500s,           0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,
 /tutorials/configurator/,            -f omnetpp.ini -c Step7B -r 0,                             500s,           0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,
 /tutorials/configurator/,            -f omnetpp.ini -c Step7C -r 0,                             500s,           0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,
-/tutorials/configurator/,            -f omnetpp.ini -c Step8A -r 0,                             100s,           f99c-9e43/tplx;e810-af2b/~tNl;50b6-b5bb/~tND;d3f3-ed4c/tyf, PASS,    wireless EthernetMac Ipv4   # Step8A extended
-/tutorials/configurator/,            -f omnetpp.ini -c Step8B -r 0,                             100s,           6daa-17f7/tplx;e810-af2b/~tNl;3708-bee1/~tND;af16-1150/tyf, PASS,    wireless EthernetMac Ipv4
-/tutorials/configurator/,            -f omnetpp.ini -c Step9 -r 0,                              100s,           7f72-228e/tplx;44d7-fbf3/~tNl;80e5-fc9f/~tND;c38c-98ef/tyf, PASS,    wireless EthernetMac Ipv4
+/tutorials/configurator/,            -f omnetpp.ini -c Step8A -r 0,                             100s,           f99c-9e43/tplx;e810-af2b/~tNl;8f87-ee38/~tND;d3f3-ed4c/tyf, PASS,    wireless EthernetMac Ipv4   # Step8A extended
+/tutorials/configurator/,            -f omnetpp.ini -c Step8B -r 0,                             100s,           6daa-17f7/tplx;e810-af2b/~tNl;e839-e562/~tND;af16-1150/tyf, PASS,    wireless EthernetMac Ipv4
+/tutorials/configurator/,            -f omnetpp.ini -c Step9 -r 0,                              100s,           7f72-228e/tplx;44d7-fbf3/~tNl;48a0-6adb/~tND;c38c-98ef/tyf, PASS,    wireless EthernetMac Ipv4
 /tutorials/configurator/,            -f omnetpp.ini -c Step10A -r 0,                            100s,           4b6f-7cd9/tplx;0000-0000/~tNl;0000-0000/~tND;095d-75bd/tyf, PASS,   wireless # Step10A extended
 /tutorials/configurator/,            -f omnetpp.ini -c Step10B -r 0,                            100s,           4b6f-7cd9/tplx;0000-0000/~tNl;0000-0000/~tND;4d60-fcf9/tyf, PASS,   wireless # Step10B extended
 /tutorials/configurator/,            -f omnetpp.ini -c Step10C -r 0,                            100s,           71f5-b341/tplx;4a61-20ba/~tNl;c614-3445/~tND;f078-56fe/tyf, PASS,    wireless Ipv4
 /tutorials/configurator/,            -f omnetpp.ini -c Step11A -r 0,                            500s,           0000-0000/tplx;0000-0000/~tNl;0000-0000/~tND;0000-0000/tyf, PASS,
 /tutorials/configurator/,            -f omnetpp.ini -c Step11B -r 0,                            500s,           49cf-d241/tplx;725c-f075/~tNl;15a3-3f79/~tND;7082-ff49/tyf, PASS, EthernetMac Ipv4
-/tutorials/configurator/,            -f omnetpp.ini -c Step12 -r 0,                             100s,           a186-bbc1/tplx;7370-3135/~tNl;c349-a25e/~tND;4b03-e5a1/tyf, PASS,    wireless EthernetMac Ipv4
+/tutorials/configurator/,            -f omnetpp.ini -c Step12 -r 0,                             100s,           a186-bbc1/tplx;7370-3135/~tNl;1438-e824/~tND;4b03-e5a1/tyf, PASS,    wireless EthernetMac Ipv4
 
 /tutorials/rip/,                     -f omnetpp.ini -c Step1 -r 0,                              100s,           2c94-a8bb/tplx;b4e0-1e61/~tNl;4bd3-4530/~tND;1e4a-2625/tyf, PASS,
 /tutorials/rip/,                     -f omnetpp.ini -c Step2 -r 0,                              100s,           6019-f318/tplx;9372-788f/~tNl;dec7-8e56/~tND;a345-d423/tyf, PASS,   # Step2 extended

--- a/tests/module/Ieee80211AgentStaReassociation_1.test
+++ b/tests/module/Ieee80211AgentStaReassociation_1.test
@@ -1,0 +1,423 @@
+%description:
+Verify that the station agent uses the management MIB association state when
+deciding whether a failed reassociation should restart scanning. A retained
+same-AP preflight refusal must not scan or disassociate, while loss of the
+current AP during a pending different-target reassociation must scan through
+the production agent-to-management path. Also verify reassociation handover
+signals, callback-visible prevAP state, and completion signal ordering.
+
+%file: TestIeee80211AgentStaReassociation.cc
+
+#include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211AgentSta : public Ieee80211AgentSta
+{
+  public:
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+
+    void setPreviousAp(const MacAddress& address) { prevAP = address; }
+    const MacAddress& getPreviousAp() const { return prevAP; }
+
+    void deliverConfirm(Ieee80211PrimConfirm *confirm)
+    {
+        Enter_Method("deliverConfirm");
+        auto message = new cMessage("confirm");
+        message->setControlInfo(confirm);
+        handleResponse(message);
+    }
+
+  protected:
+    virtual void processAssociateConfirm(Ieee80211Prim_AssociateConfirm *resp) override
+    {
+        associateConfirms++;
+        Ieee80211AgentSta::processAssociateConfirm(resp);
+    }
+
+    virtual void processReassociateConfirm(Ieee80211Prim_ReassociateConfirm *resp) override
+    {
+        reassociateConfirms++;
+        Ieee80211AgentSta::processReassociateConfirm(resp);
+    }
+};
+
+Define_Module(TestIeee80211AgentSta);
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    ApInfo *ensureAccessPoint(const MacAddress& address)
+    {
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 1;
+            ap->ssid = "SSID";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+            ap->isAuthenticated = true;
+        }
+        return ap;
+    }
+
+  public:
+    int scanCommands = 0;
+    bool forcePreflightRefusal = false;
+
+    void setAssociated(const MacAddress& address)
+    {
+        Enter_Method("setAssociated");
+        if (mib->bssStationData.isAssociated)
+            clearCurrentAssociation();
+        ensureAccessPoint(address);
+        mib->bssData.bssid = address;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.address = address;
+        assocAP.channel = 1;
+        assocAP.ssid = "SSID";
+        assocAP.beaconInterval = SimTime(100, SIMTIME_MS);
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 1);
+        scheduleAfter(SimTime(1, SIMTIME_S), assocAP.beaconTimeoutMsg);
+    }
+
+    void requestReassociation(const MacAddress& address)
+    {
+        Enter_Method("requestReassociation");
+        Ieee80211Prim_ReassociateRequest request;
+        request.setAddress(address);
+        request.setTimeout(SimTime(1, SIMTIME_S));
+        processReassociateCommand(&request);
+    }
+
+    void beginPendingReassociation(const MacAddress& targetAddress)
+    {
+        Enter_Method("beginPendingReassociation");
+        ASSERT(mib->bssStationData.isAssociated);
+        ASSERT(assocTimeoutMsg == nullptr);
+        auto target = ensureAccessPoint(targetAddress);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(target);
+        reassociationInProgress = true;
+        scheduleAfter(SimTime(1, SIMTIME_S), assocTimeoutMsg);
+    }
+
+    void terminateCurrentAp(const MacAddress& address)
+    {
+        Enter_Method("terminateCurrentAp");
+        ASSERT(terminateCurrentAssociationFromPeer(address));
+    }
+
+    void deliverFailedReassociationResponse(const MacAddress& transmitter)
+    {
+        Enter_Method("deliverFailedReassociationResponse");
+        auto packet = new Packet("ReassociationResponse");
+        auto body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(SC_UNSPECIFIED);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        processAssociationResponse(packet, header, true);
+    }
+
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+    bool hasBeaconTimer() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    bool hasPendingReassociation() const { return assocTimeoutMsg != nullptr && reassociationInProgress; }
+
+  protected:
+    virtual void processScanCommand(Ieee80211Prim_ScanRequest *ctrl) override
+    {
+        scanCommands++;
+        Ieee80211MgmtSta::processScanCommand(ctrl);
+    }
+
+    virtual bool isHtBssSupported(const ApInfo *ap, std::string& reason) const override
+    {
+        if (forcePreflightRefusal) {
+            reason = "test preflight refusal";
+            return false;
+        }
+        return Ieee80211MgmtSta::isHtBssSupported(ap, reason);
+    }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class CompletionListener : public cListener
+{
+  public:
+    TestIeee80211AgentSta *agent = nullptr;
+    Ieee80211Mib *mib = nullptr;
+    MacAddress expectedAddress;
+    bool acceptSeen = false;
+    bool callbackStateValid = true;
+    int acceptCount = 0;
+    int newApCount = 0;
+    int oldApCount = 0;
+    std::vector<std::string> events;
+
+    void reset(TestIeee80211AgentSta *newAgent, Ieee80211Mib *newMib, const MacAddress& address)
+    {
+        agent = newAgent;
+        mib = newMib;
+        expectedAddress = address;
+        acceptSeen = false;
+        callbackStateValid = true;
+        acceptCount = 0;
+        newApCount = 0;
+        oldApCount = 0;
+        events.clear();
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override
+    {
+        acceptSeen = true;
+        acceptCount++;
+        events.push_back("accept");
+        callbackStateValid = callbackStateValid && agent->getPreviousAp() == expectedAddress && mib->bssStationData.isAssociated;
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (signalID == l2AssociatedNewApSignal) {
+            newApCount++;
+            events.push_back("new");
+        }
+        else if (signalID == l2AssociatedOldApSignal) {
+            oldApCount++;
+            events.push_back("old");
+        }
+        else
+            return;
+        callbackStateValid = callbackStateValid && acceptSeen && agent->getPreviousAp() == expectedAddress && mib->bssStationData.isAssociated;
+    }
+};
+
+class DropListener : public cListener
+{
+  public:
+    int count = 0;
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override
+    {
+        count++;
+    }
+};
+
+class Ieee80211AgentStaReassociationTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211AgentSta *agent = nullptr;
+    TestIeee80211MgmtSta *mgmt = nullptr;
+    Ieee80211Mib *mib = nullptr;
+    CompletionListener completionListener;
+    DropListener dropListener;
+
+  public:
+    Ieee80211AgentStaReassociationTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        agent = check_and_cast<TestIeee80211AgentSta *>(getModuleByPath("^.sta.wlan[0].agent"));
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+        mib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.sta.wlan[0].mib"));
+        agent->subscribe("acceptConfirm", &completionListener);
+        agent->subscribe(l2AssociatedNewApSignal, &completionListener);
+        agent->subscribe(l2AssociatedOldApSignal, &completionListener);
+        agent->subscribe("dropConfirm", &dropListener);
+    }
+
+    virtual void activity() override
+    {
+        const MacAddress currentAp("02:00:00:00:00:01");
+        const MacAddress targetAp("02:00:00:00:00:02");
+
+        // A same-AP preflight refusal does not change the management-owned
+        // association state, so the agent must not restart scanning.
+        mgmt->setAssociated(currentAp);
+        mgmt->forcePreflightRefusal = true;
+        int scanCommandsBefore = mgmt->scanCommands;
+        mgmt->requestReassociation(currentAp);
+        wait(0);
+        ASSERT(agent->reassociateConfirms == 1);
+        ASSERT(dropListener.count == 1);
+        ASSERT(mgmt->scanCommands == scanCommandsBefore);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+
+        // Association success uses the same completion ordering and state
+        // visibility as reassociation success.
+        mgmt->forcePreflightRefusal = false;
+        agent->setPreviousAp(currentAp);
+        completionListener.reset(agent, mib, targetAp);
+        auto associateConfirm = new Ieee80211Prim_AssociateConfirm();
+        associateConfirm->setResultCode(PRC_SUCCESS);
+        associateConfirm->setAddress(targetAp);
+        agent->deliverConfirm(associateConfirm);
+        ASSERT(agent->associateConfirms == 1);
+        ASSERT(completionListener.acceptCount == 1);
+        ASSERT(completionListener.newApCount == 1);
+        ASSERT(completionListener.oldApCount == 0);
+        ASSERT(completionListener.events.size() == 2);
+        ASSERT(completionListener.events[0] == "accept");
+        ASSERT(completionListener.events[1] == "new");
+        ASSERT(completionListener.callbackStateValid);
+        ASSERT(agent->getPreviousAp() == targetAp);
+
+        // A successful same-AP reassociation emits the old-AP signal and
+        // leaves prevAP unchanged.
+        agent->setPreviousAp(currentAp);
+        completionListener.reset(agent, mib, currentAp);
+        auto sameReassociateConfirm = new Ieee80211Prim_ReassociateConfirm();
+        sameReassociateConfirm->setResultCode(PRC_SUCCESS);
+        sameReassociateConfirm->setAddress(currentAp);
+        agent->deliverConfirm(sameReassociateConfirm);
+        ASSERT(agent->reassociateConfirms == 2);
+        ASSERT(completionListener.acceptCount == 1);
+        ASSERT(completionListener.newApCount == 0);
+        ASSERT(completionListener.oldApCount == 1);
+        ASSERT(completionListener.events.size() == 2);
+        ASSERT(completionListener.events[0] == "accept");
+        ASSERT(completionListener.events[1] == "old");
+        ASSERT(completionListener.callbackStateValid);
+        ASSERT(agent->getPreviousAp() == currentAp);
+
+        // A different-target success emits the new-AP signal and commits the
+        // target before either completion callback can observe the state.
+        completionListener.reset(agent, mib, targetAp);
+        auto differentReassociateConfirm = new Ieee80211Prim_ReassociateConfirm();
+        differentReassociateConfirm->setResultCode(PRC_SUCCESS);
+        differentReassociateConfirm->setAddress(targetAp);
+        agent->deliverConfirm(differentReassociateConfirm);
+        ASSERT(agent->reassociateConfirms == 3);
+        ASSERT(completionListener.acceptCount == 1);
+        ASSERT(completionListener.newApCount == 1);
+        ASSERT(completionListener.oldApCount == 0);
+        ASSERT(completionListener.events.size() == 2);
+        ASSERT(completionListener.events[0] == "accept");
+        ASSERT(completionListener.events[1] == "new");
+        ASSERT(completionListener.callbackStateValid);
+        ASSERT(agent->getPreviousAp() == targetAp);
+
+        // If the current AP is lost while a different-target reassociation is
+        // pending, management clears the MIB state before the target fails.
+        // The resulting refusal must restart scanning through the real gates,
+        // and processScanCommand must not disassociate anything further.
+        agent->setPreviousAp(currentAp);
+        mgmt->setAssociated(currentAp);
+        mgmt->beginPendingReassociation(targetAp);
+        mgmt->terminateCurrentAp(currentAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->hasPendingReassociation());
+        mgmt->deliverFailedReassociationResponse(targetAp);
+        wait(0);
+        wait(0);
+        ASSERT(agent->reassociateConfirms == 4);
+        ASSERT(dropListener.count == 2);
+        ASSERT(mgmt->scanCommands == scanCommandsBefore + 1);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+
+        // An unspecified previous AP is also classified as a new AP.
+        mgmt->setAssociated(currentAp);
+        agent->setPreviousAp(MacAddress());
+        completionListener.reset(agent, mib, currentAp);
+        auto unspecifiedPreviousApConfirm = new Ieee80211Prim_ReassociateConfirm();
+        unspecifiedPreviousApConfirm->setResultCode(PRC_SUCCESS);
+        unspecifiedPreviousApConfirm->setAddress(currentAp);
+        agent->deliverConfirm(unspecifiedPreviousApConfirm);
+        ASSERT(agent->reassociateConfirms == 5);
+        ASSERT(completionListener.acceptCount == 1);
+        ASSERT(completionListener.newApCount == 1);
+        ASSERT(completionListener.oldApCount == 0);
+        ASSERT(completionListener.callbackStateValid);
+        ASSERT(agent->getPreviousAp() == currentAp);
+
+        std::cout << "STA reassociation MIB retry policy and completion ordering verified.\n";
+    }
+};
+
+Define_Module(Ieee80211AgentStaReassociationTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211AgentSta;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211AgentSta extends Ieee80211AgentSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211AgentSta);
+}
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple Ieee80211AgentStaReassociationTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211AgentStaReassociationTest);
+}
+
+network Ieee80211AgentStaReassociationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].agent.typename = "TestIeee80211AgentSta";
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+        }
+        test: Ieee80211AgentStaReassociationTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211AgentStaReassociationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 1ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 1s
+*.sta.wlan[0].agent.activeScan = false
+*.sta.wlan[0].agent.channelsToScan = "1"
+**.wlan[*].opMode = "g(mixed)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+STA reassociation MIB retry policy and completion ordering verified.

--- a/tests/module/Ieee80211MgmtApUnavailableChannel_1.test
+++ b/tests/module/Ieee80211MgmtApUnavailableChannel_1.test
@@ -1,0 +1,44 @@
+%description:
+An HT-capable AP must not serialize a management frame before its radio has
+published a valid primary channel.  A radio channel of -1 suppresses the
+initial channel signal, so the first beacon deterministically reports the
+missing MIB-owned channel instead of serializing an invalid value.
+
+%file: test.ned
+
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+network Ieee80211MgmtApUnavailableChannelTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApUnavailableChannelTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].radio.channelNumber = -1
+*.ap.wlan[0].mgmt.beaconInterval = 1us
+**.wlan[0].opMode = "n(mixed-2.4Ghz)"
+**.wlan[0].bitrate = 65Mbps
+**.wlan[0].radio.bandName = "2.4 GHz"
+**.wlan[0].radio.centerFrequency = 2.4GHz
+*.ap.mobility.initFromDisplayString = false
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%exitcode: 1
+
+%postrun-command: grep "<!>" test.* > test_err.out || true
+
+%contains: test_err.out
+IEEE 802.11 primary channel is unavailable

--- a/tests/module/Ieee80211MgmtStaDeauthentication_1.test
+++ b/tests/module/Ieee80211MgmtStaDeauthentication_1.test
@@ -1,0 +1,409 @@
+%description:
+Verify that a station tears down its current association when the associated
+AP sends Deauthentication, while preserving unrelated AP transactions.
+
+%file: TestIeee80211MgmtStaDeauthentication.cc
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    ApInfo *ensureAccessPoint(const MacAddress& address)
+    {
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 1;
+            ap->ssid = "SSID";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+        }
+        ap->isAuthenticated = true;
+        return ap;
+    }
+
+  public:
+    int associationConfirms = 0;
+    int reassociationConfirms = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+    MacAddress lastAssociationAddress;
+    MacAddress lastReassociationAddress;
+    bool confirmationSawClearedAssociation = false;
+    bool confirmationSawDeauthenticatedAssociation = false;
+    bool lastAssociationConfirmationSawTerminalState = false;
+    bool lastReassociationConfirmationSawTerminalState = false;
+
+    void setAssociated(const MacAddress& address, bool cacheAp = true)
+    {
+        Enter_Method("setAssociated");
+        ASSERT(!mib->bssStationData.isAssociated);
+        if (cacheAp)
+            ensureAccessPoint(address);
+        mib->bssData.bssid = address;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.address = address;
+        assocAP.channel = 1;
+        assocAP.ssid = "SSID";
+        assocAP.isAuthenticated = true;
+        assocAP.beaconInterval = SimTime(100, SIMTIME_MS);
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 6);
+        scheduleAfter(SimTime(1, SIMTIME_S), assocAP.beaconTimeoutMsg);
+    }
+
+    void installPeerHtState(const MacAddress& address)
+    {
+        Enter_Method("installPeerHtState");
+        mib->setPrimaryChannel(1);
+        mib->setPeerHtCapabilities(address, mib->localHtCapabilities, mib->getHtOperation());
+    }
+
+    void authenticatePeer(const MacAddress& address)
+    {
+        Enter_Method("authenticatePeer");
+        ensureAccessPoint(address);
+    }
+
+    void clearCachedAccessPoints()
+    {
+        Enter_Method("clearCachedAccessPoints");
+        clearAPList();
+    }
+
+    void preparePendingAssociation(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("preparePendingAssociation");
+        ASSERT(assocTimeoutMsg == nullptr);
+        auto ap = ensureAccessPoint(address);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+        scheduleAfter(SimTime(1, SIMTIME_S), assocTimeoutMsg);
+    }
+
+    bool hasPendingAssociation() const { return assocTimeoutMsg != nullptr; }
+    bool isPendingAssociationScheduled() const { return assocTimeoutMsg != nullptr && assocTimeoutMsg->isScheduled(); }
+    bool isReassociationPending() const { return reassociationInProgress; }
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    bool hasBeaconTimer() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+    bool isAuthenticated(const MacAddress& address) const
+    {
+        auto ap = const_cast<TestIeee80211MgmtSta *>(this)->lookupAP(address);
+        return ap != nullptr && ap->isAuthenticated;
+    }
+    bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
+
+    void deliverDeauthentication(const MacAddress& transmitter, const MacAddress& address3)
+    {
+        Enter_Method("deliverDeauthentication");
+        auto packet = new Packet("Deauthentication");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        header->setAddress3(address3);
+        handleDeauthenticationFrame(packet, header);
+    }
+
+    void deliverAssociationResponse(const MacAddress& transmitter, bool reassociation, Ieee80211StatusCode statusCode)
+    {
+        Enter_Method("deliverAssociationResponse");
+        auto packet = new Packet("AssociationResponse");
+        auto body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+  protected:
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associationConfirms++;
+        lastAssociationAddress = ap->address;
+        lastAssociationResult = resultCode;
+        lastAssociationConfirmationSawTerminalState = !ap->isAuthenticated && assocTimeoutMsg == nullptr;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+        confirmationSawDeauthenticatedAssociation = confirmationSawDeauthenticatedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified() && !ap->isAuthenticated);
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociationConfirms++;
+        lastReassociationAddress = ap->address;
+        lastReassociationResult = resultCode;
+        lastReassociationConfirmationSawTerminalState = !ap->isAuthenticated && assocTimeoutMsg == nullptr;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+        confirmationSawDeauthenticatedAssociation = confirmationSawDeauthenticatedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified() && !ap->isAuthenticated);
+    }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class Ieee80211MgmtStaDeauthenticationTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211MgmtSta *mgmt = nullptr;
+
+  public:
+    Ieee80211MgmtStaDeauthenticationTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+    }
+
+    virtual void activity() override
+    {
+        const MacAddress currentAp("02:00:00:00:00:01");
+        const MacAddress targetAp("02:00:00:00:00:02");
+        const MacAddress foreignAp("02:00:00:00:00:03");
+
+        // Address 2 identifies the sender. A forged/different Address 3 must
+        // not tear down the current association.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->deliverDeauthentication(foreignAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+
+        // The associated AP's discovery entry and negotiated HT state are
+        // both cleared, and the beacon timer and association snapshot vanish.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        ASSERT(mgmt->isAuthenticated(currentAp));
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasBeaconTimer());
+        ASSERT(!mgmt->isAuthenticated(currentAp));
+        ASSERT(!mgmt->hasPeerHtState(currentAp));
+        ASSERT(mgmt->associationConfirms == 0);
+        ASSERT(mgmt->reassociationConfirms == 0);
+
+        // Association state remains authoritative even when the AP is no
+        // longer present in the scan/authentication cache.
+        mgmt->clearCachedAccessPoints();
+        mgmt->setAssociated(currentAp, false);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->deliverDeauthentication(currentAp, currentAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasBeaconTimer());
+        ASSERT(!mgmt->hasPeerHtState(currentAp));
+
+        // An authenticated but non-associated AP keeps the current pair
+        // intact while its own authentication and HT state are removed.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->authenticatePeer(foreignAp);
+        mgmt->installPeerHtState(foreignAp);
+        mgmt->deliverDeauthentication(foreignAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        ASSERT(!mgmt->isAuthenticated(foreignAp));
+        ASSERT(!mgmt->hasPeerHtState(foreignAp));
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+
+        // A current-AP deauthentication does not cancel a reassociation to a
+        // different AP; that transaction can still complete successfully.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == targetAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->reassociationConfirms == 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        mgmt->deliverDeauthentication(targetAp, foreignAp);
+
+        // A deauthentication from an unrelated AP does not cancel an initial
+        // association to the pending target, but the target's deauthentication
+        // cancels it and emits exactly one refusal.
+        ASSERT(!mgmt->isAssociated());
+        mgmt->preparePendingAssociation(targetAp, false);
+        mgmt->authenticatePeer(foreignAp);
+        mgmt->installPeerHtState(targetAp);
+        mgmt->installPeerHtState(foreignAp);
+        int associationConfirmsBeforeTargetDeauthentication = mgmt->associationConfirms;
+        mgmt->deliverDeauthentication(foreignAp, targetAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isAuthenticated(targetAp));
+        ASSERT(mgmt->hasPeerHtState(targetAp));
+        ASSERT(!mgmt->isAuthenticated(foreignAp));
+        ASSERT(!mgmt->hasPeerHtState(foreignAp));
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication);
+        mgmt->deliverDeauthentication(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAuthenticated(targetAp));
+        ASSERT(!mgmt->hasPeerHtState(targetAp));
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication + 1);
+        ASSERT(mgmt->lastAssociationAddress == targetAp);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(mgmt->lastAssociationConfirmationSawTerminalState);
+        mgmt->deliverAssociationResponse(targetAp, false, SC_SUCCESSFUL);
+        ASSERT(!mgmt->isAssociated());
+        mgmt->deliverDeauthentication(targetAp, foreignAp);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication + 1);
+
+        // A target deauthentication cancels a reassociation without disturbing
+        // the current AP association or its negotiated HT state.
+        mgmt->setAssociated(currentAp);
+        mgmt->installPeerHtState(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->installPeerHtState(targetAp);
+        int reassociationConfirmsBeforeTargetDeauthentication = mgmt->reassociationConfirms;
+        associationConfirmsBeforeTargetDeauthentication = mgmt->associationConfirms;
+        mgmt->deliverDeauthentication(targetAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAuthenticated(targetAp));
+        ASSERT(!mgmt->hasPeerHtState(targetAp));
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeTargetDeauthentication + 1);
+        ASSERT(mgmt->lastReassociationAddress == targetAp);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+        ASSERT(mgmt->lastReassociationConfirmationSawTerminalState);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeTargetDeauthentication);
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        mgmt->deliverDeauthentication(targetAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasPeerHtState(currentAp));
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeTargetDeauthentication + 1);
+        mgmt->deliverDeauthentication(currentAp, targetAp);
+
+        // A same-peer pending association is canceled once, and its refusal
+        // is observed only after current association state was cleared.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(currentAp, false);
+        int associationConfirmsBeforeSamePeer = mgmt->associationConfirms;
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeSamePeer + 1);
+        ASSERT(mgmt->lastAssociationAddress == currentAp);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(mgmt->confirmationSawClearedAssociation);
+        ASSERT(mgmt->confirmationSawDeauthenticatedAssociation);
+        mgmt->deliverAssociationResponse(currentAp, false, SC_SUCCESSFUL);
+        ASSERT(mgmt->associationConfirms == associationConfirmsBeforeSamePeer + 1);
+
+        // The same transaction rule applies to a pending reassociation.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(currentAp, true);
+        int reassociationConfirmsBeforeSamePeer = mgmt->reassociationConfirms;
+        mgmt->deliverDeauthentication(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeSamePeer + 1);
+        ASSERT(mgmt->lastReassociationAddress == currentAp);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+        mgmt->deliverAssociationResponse(currentAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->reassociationConfirms == reassociationConfirmsBeforeSamePeer + 1);
+
+        std::cout << "STA Deauthentication peer filtering and association teardown verified.\n";
+        std::cout << "STA deauthentication transaction cancellation and preservation verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaDeauthenticationTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple Ieee80211MgmtStaDeauthenticationTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaDeauthenticationTest);
+}
+
+network Ieee80211MgmtStaDeauthenticationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+        }
+        test: Ieee80211MgmtStaDeauthenticationTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaDeauthenticationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 1s
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+STA Deauthentication peer filtering and association teardown verified.
+
+%contains: stdout
+STA deauthentication transaction cancellation and preservation verified.

--- a/tests/module/Ieee80211MgmtStaDisassociation_1.test
+++ b/tests/module/Ieee80211MgmtStaDisassociation_1.test
@@ -1,0 +1,396 @@
+%description:
+Verify that a station processes a Disassociation only when it is transmitted
+by the currently associated AP. Foreign and pending-only frames preserve an
+active association transaction, while a current-AP frame clears the current
+association and emits one typed refusal only for a same-AP pending request.
+
+%file: TestIeee80211MgmtSta.cc
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    ApInfo *ensureAccessPoint(const MacAddress& address)
+    {
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 1;
+            ap->ssid = "SSID";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+            ap->isAuthenticated = true;
+        }
+        return ap;
+    }
+
+  public:
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+    int managementFramesSent = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+    MacAddress lastAssociationAddress;
+    MacAddress lastReassociationAddress;
+    MacAddress lastManagementFrameAddress;
+    bool confirmationSawClearedAssociation = false;
+
+    void setAssociated(const MacAddress& address)
+    {
+        Enter_Method("setAssociated");
+        ASSERT(!mib->bssStationData.isAssociated);
+        ensureAccessPoint(address);
+        mib->bssData.bssid = address;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.address = address;
+        assocAP.channel = 1;
+        assocAP.ssid = "SSID";
+        assocAP.beaconInterval = SimTime(100, SIMTIME_MS);
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 6);
+        scheduleAfter(SimTime(1, SIMTIME_S), assocAP.beaconTimeoutMsg);
+    }
+
+    void preparePendingAssociation(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("preparePendingAssociation");
+        ASSERT(assocTimeoutMsg == nullptr);
+        auto ap = ensureAccessPoint(address);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+        scheduleAfter(SimTime(1, SIMTIME_S), assocTimeoutMsg);
+    }
+
+    void abandonPendingAssociation()
+    {
+        Enter_Method("abandonPendingAssociation");
+        cancelPendingAssociation();
+    }
+
+    void requestDisassociation(const MacAddress& address)
+    {
+        Enter_Method("requestDisassociation");
+        auto request = new Ieee80211Prim_DisassociateRequest();
+        request->setAddress(address);
+        request->setReasonCode(RC_UNSPECIFIED);
+        handleCommand(PR_DISASSOCIATE_REQUEST, request);
+    }
+
+    bool hasPendingAssociation() const { return assocTimeoutMsg != nullptr; }
+    bool isPendingAssociationScheduled() const { return assocTimeoutMsg != nullptr && assocTimeoutMsg->isScheduled(); }
+    bool isReassociationPending() const { return reassociationInProgress; }
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+
+    void deliverDisassociation(const MacAddress& transmitter, const MacAddress& address3)
+    {
+        Enter_Method("deliverDisassociation");
+        auto packet = new Packet("Disassociation");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        header->setAddress3(address3);
+        handleDisassociationFrame(packet, header);
+    }
+
+    void deliverAssociationResponse(const MacAddress& transmitter, bool reassociation, Ieee80211StatusCode statusCode)
+    {
+        Enter_Method("deliverAssociationResponse");
+        auto packet = new Packet("AssociationResponse");
+        auto body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(transmitter);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+  protected:
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& address) override
+    {
+        (void)name;
+        (void)body;
+        (void)subtype;
+        managementFramesSent++;
+        lastManagementFrameAddress = address;
+    }
+
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associateConfirms++;
+        lastAssociationAddress = ap->address;
+        lastAssociationResult = resultCode;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociateConfirms++;
+        lastReassociationAddress = ap->address;
+        lastReassociationResult = resultCode;
+        confirmationSawClearedAssociation = confirmationSawClearedAssociation ||
+                (!mib->bssStationData.isAssociated && assocAP.address.isUnspecified());
+    }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class Ieee80211MgmtStaDisassociationTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211MgmtSta *mgmt = nullptr;
+
+  public:
+    Ieee80211MgmtStaDisassociationTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+    }
+
+    virtual void activity() override
+    {
+        const MacAddress currentAp("02:00:00:00:00:01");
+        const MacAddress targetAp("02:00:00:00:00:02");
+        const MacAddress foreignAp("02:00:00:00:00:03");
+
+        // A pending-only target is not an associated peer and cannot cancel
+        // the request merely by transmitting a Disassociation.
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        mgmt->abandonPendingAssociation();
+
+        // Address 3 is deliberately the pending target; Address 2 is
+        // unrelated. Validation must use the transmitter address.
+        mgmt->preparePendingAssociation(targetAp, false);
+        mgmt->deliverDisassociation(foreignAp, targetAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(!mgmt->isReassociationPending());
+        mgmt->abandonPendingAssociation();
+
+        // A current-AP frame tears down the current pair when no request is
+        // pending, including the beacon timer and copied association state.
+        mgmt->setAssociated(currentAp);
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(mgmt->associateConfirms == 0);
+        ASSERT(mgmt->reassociateConfirms == 0);
+
+        // A foreign frame leaves both the current association and a request
+        // to another AP untouched.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDisassociation(foreignAp, currentAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociateConfirms == 0);
+
+        // The current AP can clear its own association without cancelling the
+        // reassociation transaction to another AP; that response can still
+        // complete the pending request.
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == targetAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->reassociateConfirms == 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+
+        // A same-AP pending reassociation is terminated exactly once. The
+        // overridden confirmation also proves that teardown precedes the
+        // primitive visible to the agent.
+        mgmt->setAssociated(targetAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociateConfirms == 2);
+        ASSERT(mgmt->lastReassociationAddress == targetAp);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+        ASSERT(mgmt->confirmationSawClearedAssociation);
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->reassociateConfirms == 2);
+
+        // Exercise the association confirmation branch as well, even though
+        // normal station sequencing starts association while unassociated.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(currentAp, false);
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->associateConfirms == 1);
+        ASSERT(mgmt->lastAssociationAddress == currentAp);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+
+        // An unrelated primitive request must not cancel an in-progress
+        // reassociation to another AP, and that response must still complete.
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        int reassociateConfirmsBefore = mgmt->reassociateConfirms;
+        mgmt->requestDisassociation(foreignAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(mgmt->isReassociationPending());
+        ASSERT(mgmt->managementFramesSent == 1);
+        ASSERT(mgmt->lastManagementFrameAddress == foreignAp);
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == targetAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->reassociateConfirms == reassociateConfirmsBefore + 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+
+        // A request naming the pending target cancels that transaction but
+        // leaves the current association intact; a late response is ignored.
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        mgmt->setAssociated(currentAp);
+        mgmt->preparePendingAssociation(targetAp, true);
+        reassociateConfirmsBefore = mgmt->reassociateConfirms;
+        mgmt->requestDisassociation(targetAp);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->reassociateConfirms == reassociateConfirmsBefore);
+        ASSERT(mgmt->managementFramesSent == 2);
+        ASSERT(mgmt->lastManagementFrameAddress == targetAp);
+        mgmt->deliverAssociationResponse(targetAp, true, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == currentAp);
+        ASSERT(mgmt->reassociateConfirms == reassociateConfirmsBefore);
+
+        // The same peer scoping applies while unassociated and an initial
+        // association is pending: an unrelated request preserves it.
+        mgmt->deliverDisassociation(currentAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        mgmt->preparePendingAssociation(targetAp, false);
+        int associateConfirmsBefore = mgmt->associateConfirms;
+        mgmt->requestDisassociation(foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isPendingAssociationScheduled());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->managementFramesSent == 3);
+        ASSERT(mgmt->lastManagementFrameAddress == foreignAp);
+        mgmt->deliverAssociationResponse(targetAp, false, SC_SUCCESSFUL);
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress() == targetAp);
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(mgmt->associateConfirms == associateConfirmsBefore + 1);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+
+        // A same-target request cancels an initial association while the STA
+        // is unassociated, and a response arriving afterwards is ignored.
+        mgmt->deliverDisassociation(targetAp, foreignAp);
+        ASSERT(!mgmt->isAssociated());
+        mgmt->preparePendingAssociation(targetAp, false);
+        associateConfirmsBefore = mgmt->associateConfirms;
+        mgmt->requestDisassociation(targetAp);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(mgmt->managementFramesSent == 4);
+        ASSERT(mgmt->lastManagementFrameAddress == targetAp);
+        mgmt->deliverAssociationResponse(targetAp, false, SC_SUCCESSFUL);
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->associateConfirms == associateConfirmsBefore);
+
+        std::cout << "STA Disassociation peer filtering and pending-request preservation verified.\n";
+        std::cout << "STA same-peer disassociation confirmation typing and teardown verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaDisassociationTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple Ieee80211MgmtStaDisassociationTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaDisassociationTest);
+}
+
+network Ieee80211MgmtStaDisassociationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+        }
+        test: Ieee80211MgmtStaDisassociationTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaDisassociationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 1s
+**.wlan[*].opMode = "g(mixed)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+STA Disassociation peer filtering and pending-request preservation verified.
+
+%contains: stdout
+STA same-peer disassociation confirmation typing and teardown verified.

--- a/tests/module/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/module/Ieee80211MgmtStaDiscovery_1.test
@@ -11,6 +11,8 @@ channel. Legacy packet-domain discovery keeps its channelNumber unchanged.
 #include "inet/common/packet/Packet.h"
 #include "inet/common/packet/chunk/BytesChunk.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
 #include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
@@ -475,6 +477,72 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->isReassociationInProgressForTest());
         ASSERT(mgmt->reassociationConfirms == 2);
         ASSERT(mgmt->lastReassociationResult == PRC_TIMEOUT);
+
+        auto dcfRateSelection = check_and_cast<RateSelection *>(getModuleByPath("^.sta.wlan[0].mac.dcf.rateSelection"));
+        auto qosRateSelection = check_and_cast<QosRateSelection *>(getModuleByPath("^.sta.wlan[0].mac.hcf.rateSelection"));
+        const auto *modeSet = physicallayer::Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+        auto dataHeader = makeShared<Ieee80211DataHeader>();
+        dataHeader->setReceiverAddress(address);
+        Packet ratePacket("rate-selection");
+        const auto *dcfHtMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+        const auto *qosHtMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+        ASSERT(dcfHtMode->getHtMcsIndex() >= 0);
+        ASSERT(qosHtMode->getHtMcsIndex() >= 0);
+
+        // Both production selectors consume the same negotiated directional
+        // capability gate. A sparse peer that advertises only MCS 0 must not
+        // receive the configured faster HT mode.
+        Ieee80211HtCapabilities sparsePeer;
+        sparsePeer.supportedChannelWidths.insert(MHz(20));
+        sparsePeer.rxMcsSupported[0] = true;
+        sparsePeer.txMcsNss.maxMcsPerNss[0] = 0;
+        Ieee80211HtOperation sparseOperation;
+        sparseOperation.operatingChannelWidth = MHz(20);
+        sparseOperation.basicMcsSupported[0] = true;
+        staMib->setPeerHtCapabilities(address, sparsePeer, sparseOperation);
+        const auto *dcfSparseMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+        const auto *qosSparseMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+        ASSERT(dcfSparseMode == qosSparseMode);
+        ASSERT(dcfSparseMode->getHtMcsIndex() == 0);
+        ASSERT(dcfSparseMode->getDataMode()->getBandwidth() == MHz(20));
+
+        // The invalid/absent negotiated state is a legacy-only unicast
+        // condition, while group-addressed traffic keeps its existing HT
+        // selection policy.
+        staMib->removePeerHtCapabilities(address);
+        const auto *dcfLegacyMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+        const auto *qosLegacyMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+        ASSERT(dcfLegacyMode == modeSet->getFastestLegacyOperationalMode());
+        ASSERT(qosLegacyMode == modeSet->getFastestLegacyOperationalMode());
+        ASSERT(dcfLegacyMode->getHtMcsIndex() < 0);
+        ASSERT(qosLegacyMode->getHtMcsIndex() < 0);
+
+        // IEEE Std 802.11-2024, 10.6.6.5.2: a non-HT ACK or CTS primary
+        // rate must not exceed the preceding frame's rate (or non-HT
+        // reference rate). Both production selectors therefore bound the
+        // legacy fallback below an MCS 0 long-GI 20 MHz input.
+        const auto *mcs0Long = modeSet->getMode(Mbps(6.5), MHz(20), 1);
+        const auto *legacy6Mbps = modeSet->getMode(Mbps(6));
+        Packet responsePacket("response-rate-selection");
+        responsePacket.addTag<physicallayer::Ieee80211ModeInd>()->setMode(mcs0Long);
+        auto responseDataHeader = makeShared<Ieee80211DataHeader>();
+        responseDataHeader->setTransmitterAddress(address);
+        ASSERT(dcfRateSelection->computeResponseAckFrameMode(&responsePacket, responseDataHeader) == legacy6Mbps);
+        ASSERT(qosRateSelection->computeResponseAckFrameMode(&responsePacket, responseDataHeader) == legacy6Mbps);
+        auto rtsHeader = makeShared<Ieee80211RtsFrame>();
+        rtsHeader->setTransmitterAddress(address);
+        ASSERT(dcfRateSelection->computeResponseCtsFrameMode(&responsePacket, rtsHeader) == legacy6Mbps);
+        ASSERT(qosRateSelection->computeResponseCtsFrameMode(&responsePacket, rtsHeader) == legacy6Mbps);
+
+        auto multicastHeader = makeShared<Ieee80211DataHeader>();
+        multicastHeader->setReceiverAddress(MacAddress::BROADCAST_ADDRESS);
+        const auto *dcfMulticastMode = dcfRateSelection->computeMode(&ratePacket, multicastHeader);
+        const auto *qosMulticastMode = qosRateSelection->computeMode(&ratePacket, multicastHeader, nullptr);
+        ASSERT(dcfMulticastMode->getHtMcsIndex() >= 0);
+        ASSERT(qosMulticastMode->getHtMcsIndex() >= 0);
+        staMib->setPeerHtCapabilities(address, staMib->localHtCapabilities, staMib->getHtOperation());
+        ASSERT(dcfRateSelection->computeMode(&ratePacket, dataHeader)->getHtMcsIndex() >= 0);
+        ASSERT(qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr)->getHtMcsIndex() >= 0);
 
         mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);

--- a/tests/module/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/module/Ieee80211MgmtStaDiscovery_1.test
@@ -287,6 +287,14 @@ class TestIeee80211MgmtStaDiscovery : public Ieee80211MgmtSta
         processAssociationResponse(packet, header, reassociation);
     }
 
+    void resetAssociationState()
+    {
+        Enter_Method("resetAssociationState");
+        cancelPendingAssociation();
+        if (mib->bssStationData.isAssociated)
+            clearCurrentAssociation();
+    }
+
     bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
 
     bool isAssociatedForTest() const { return mib->bssStationData.isAssociated; }
@@ -400,6 +408,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         // IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4: a successful
         // association remains successful when the HT exchange is absent or
         // unusable; only the negotiated HT state is suppressed.
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
         ASSERT(mgmt->associationConfirms == 2);
@@ -407,6 +416,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->hasPeerHtState(address));
         ASSERT(htNegotiationFailures == 0);
 
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
         ASSERT(mgmt->associationConfirms == 3);
@@ -466,6 +476,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(mgmt->reassociationConfirms == 2);
         ASSERT(mgmt->lastReassociationResult == PRC_TIMEOUT);
 
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::PARTIAL);
         ASSERT(mgmt->associationConfirms == 4);
@@ -475,6 +486,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(!lastFailureReason.empty());
         ASSERT(!lastFailureWasReassociation);
 
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::UNUSABLE);
         ASSERT(mgmt->associationConfirms == 5);
@@ -482,6 +494,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->hasPeerHtState(address));
         ASSERT(htNegotiationFailures == 2);
 
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_DATARATE_UNSUP, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
         ASSERT(mgmt->associationConfirms == 6);
@@ -491,6 +504,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
 
         // The same policy applies to reassociation responses, and its
         // diagnostic retains the procedure context for observers.
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
         ASSERT(mgmt->hasPeerHtState(address));
@@ -504,6 +518,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
 
         // Missing packet-domain channel metadata is an invalid HT response,
         // not an exception. The association result itself remains successful.
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, false);
         ASSERT(mgmt->associationConfirms == 8);
@@ -516,6 +531,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         // Typed conversion failures in both successful response subtypes
         // preserve the successful association result while producing exactly
         // one HT negotiation diagnostic.
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::MALFORMED_CAPABILITIES);
         ASSERT(mgmt->associationConfirms == 9);
@@ -523,6 +539,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         ASSERT(!mgmt->hasPeerHtState(address));
         ASSERT(htNegotiationFailures == 5);
 
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
         ASSERT(mgmt->associationConfirms == 10);
@@ -543,6 +560,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         int expectedReassociationConfirms = mgmt->reassociationConfirms;
         int expectedFailures = htNegotiationFailures;
         auto expectInvalidAssociationTuple = [&](int primaryChannel, int secondaryChannelOffset, int width) {
+            mgmt->resetAssociationState();
             mgmt->prepareResponse(address, false);
             mgmt->deliverResponse(address, false, SC_SUCCESSFUL,
                     TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, true,
@@ -560,6 +578,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         expectInvalidAssociationTuple(13, 1, 40);
 
         auto expectValidAssociationTuple = [&](int primaryChannel, int secondaryChannelOffset) {
+            mgmt->resetAssociationState();
             mgmt->prepareResponse(address, false);
             mgmt->deliverResponse(address, false, SC_SUCCESSFUL,
                     TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, true,
@@ -607,6 +626,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
         // An unmappable standards-facing primary is peer input: a successful
         // association remains successful, but no negotiated HT state is kept
         // and exactly one diagnostic is emitted.
+        mgmt->resetAssociationState();
         mgmt->prepareResponse(address, false);
         mgmt->deliverResponse(address, false, SC_SUCCESSFUL,
                 TestIeee80211MgmtStaDiscovery::ResponseHtForm::UNMAPPABLE_PRIMARY);
@@ -619,6 +639,7 @@ class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
 
         // A production legacy STA ignores malformed optional HT elements in
         // discovery and successful association/reassociation responses.
+        mgmt->resetAssociationState();
         mgmt->setLegacyForTest();
         const MacAddress legacyAddress("02:00:00:00:00:04");
         mgmt->deliverDiscovery(legacyAddress, false, true, false, 11);

--- a/tests/module/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/module/Ieee80211MgmtStaDiscovery_1.test
@@ -1,0 +1,721 @@
+%description:
+Verify that serialized HT discovery stores the HT Operation primary channel and
+that the production authentication and association paths tune to that cached
+channel. Legacy packet-domain discovery keeps its channelNumber unchanged.
+
+%file: TestIeee80211MgmtStaDiscovery.cc
+
+#include <string>
+#include <vector>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Channel.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtStaDiscovery : public Ieee80211MgmtSta
+{
+  public:
+    int changedChannel = -1;
+    std::vector<int> changedChannels;
+    int associationConfirms = 0;
+    int reassociationConfirms = 0;
+    int managementFramesSent = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+
+    virtual void changeChannel(int channel) override
+    {
+        changedChannel = channel;
+        changedChannels.push_back(channel);
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& address) override
+    {
+        // The channel-tuning seam is the subject of this test; no peer is
+        // needed for the generated authentication/association requests.
+        managementFramesSent++;
+    }
+
+    void storeSerializedDiscovery(const MacAddress& address, int primaryChannel, bool probeResponse)
+    {
+        Enter_Method("storeSerializedDiscovery");
+        Ptr<Ieee80211BeaconFrame> original;
+        if (probeResponse)
+            original = makeShared<Ieee80211ProbeResponseFrame>();
+        else
+            original = makeShared<Ieee80211BeaconFrame>();
+        original->setSSID("serialized");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        original->setSupportedRates(rates);
+        original->setBeaconInterval(SimTime(100, SIMTIME_MS));
+        Ieee80211HtCapabilities capabilities;
+        capabilities.supportedChannelWidths.insert(MHz(20));
+        capabilities.rxMcsSupported[0] = true;
+        capabilities.txMcsNss.maxMcsPerNss[0] = 0;
+        setHtCapabilities(original, capabilities);
+        Ieee80211HtOperation operation;
+        operation.primaryChannel = primaryChannel;
+        operation.basicMcsSupported[0] = true;
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        setHtOperation(original, band, operation);
+        original->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(original));
+
+        Packet packet("discovery", original);
+        auto bytes = packet.peekAllAsBytes()->getBytes();
+        Packet encoded("encoded", makeShared<BytesChunk>(bytes));
+        encoded.addTag<SignalPowerInd>()->setPower(mW(1));
+        Ptr<const Ieee80211BeaconFrame> decoded;
+        if (probeResponse)
+            decoded = encoded.popAtFront<Ieee80211ProbeResponseFrame>(B(bytes.size()));
+        else
+            decoded = encoded.popAtFront<Ieee80211BeaconFrame>(B(bytes.size()));
+        physicallayer::Ieee80211Channel channel(band, primaryChannel);
+        encoded.addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        storeAPInfo(&encoded, header, decoded);
+    }
+
+    void deliverDiscovery(const MacAddress& address, bool probeResponse, bool malformedCapabilities,
+            bool malformedOperation, int legacyChannel = 9, bool channelIndicationPresent = true)
+    {
+        Enter_Method("deliverDiscovery");
+        Ptr<Ieee80211BeaconFrame> body = probeResponse ?
+                staticPtrCast<Ieee80211BeaconFrame>(makeShared<Ieee80211ProbeResponseFrame>()) :
+                makeShared<Ieee80211BeaconFrame>();
+        body->setSSID("malformed");
+        body->setChannelNumber(legacyChannel);
+        body->setBeaconInterval(SimTime(100, SIMTIME_MS));
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+        setHtCapabilities(body, mib->localHtCapabilities);
+        setHtOperation(body, &physicallayer::Ieee80211CompliantBands::band2_4GHz, mib->getHtOperation());
+        if (malformedCapabilities) {
+            auto capabilities = body->getHtCapabilities();
+            capabilities.maxAmpduLengthExponent = 4;
+            body->setHtCapabilities(capabilities);
+        }
+        if (malformedOperation) {
+            auto operation = body->getHtOperation();
+            operation.secondaryChannelOffset = 1;
+            body->setHtOperation(operation);
+        }
+        body->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(body));
+        auto packet = new Packet("malformed-discovery");
+        packet->insertAtBack(body);
+        packet->addTag<SignalPowerInd>()->setPower(mW(1));
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        physicallayer::Ieee80211Channel channel(band, mib->getHtOperation().primaryChannel);
+        if (channelIndicationPresent)
+            packet->addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        if (probeResponse)
+            handleProbeResponseFrame(packet, header);
+        else
+            handleBeaconFrame(packet, header);
+    }
+
+    void startAuthenticationForTest(const MacAddress& address)
+    {
+        Enter_Method("startAuthenticationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        startAuthentication(ap, SimTime(1, SIMTIME_MS));
+    }
+
+    void finishAuthenticationForTest(const MacAddress& address)
+    {
+        Enter_Method("finishAuthenticationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        if (ap->authTimeoutMsg != nullptr)
+            cancelAndDelete(ap->authTimeoutMsg);
+        ap->authTimeoutMsg = nullptr;
+        ap->isAuthenticated = true;
+    }
+
+    void startAssociationForTest(const MacAddress& address)
+    {
+        Enter_Method("startAssociationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        startAssociation(ap, SimTime(1, SIMTIME_MS));
+    }
+
+    void associateThroughCommandForTest(const MacAddress& address)
+    {
+        Enter_Method("associateThroughCommandForTest");
+        auto request = new Ieee80211Prim_AssociateRequest();
+        request->setAddress(address);
+        request->setTimeout(SimTime(1, SIMTIME_MS));
+        handleCommand(0, request);
+    }
+
+    void setUnsupportedCachedBasicMcsForTest(const MacAddress& address)
+    {
+        Enter_Method("setUnsupportedCachedBasicMcsForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr && ap->htOperationPresent);
+        ap->htOperation.basicMcsSupported.fill(false);
+        ap->htOperation.basicMcsSupported[32] = true;
+    }
+
+    void startReassociationForTest(const MacAddress& address)
+    {
+        Enter_Method("startReassociationForTest");
+        auto ap = lookupAP(address);
+        ASSERT(ap != nullptr);
+        startReassociation(ap, SimTime(1, SIMTIME_MS));
+    }
+
+    void deliverReassociationTimeoutForTest()
+    {
+        Enter_Method("deliverReassociationTimeoutForTest");
+        ASSERT(assocTimeoutMsg != nullptr);
+        cancelEvent(assocTimeoutMsg);
+        handleTimer(assocTimeoutMsg);
+    }
+
+    void cancelAssociationForTest()
+    {
+        Enter_Method("cancelAssociationForTest");
+        cancelPendingAssociation();
+    }
+
+    const ApInfo *getCachedAp(const MacAddress& address) const
+    {
+        return const_cast<TestIeee80211MgmtStaDiscovery *>(this)->lookupAP(address);
+    }
+
+    void prepareResponse(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("prepareResponse");
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = 6;
+            ap->ssid = "serialized";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+        }
+        ap->isAuthenticated = true;
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+    }
+
+    enum class ResponseHtForm { LEGACY, VALID, PARTIAL, UNUSABLE, MALFORMED_CAPABILITIES, MALFORMED_OPERATION, UNMAPPABLE_PRIMARY };
+
+    void deliverResponse(const MacAddress& address, bool reassociation, Ieee80211StatusCode statusCode, ResponseHtForm htForm,
+            bool channelIndicationPresent = true, int responsePrimaryChannel = -1,
+            int responseSecondaryChannelOffset = -1, int responseOperatingChannelWidth = 0)
+    {
+        Enter_Method("deliverResponse");
+        Ptr<Ieee80211AssociationResponseFrame> body;
+        if (reassociation)
+            body = makeShared<Ieee80211ReassociationResponseFrame>();
+        else
+            body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setAid(1);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+        if (htForm != ResponseHtForm::LEGACY) {
+            auto capabilities = mib->localHtCapabilities;
+            auto operation = mib->getHtOperation();
+            if (responsePrimaryChannel >= 0)
+                operation.primaryChannel = responsePrimaryChannel;
+            if (responseOperatingChannelWidth == 20)
+                operation.operatingChannelWidth = MHz(20);
+            else if (responseOperatingChannelWidth == 40) {
+                operation.operatingChannelWidth = MHz(40);
+                capabilities.supportedChannelWidths.insert(MHz(40));
+            }
+            if (responseSecondaryChannelOffset >= 0)
+                operation.secondaryChannelOffset = responseSecondaryChannelOffset;
+            if (htForm == ResponseHtForm::UNUSABLE) {
+                capabilities.rxMcsSupported.fill(false);
+                capabilities.txMcsNss.maxMcsPerNss.fill(-1);
+            }
+            setHtCapabilities(body, capabilities);
+            if (htForm != ResponseHtForm::PARTIAL)
+                setHtOperation(body, &physicallayer::Ieee80211CompliantBands::band2_4GHz, operation);
+            if (htForm == ResponseHtForm::MALFORMED_CAPABILITIES) {
+                auto malformedCapabilities = body->getHtCapabilities();
+                malformedCapabilities.maxAmpduLengthExponent = 4;
+                body->setHtCapabilities(malformedCapabilities);
+            }
+            if (htForm == ResponseHtForm::MALFORMED_OPERATION) {
+                auto malformedOperation = body->getHtOperation();
+                malformedOperation.secondaryChannelOffset = 2;
+                body->setHtOperation(malformedOperation);
+            }
+            if (htForm == ResponseHtForm::UNMAPPABLE_PRIMARY) {
+                auto unmappableOperation = body->getHtOperation();
+                unmappableOperation.primaryChannel = 99;
+                body->setHtOperation(unmappableOperation);
+            }
+        }
+        body->setChunkLength(B(9) + getHtMgmtElementsLength(body));
+        auto packet = new Packet("AssociationResponse");
+        packet->insertAtBack(body);
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        int channelNumber = responsePrimaryChannel >= 0 ? responsePrimaryChannel : mib->getHtOperation().primaryChannel;
+        physicallayer::Ieee80211Channel channel(band, channelNumber);
+        if (channelIndicationPresent)
+            packet->addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
+
+    bool isAssociatedForTest() const { return mib->bssStationData.isAssociated; }
+    const MacAddress& getAssociatedAddressForTest() const { return assocAP.address; }
+    bool hasBeaconTimeoutForTest() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    simtime_t getBeaconTimeoutArrivalForTest() const { return assocAP.beaconTimeoutMsg->getArrivalTime(); }
+    simtime_t getBeaconIntervalForTest() const { return assocAP.beaconInterval; }
+    bool hasPendingAssociationForTest() const { return assocTimeoutMsg != nullptr; }
+    bool isReassociationInProgressForTest() const { return reassociationInProgress; }
+    void clearChangedChannelsForTest() { changedChannels.clear(); }
+
+    void setLegacyForTest()
+    {
+        Enter_Method("setLegacyForTest");
+        mib->localHtCapabilitiesValid = false;
+    }
+
+    void setPrimaryChannelForTest(int channel)
+    {
+        Enter_Method("setPrimaryChannelForTest");
+        mib->setPrimaryChannel(channel);
+    }
+
+  protected:
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associationConfirms++;
+        lastAssociationResult = resultCode;
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociationConfirms++;
+        lastReassociationResult = resultCode;
+    }
+};
+
+Define_Module(TestIeee80211MgmtStaDiscovery);
+
+class Ieee80211MgmtStaDiscoveryTest : public cSimpleModule, public cListener
+{
+    using cListener::finish;
+
+    int htNegotiationFailures = 0;
+    bool lastFailureWasReassociation = false;
+    std::string lastFailureReason;
+
+  public:
+    Ieee80211MgmtStaDiscoveryTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtStaDiscovery *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+        mgmt->subscribe(Ieee80211MgmtSta::htNegotiationFailedSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (signalID == Ieee80211MgmtSta::htNegotiationFailedSignal) {
+            auto notification = check_and_cast<Ieee80211MgmtSta::HtNegotiationFailure *>(value);
+            htNegotiationFailures++;
+            lastFailureWasReassociation = notification->isReassociation();
+            lastFailureReason = notification->getReason();
+        }
+    }
+
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtStaDiscovery *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+        const MacAddress address("02:00:00:00:00:01");
+
+        mgmt->setPrimaryChannelForTest(6);
+        mgmt->storeSerializedDiscovery(address, 6, false);
+        ASSERT(mgmt->getCachedAp(address)->channel == 6);
+
+        const MacAddress probeAddress("02:00:00:00:00:02");
+        mgmt->storeSerializedDiscovery(probeAddress, 13, true);
+        ASSERT(mgmt->getCachedAp(probeAddress)->channel == 13);
+
+        // Malformed Beacon and Probe Response HT elements are peer input:
+        // neither one may abort the simulation or create a new cache entry.
+        const MacAddress malformedAddress("02:00:00:00:00:03");
+        mgmt->deliverDiscovery(malformedAddress, false, true, false);
+        ASSERT(mgmt->getCachedAp(malformedAddress) == nullptr);
+        mgmt->deliverDiscovery(malformedAddress, true, false, true);
+        ASSERT(mgmt->getCachedAp(malformedAddress) == nullptr);
+
+        mgmt->startAuthenticationForTest(address);
+        ASSERT(mgmt->changedChannel == 6);
+        mgmt->finishAuthenticationForTest(address);
+
+        mgmt->startAssociationForTest(address);
+        ASSERT(mgmt->changedChannel == 6);
+        mgmt->cancelAssociationForTest();
+
+        // The Basic HT-MCS Set is authoritative in the cached Beacon/Probe
+        // Response. An unsupported set refuses the production command before
+        // channel tuning or Association Request transmission.
+        mgmt->setUnsupportedCachedBasicMcsForTest(address);
+        int framesBeforeRefusal = mgmt->managementFramesSent;
+        int channelsBeforeRefusal = mgmt->changedChannels.size();
+        mgmt->associateThroughCommandForTest(address);
+        ASSERT(mgmt->associationConfirms == 1);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(mgmt->managementFramesSent == framesBeforeRefusal);
+        ASSERT((int)mgmt->changedChannels.size() == channelsBeforeRefusal);
+        ASSERT(!mgmt->hasPendingAssociationForTest());
+        mgmt->storeSerializedDiscovery(address, 6, false);
+
+        // IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4: a successful
+        // association remains successful when the HT exchange is absent or
+        // unusable; only the negotiated HT state is suppressed.
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
+        ASSERT(mgmt->associationConfirms == 2);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 0);
+
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
+        ASSERT(mgmt->associationConfirms == 3);
+        ASSERT(mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 0);
+
+        // An invalid Beacon from the associated AP must not extend the
+        // beacon-loss deadline, even though the handler reaches the normal
+        // management-frame path.
+        simtime_t beaconDeadline = mgmt->getBeaconTimeoutArrivalForTest();
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverDiscovery(address, false, false, true);
+        ASSERT(mgmt->getBeaconTimeoutArrivalForTest() == beaconDeadline);
+        ASSERT(mgmt->getCachedAp(address)->channel == 6);
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverDiscovery(address, false, false, false);
+        ASSERT(mgmt->getBeaconTimeoutArrivalForTest() ==
+                simTime() + 3.5 * mgmt->getBeaconIntervalForTest());
+
+        auto staMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.sta.wlan[0].mib"));
+
+        // IEEE Std 802.11-2024, 11.3.5.4(f): a refused or timed-out
+        // reassociation to another AP keeps the current association and
+        // restores the current AP's channel before reporting failure.
+        mgmt->finishAuthenticationForTest(probeAddress);
+        staMib->setPeerHtCapabilities(probeAddress, staMib->localHtCapabilities, staMib->getHtOperation());
+        mgmt->clearChangedChannelsForTest();
+        mgmt->startReassociationForTest(probeAddress);
+        mgmt->deliverResponse(probeAddress, true, SC_DATARATE_UNSUP, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
+        ASSERT(mgmt->changedChannels.size() == 2);
+        ASSERT(mgmt->changedChannels[0] == 13);
+        ASSERT(mgmt->changedChannels[1] == 6);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->getAssociatedAddressForTest() == address);
+        ASSERT(mgmt->hasBeaconTimeoutForTest());
+        ASSERT(mgmt->hasPeerHtState(address));
+        ASSERT(!mgmt->hasPeerHtState(probeAddress));
+        ASSERT(!mgmt->hasPendingAssociationForTest());
+        ASSERT(!mgmt->isReassociationInProgressForTest());
+        ASSERT(mgmt->reassociationConfirms == 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_REFUSED);
+
+        staMib->setPeerHtCapabilities(probeAddress, staMib->localHtCapabilities, staMib->getHtOperation());
+        mgmt->clearChangedChannelsForTest();
+        mgmt->startReassociationForTest(probeAddress);
+        mgmt->deliverReassociationTimeoutForTest();
+        ASSERT(mgmt->changedChannels.size() == 2);
+        ASSERT(mgmt->changedChannels[0] == 13);
+        ASSERT(mgmt->changedChannels[1] == 6);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->getAssociatedAddressForTest() == address);
+        ASSERT(mgmt->hasBeaconTimeoutForTest());
+        ASSERT(mgmt->hasPeerHtState(address));
+        ASSERT(!mgmt->hasPeerHtState(probeAddress));
+        ASSERT(!mgmt->hasPendingAssociationForTest());
+        ASSERT(!mgmt->isReassociationInProgressForTest());
+        ASSERT(mgmt->reassociationConfirms == 2);
+        ASSERT(mgmt->lastReassociationResult == PRC_TIMEOUT);
+
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::PARTIAL);
+        ASSERT(mgmt->associationConfirms == 4);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 1);
+        ASSERT(!lastFailureReason.empty());
+        ASSERT(!lastFailureWasReassociation);
+
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::UNUSABLE);
+        ASSERT(mgmt->associationConfirms == 5);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 2);
+
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_DATARATE_UNSUP, TestIeee80211MgmtStaDiscovery::ResponseHtForm::LEGACY);
+        ASSERT(mgmt->associationConfirms == 6);
+        ASSERT(mgmt->lastAssociationResult == PRC_REFUSED);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 2);
+
+        // The same policy applies to reassociation responses, and its
+        // diagnostic retains the procedure context for observers.
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
+        ASSERT(mgmt->hasPeerHtState(address));
+        mgmt->prepareResponse(probeAddress, true);
+        mgmt->deliverResponse(probeAddress, true, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::PARTIAL);
+        ASSERT(mgmt->reassociationConfirms == 3);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(probeAddress));
+        ASSERT(htNegotiationFailures == 3);
+        ASSERT(lastFailureWasReassociation);
+
+        // Missing packet-domain channel metadata is an invalid HT response,
+        // not an exception. The association result itself remains successful.
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, false);
+        ASSERT(mgmt->associationConfirms == 8);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 4);
+        ASSERT(lastFailureReason.find("channel") != std::string::npos || lastFailureReason.find("band") != std::string::npos);
+
+        // Typed conversion failures in both successful response subtypes
+        // preserve the successful association result while producing exactly
+        // one HT negotiation diagnostic.
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::MALFORMED_CAPABILITIES);
+        ASSERT(mgmt->associationConfirms == 9);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 5);
+
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID);
+        ASSERT(mgmt->associationConfirms == 10);
+        ASSERT(mgmt->hasPeerHtState(address));
+        mgmt->prepareResponse(address, true);
+        mgmt->deliverResponse(address, true, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::MALFORMED_OPERATION);
+        ASSERT(mgmt->reassociationConfirms == 4);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == 6);
+        ASSERT(lastFailureWasReassociation);
+
+        // Exercise the complete response tuple through both production
+        // response handlers. Width/offset inconsistencies and a nonexistent
+        // secondary channel are invalid; both legal 2.4 GHz edge tuples are
+        // accepted and negotiate without a diagnostic.
+        int expectedAssociationConfirms = mgmt->associationConfirms;
+        int expectedReassociationConfirms = mgmt->reassociationConfirms;
+        int expectedFailures = htNegotiationFailures;
+        auto expectInvalidAssociationTuple = [&](int primaryChannel, int secondaryChannelOffset, int width) {
+            mgmt->prepareResponse(address, false);
+            mgmt->deliverResponse(address, false, SC_SUCCESSFUL,
+                    TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, true,
+                    primaryChannel, secondaryChannelOffset, width);
+            expectedAssociationConfirms++;
+            expectedFailures++;
+            ASSERT(mgmt->associationConfirms == expectedAssociationConfirms);
+            ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+            ASSERT(!mgmt->hasPeerHtState(address));
+            ASSERT(htNegotiationFailures == expectedFailures);
+        };
+        expectInvalidAssociationTuple(6, 1, 20);
+        expectInvalidAssociationTuple(6, 3, 20);
+        expectInvalidAssociationTuple(6, 0, 40);
+        expectInvalidAssociationTuple(13, 1, 40);
+
+        auto expectValidAssociationTuple = [&](int primaryChannel, int secondaryChannelOffset) {
+            mgmt->prepareResponse(address, false);
+            mgmt->deliverResponse(address, false, SC_SUCCESSFUL,
+                    TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, true,
+                    primaryChannel, secondaryChannelOffset, 40);
+            expectedAssociationConfirms++;
+            ASSERT(mgmt->associationConfirms == expectedAssociationConfirms);
+            ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+            ASSERT(mgmt->hasPeerHtState(address));
+            ASSERT(htNegotiationFailures == expectedFailures);
+        };
+        expectValidAssociationTuple(0, 1);
+        expectValidAssociationTuple(12, 3);
+
+        auto expectInvalidReassociationTuple = [&](int primaryChannel, int secondaryChannelOffset, int width) {
+            mgmt->prepareResponse(address, true);
+            mgmt->deliverResponse(address, true, SC_SUCCESSFUL,
+                    TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, true,
+                    primaryChannel, secondaryChannelOffset, width);
+            expectedReassociationConfirms++;
+            expectedFailures++;
+            ASSERT(mgmt->reassociationConfirms == expectedReassociationConfirms);
+            ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+            ASSERT(!mgmt->hasPeerHtState(address));
+            ASSERT(htNegotiationFailures == expectedFailures);
+        };
+        expectInvalidReassociationTuple(6, 1, 20);
+        expectInvalidReassociationTuple(6, 3, 20);
+        expectInvalidReassociationTuple(6, 0, 40);
+        expectInvalidReassociationTuple(13, 1, 40);
+
+        auto expectValidReassociationTuple = [&](int primaryChannel, int secondaryChannelOffset) {
+            mgmt->prepareResponse(address, true);
+            mgmt->deliverResponse(address, true, SC_SUCCESSFUL,
+                    TestIeee80211MgmtStaDiscovery::ResponseHtForm::VALID, true,
+                    primaryChannel, secondaryChannelOffset, 40);
+            expectedReassociationConfirms++;
+            ASSERT(mgmt->reassociationConfirms == expectedReassociationConfirms);
+            ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+            ASSERT(mgmt->hasPeerHtState(address));
+            ASSERT(htNegotiationFailures == expectedFailures);
+        };
+        expectValidReassociationTuple(0, 1);
+        expectValidReassociationTuple(12, 3);
+
+        // An unmappable standards-facing primary is peer input: a successful
+        // association remains successful, but no negotiated HT state is kept
+        // and exactly one diagnostic is emitted.
+        mgmt->prepareResponse(address, false);
+        mgmt->deliverResponse(address, false, SC_SUCCESSFUL,
+                TestIeee80211MgmtStaDiscovery::ResponseHtForm::UNMAPPABLE_PRIMARY);
+        expectedAssociationConfirms++;
+        expectedFailures++;
+        ASSERT(mgmt->associationConfirms == expectedAssociationConfirms);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(address));
+        ASSERT(htNegotiationFailures == expectedFailures);
+
+        // A production legacy STA ignores malformed optional HT elements in
+        // discovery and successful association/reassociation responses.
+        mgmt->setLegacyForTest();
+        const MacAddress legacyAddress("02:00:00:00:00:04");
+        mgmt->deliverDiscovery(legacyAddress, false, true, false, 11);
+        mgmt->deliverDiscovery(legacyAddress, true, false, true, 12);
+        auto legacyAp = mgmt->getCachedAp(legacyAddress);
+        ASSERT(legacyAp != nullptr);
+        ASSERT(legacyAp->channel == 12);
+        ASSERT(!legacyAp->htCapabilitiesPresent);
+        ASSERT(!legacyAp->htOperationPresent);
+        int failuresBeforeLegacyResponse = htNegotiationFailures;
+        mgmt->prepareResponse(legacyAddress, false);
+        mgmt->deliverResponse(legacyAddress, false, SC_SUCCESSFUL, TestIeee80211MgmtStaDiscovery::ResponseHtForm::MALFORMED_CAPABILITIES);
+        expectedAssociationConfirms++;
+        ASSERT(mgmt->associationConfirms == expectedAssociationConfirms);
+        ASSERT(mgmt->lastAssociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(legacyAddress));
+        ASSERT(htNegotiationFailures == failuresBeforeLegacyResponse);
+        mgmt->prepareResponse(legacyAddress, true);
+        mgmt->deliverResponse(legacyAddress, true, SC_SUCCESSFUL,
+                TestIeee80211MgmtStaDiscovery::ResponseHtForm::MALFORMED_OPERATION);
+        ASSERT(mgmt->reassociationConfirms == expectedReassociationConfirms + 1);
+        ASSERT(mgmt->lastReassociationResult == PRC_SUCCESS);
+        ASSERT(!mgmt->hasPeerHtState(legacyAddress));
+        ASSERT(htNegotiationFailures == failuresBeforeLegacyResponse);
+
+        std::cout << "Serialized Beacon and Probe Response HT discovery drive production tuning to advertised channels.\n";
+        std::cout << "Association and reassociation HT response semantics preserve success and diagnose invalid negotiation.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaDiscoveryTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtStaDiscovery extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtStaDiscovery);
+}
+
+simple Ieee80211MgmtStaDiscoveryTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaDiscoveryTest);
+}
+
+network Ieee80211MgmtStaDiscoveryTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtStaDiscovery";
+                wlan[*].agent.typename = "Ieee80211AgentSta";
+        }
+        test: Ieee80211MgmtStaDiscoveryTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaDiscoveryTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+seed-set = 0
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 100s
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+*.sta.wlan[0].mac.qosStation = true
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+Serialized Beacon and Probe Response HT discovery drive production tuning to advertised channels.
+
+%contains: stdout
+Association and reassociation HT response semantics preserve success and diagnose invalid negotiation.

--- a/tests/module/Ieee80211MgmtStaLifecycle_1.test
+++ b/tests/module/Ieee80211MgmtStaLifecycle_1.test
@@ -1,0 +1,361 @@
+%description:
+Verify that detailed station management tears down production-reachable scan,
+authentication, association, reassociation, beacon, and negotiated peer HT
+state on shutdown and crash. The node remains down past every pending timer
+deadline and restarts without resurrecting the interrupted state.
+
+%file: TestIeee80211MgmtStaLifecycle.cc
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  protected:
+    static MacAddress getCurrentAccessPointAddress()
+    {
+        return MacAddress("02:00:00:00:00:01");
+    }
+
+    static MacAddress getTargetAccessPointAddress()
+    {
+        return MacAddress("02:00:00:00:00:02");
+    }
+
+    ApInfo *addAccessPoint(const MacAddress& address, bool authenticated)
+    {
+        ASSERT(lookupAP(address) == nullptr);
+        apList.push_back(ApInfo());
+        auto ap = &apList.back();
+        ap->channel = 6;
+        ap->address = address;
+        ap->ssid = "lifecycle-ssid";
+        ap->beaconInterval = SimTime(100, SIMTIME_US);
+        ap->isAuthenticated = authenticated;
+        return ap;
+    }
+
+    void assertCleanEntryState()
+    {
+        ASSERT(!isScanning);
+        ASSERT(scanTimer == nullptr);
+        ASSERT(apList.empty());
+        ASSERT(assocTimeoutMsg == nullptr);
+        ASSERT(!reassociationInProgress);
+        ASSERT(!mib->bssStationData.isAssociated);
+        ASSERT(assocAP.address.isUnspecified());
+        ASSERT(assocAP.beaconTimeoutMsg == nullptr);
+    }
+
+  public:
+    void startActiveScanPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startActiveScanPhase");
+        assertCleanEntryState();
+
+        Ieee80211Prim_ScanRequest request;
+        request.setBSSType(BSSTYPE_INFRASTRUCTURE);
+        request.setActiveScan(true);
+        request.setProbeDelay(timerDelay);
+        request.setMinChannelTime(timerDelay);
+        request.setMaxChannelTime(timerDelay);
+        request.setChannelListArraySize(1);
+        request.setChannelList(0, 6);
+        processScanCommand(&request);
+    }
+
+    void startAuthenticationPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startAuthenticationPhase");
+        assertCleanEntryState();
+        startAuthentication(addAccessPoint(getTargetAccessPointAddress(), false), timerDelay);
+    }
+
+    void startAssociationPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startAssociationPhase");
+        assertCleanEntryState();
+        startAssociation(addAccessPoint(getTargetAccessPointAddress(), true), timerDelay);
+    }
+
+    void startReassociationPhase(simtime_t timerDelay)
+    {
+        Enter_Method("startReassociationPhase");
+        assertCleanEntryState();
+        ASSERT(mib->isHtOperationSupported());
+
+        const auto currentAddress = getCurrentAccessPointAddress();
+        auto targetAp = addAccessPoint(getTargetAccessPointAddress(), true);
+
+        // This is the coherent state produced by a successful Association
+        // Response: an associated AP, negotiated peer HT state, and beacon
+        // timeout. startReassociation() then enters the real pending path.
+        mib->bssData.ssid = "lifecycle-ssid";
+        mib->bssData.bssid = currentAddress;
+        mib->bssStationData.isAssociated = true;
+        assocAP = AssociatedApInfo();
+        assocAP.channel = 6;
+        assocAP.address = currentAddress;
+        assocAP.ssid = "lifecycle-ssid";
+        assocAP.beaconInterval = SimTime(100, SIMTIME_US);
+        assocAP.isAuthenticated = true;
+        assocAP.beaconTimeoutMsg = new cMessage("beaconTimeout", 6);
+        scheduleAfter(timerDelay, assocAP.beaconTimeoutMsg);
+
+        Ieee80211HtOperation operation;
+        operation.primaryChannel = 6;
+        operation.basicMcsSupported[0] = true;
+        mib->setPeerHtCapabilities(currentAddress, mib->localHtCapabilities, operation);
+        startReassociation(targetAp, timerDelay);
+    }
+
+    bool hasScanTimer() const { return scanTimer != nullptr; }
+    bool isActiveScanSubscribed() const { return host != nullptr && host->isSubscribed(physicallayer::IRadio::receptionStateChangedSignal, const_cast<TestIeee80211MgmtSta *>(this)); }
+    bool hasPendingAuthentication() const
+    {
+        for (const auto& ap : apList)
+            if (ap.authTimeoutMsg != nullptr)
+                return true;
+        return false;
+    }
+    bool hasPendingAssociation() const { return assocTimeoutMsg != nullptr; }
+    bool hasBeaconTimer() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    bool hasCurrentPeerHtState() const { return mib->findPeerHtState(getCurrentAccessPointAddress()) != nullptr; }
+    bool isAssociated() const { return mib->bssStationData.isAssociated; }
+    bool isReassociationPending() const { return reassociationInProgress; }
+    bool isScanningNow() const { return isScanning; }
+    bool isApListEmpty() const { return apList.empty(); }
+    MacAddress getAssociatedAddress() const { return assocAP.address; }
+    const std::string& getCachedSsid() const { return mib->bssData.ssid; }
+    MacAddress getCachedBssid() const { return mib->bssData.bssid; }
+};
+
+Define_Module(TestIeee80211MgmtSta);
+
+class TestIeee80211AgentSta : public Ieee80211AgentSta
+{
+  protected:
+    virtual void initialize(int stage) override
+    {
+        SimpleModule::initialize(stage);
+    }
+
+    virtual void handleMessage(cMessage *message) override
+    {
+        delete message;
+    }
+};
+
+Define_Module(TestIeee80211AgentSta);
+
+class Ieee80211MgmtStaLifecycleTest : public cSimpleModule
+{
+  protected:
+    TestIeee80211MgmtSta *mgmt = nullptr;
+
+  public:
+    Ieee80211MgmtStaLifecycleTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtSta *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+    }
+
+    virtual void activity() override
+    {
+        const auto timerDelay = SimTime(5, SIMTIME_US);
+        const auto downCheckDelay = SimTime(6, SIMTIME_US);
+        const auto restartOffset = SimTime(4500, SIMTIME_NS);
+        const auto nextDownCheckDelay = SimTime(5500, SIMTIME_NS);
+
+        mgmt->startActiveScanPhase(timerDelay);
+        ASSERT(mgmt->isScanningNow());
+        ASSERT(mgmt->hasScanTimer());
+        ASSERT(mgmt->isActiveScanSubscribed());
+        std::cout << "Detailed STA active scan entered through processScanCommand.\n";
+
+        wait(downCheckDelay); // shutdown at 1 us; old timer deadline at 5 us
+        checkClearedState(false, "active scan shutdown");
+        wait(restartOffset); // startup at 10 us
+        checkClearedState(false, "active scan restart");
+
+        mgmt->startAuthenticationPhase(timerDelay);
+        ASSERT(mgmt->hasPendingAuthentication());
+        ASSERT(!mgmt->isAssociated());
+        std::cout << "Detailed STA authentication entered through startAuthentication.\n";
+
+        wait(nextDownCheckDelay); // crash at 11.5 us; old deadline at 15.5 us
+        checkClearedState(false, "authentication crash");
+        wait(restartOffset); // startup at 20 us
+        checkClearedState(false, "authentication restart");
+
+        mgmt->startAssociationPhase(timerDelay);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAssociated());
+        std::cout << "Detailed STA association entered through startAssociation.\n";
+
+        wait(nextDownCheckDelay); // shutdown at 21.5 us; old deadline at 25.5 us
+        checkClearedState(false, "association shutdown");
+        wait(restartOffset); // startup at 30 us
+        checkClearedState(false, "association restart");
+
+        mgmt->startReassociationPhase(timerDelay);
+        ASSERT(mgmt->hasPendingAssociation());
+        ASSERT(mgmt->isReassociationPending());
+        ASSERT(mgmt->isAssociated());
+        ASSERT(mgmt->hasBeaconTimer());
+        ASSERT(mgmt->hasCurrentPeerHtState());
+        std::cout << "Detailed STA reassociation entered through startReassociation.\n";
+
+        wait(nextDownCheckDelay); // crash at 31.5 us; old deadlines at 35.5 us
+        checkClearedState(true, "reassociation crash");
+        wait(restartOffset); // startup at 40 us
+        checkClearedState(true, "reassociation restart");
+
+        std::cout << "Detailed STA reachable lifecycle teardown and restart cleanliness verified.\n";
+    }
+
+    void checkClearedState(bool expectCachedAssociation, const char *phase)
+    {
+        ASSERT(!mgmt->isScanningNow());
+        ASSERT(!mgmt->hasScanTimer());
+        ASSERT(!mgmt->isActiveScanSubscribed());
+        ASSERT(!mgmt->hasPendingAuthentication());
+        ASSERT(!mgmt->hasPendingAssociation());
+        ASSERT(!mgmt->isReassociationPending());
+        ASSERT(!mgmt->isAssociated());
+        ASSERT(mgmt->getAssociatedAddress().isUnspecified());
+        ASSERT(!mgmt->hasBeaconTimer());
+        ASSERT(!mgmt->hasCurrentPeerHtState());
+        ASSERT(mgmt->isApListEmpty());
+        if (expectCachedAssociation) {
+            ASSERT(mgmt->getCachedSsid() == "lifecycle-ssid");
+            ASSERT(mgmt->getCachedBssid() == MacAddress("02:00:00:00:00:01"));
+        }
+        std::cout << "Detailed STA state cleared after " << phase << ".\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaLifecycleTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.common.scenario.ScenarioManager;
+import inet.linklayer.ieee80211.mgmt.Ieee80211AgentSta;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtSta extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtSta);
+}
+
+simple TestIeee80211AgentSta extends Ieee80211AgentSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211AgentSta);
+}
+
+simple Ieee80211MgmtStaLifecycleTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaLifecycleTest);
+}
+
+network Ieee80211MgmtStaLifecycleTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        scenarioManager: ScenarioManager;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtSta";
+                wlan[*].agent.typename = "TestIeee80211AgentSta";
+        }
+        test: Ieee80211MgmtStaLifecycleTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaLifecycleTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 45us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+*.sta.wlan[0].radio.channelNumber = 6
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+**.hasStatus = true
+**.scenarioManager.script = xmldoc("scenario.xml")
+
+%file: scenario.xml
+
+<scenario>
+    <at t="1us">
+        <shutdown module="sta"/>
+    </at>
+    <at t="10us">
+        <startup module="sta"/>
+    </at>
+    <at t="11500ns">
+        <crash module="sta"/>
+    </at>
+    <at t="20us">
+        <startup module="sta"/>
+    </at>
+    <at t="21500ns">
+        <shutdown module="sta"/>
+    </at>
+    <at t="30us">
+        <startup module="sta"/>
+    </at>
+    <at t="31500ns">
+        <crash module="sta"/>
+    </at>
+    <at t="40us">
+        <startup module="sta"/>
+    </at>
+</scenario>
+
+%contains: stdout
+Detailed STA active scan entered through processScanCommand.
+
+%contains: stdout
+Detailed STA authentication entered through startAuthentication.
+
+%contains: stdout
+Detailed STA association entered through startAssociation.
+
+%contains: stdout
+Detailed STA reassociation entered through startReassociation.
+
+%contains: stdout
+Detailed STA reachable lifecycle teardown and restart cleanliness verified.

--- a/tests/module/Ieee80211MgmtStaSimplifiedInitialization_1.test
+++ b/tests/module/Ieee80211MgmtStaSimplifiedInitialization_1.test
@@ -1,0 +1,245 @@
+%description:
+Verify simplified station BSS identity is visible to automatic network
+configuration while negotiated HT peer state is installed only at the last
+initialization stage. Verify shutdown removes the AP-side association and HT
+peer state and startup restores both. Verify crash performs the same cleanup,
+and remains safe when the recorded AP can no longer be resolved.
+
+%file: TestInitializationObserver.cc
+
+#include "inet/common/InitStages.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/networklayer/common/L3AddressResolver.h"
+#include "inet/networklayer/common/NetworkInterface.h"
+#include "inet/networklayer/configurator/ipv4/Ipv4NetworkConfigurator.h"
+
+namespace inet {
+
+class TestIpv4NetworkConfigurator : public Ipv4NetworkConfigurator
+{
+  public:
+    std::string getTestWirelessId(NetworkInterface *networkInterface) { return getWirelessId(networkInterface); }
+};
+
+Define_Module(TestIpv4NetworkConfigurator);
+
+class TestInitializationObserver : public cSimpleModule
+{
+  protected:
+    virtual int numInitStages() const override { return NUM_INIT_STAGES; }
+
+    virtual void initialize(int stage) override
+    {
+        if (stage == INITSTAGE_NETWORK_CONFIGURATION || stage == INITSTAGE_LAST) {
+            auto configurator = check_and_cast<TestIpv4NetworkConfigurator *>(getModuleByPath("^.configurator"));
+            auto apInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.ap.wlan[0]"));
+            auto staInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.sta.wlan[0]"));
+            auto apMib = check_and_cast<ieee80211::Ieee80211Mib *>(apInterface->getSubmodule("mib"));
+            auto staMib = check_and_cast<ieee80211::Ieee80211Mib *>(staInterface->getSubmodule("mib"));
+
+            ASSERT(staInterface->getSubmodule("agent") == nullptr);
+            ASSERT(apMib->hasPrimaryChannel());
+            ASSERT(apMib->requirePrimaryChannel() == 6);
+            if (stage == INITSTAGE_NETWORK_CONFIGURATION) {
+                ASSERT(apMib->bssData.ssid == "review-ssid");
+                ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
+                ASSERT(configurator->getTestWirelessId(apInterface) == configurator->getTestWirelessId(staInterface));
+                ASSERT(!staMib->address.isUnspecified());
+                ASSERT(apMib->bssAccessPointData.stations.find(MacAddress::UNSPECIFIED_ADDRESS) == apMib->bssAccessPointData.stations.end());
+                ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+                ASSERT(apMib->findPeerHtState(staMib->address) == nullptr);
+                ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+                std::cout << "Simplified STA wireless identity available during network configuration.\n";
+            }
+            else {
+                ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+                ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+                ASSERT(apMib->findPeerHtState(staMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);
+                ASSERT(staMib->findPeerHtState(apMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);
+                std::cout << "Simplified STA HT peer state installed at last initialization stage.\n";
+                scheduleAt(SimTime(1500, SIMTIME_NS), new cMessage("checkShutdown"));
+                scheduleAt(SimTime(2500, SIMTIME_NS), new cMessage("checkShutdownRestart"));
+                scheduleAt(SimTime(3500, SIMTIME_NS), new cMessage("checkResolvableCrash"));
+                scheduleAt(SimTime(4500, SIMTIME_NS), new cMessage("checkCrashRestart"));
+                scheduleAt(SimTime(5500, SIMTIME_NS), new cMessage("prepareMissingApCrash"));
+                scheduleAt(SimTime(6500, SIMTIME_NS), new cMessage("checkMissingApCrash"));
+            }
+        }
+    }
+
+    virtual void handleMessage(cMessage *message) override
+    {
+        auto apInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.ap.wlan[0]"));
+        auto staInterface = check_and_cast<NetworkInterface *>(getModuleByPath("^.sta.wlan[0]"));
+        auto apMib = check_and_cast<ieee80211::Ieee80211Mib *>(apInterface->getSubmodule("mib"));
+        auto staMib = check_and_cast<ieee80211::Ieee80211Mib *>(staInterface->getSubmodule("mib"));
+        if (!strcmp(message->getName(), "checkShutdown")) {
+            ASSERT(!staMib->bssStationData.isAssociated);
+            ASSERT(apMib->bssAccessPointData.stations.find(staMib->address) == apMib->bssAccessPointData.stations.end());
+            ASSERT(apMib->findPeerHtState(staMib->address) == nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+            std::cout << "Simplified STA AP-side association and HT peer state removed after shutdown.\n";
+        }
+        else if (!strcmp(message->getName(), "checkShutdownRestart")) {
+            ASSERT(staMib->bssStationData.isAssociated);
+            ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+            std::cout << "Simplified STA association and HT peer state restored after shutdown restart.\n";
+        }
+        else if (!strcmp(message->getName(), "checkResolvableCrash")) {
+            ASSERT(!staMib->bssStationData.isAssociated);
+            ASSERT(apMib->bssAccessPointData.stations.find(staMib->address) == apMib->bssAccessPointData.stations.end());
+            ASSERT(apMib->findPeerHtState(staMib->address) == nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+            std::cout << "Simplified STA AP-side association and HT peer state removed after resolvable crash.\n";
+        }
+        else if (!strcmp(message->getName(), "checkCrashRestart")) {
+            ASSERT(staMib->bssStationData.isAssociated);
+            ASSERT(staMib->bssData.ssid == apMib->bssData.ssid);
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+            std::cout << "Simplified STA association and HT peer state restored after crash restart.\n";
+        }
+        else if (!strcmp(message->getName(), "prepareMissingApCrash")) {
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+            staMib->bssData.bssid = MacAddress("02:00:00:00:00:ff");
+            ASSERT(staMib->bssData.bssid != apMib->address);
+            ASSERT(L3AddressResolver().findHostWithAddress(staMib->bssData.bssid) == nullptr);
+            std::cout << "Simplified STA recorded BSSID made unresolvable before crash.\n";
+        }
+        else if (!strcmp(message->getName(), "checkMissingApCrash")) {
+            ASSERT(!staMib->bssStationData.isAssociated);
+            ASSERT(staMib->bssData.bssid == MacAddress("02:00:00:00:00:ff"));
+            ASSERT(L3AddressResolver().findHostWithAddress(staMib->bssData.bssid) == nullptr);
+            ASSERT(staMib->findPeerHtState(apMib->address) == nullptr);
+            ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == ieee80211::Ieee80211Mib::ASSOCIATED);
+            ASSERT(apMib->findPeerHtState(staMib->address) != nullptr);
+            std::cout << "Simplified STA crash tolerated missing AP lookup and cleared local HT peer state.\n";
+        }
+        else
+            ASSERT(false);
+        delete message;
+    }
+};
+
+Define_Module(TestInitializationObserver);
+
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.common.scenario.ScenarioManager;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIpv4NetworkConfigurator extends Ipv4NetworkConfigurator
+{
+    parameters:
+        @class(::inet::TestIpv4NetworkConfigurator);
+}
+
+simple TestInitializationObserver extends SimpleModule
+{
+    parameters:
+        @class(::inet::TestInitializationObserver);
+}
+
+network Ieee80211MgmtStaSimplifiedInitializationTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        configurator: TestIpv4NetworkConfigurator;
+        scenarioManager: ScenarioManager;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtStaSimplified";
+                wlan[*].agent.typename = "";
+        }
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtApSimplified";
+                wlan[*].agent.typename = "";
+        }
+        observer: TestInitializationObserver;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaSimplifiedInitializationTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 7us
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "auto"
+*.ap.wlan[0].mgmt.ssid = "review-ssid"
+*.ap.wlan[0].radio.channelNumber = 6
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+**.wlan[0].opMode = "n(mixed-2.4Ghz)"
+**.hasStatus = true
+**.scenarioManager.script = xmldoc("scenario.xml")
+**.wlan[0].bitrate = 65Mbps
+**.wlan[0].radio.bandName = "2.4 GHz"
+**.wlan[0].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%file: scenario.xml
+
+<scenario>
+    <at t="1us">
+        <shutdown module="sta"/>
+    </at>
+    <at t="2us">
+        <startup module="sta"/>
+    </at>
+    <at t="3us">
+        <crash module="sta"/>
+    </at>
+    <at t="4us">
+        <startup module="sta"/>
+    </at>
+    <at t="6us">
+        <crash module="sta"/>
+    </at>
+</scenario>
+
+%contains: stdout
+Simplified STA wireless identity available during network configuration.
+
+%contains: stdout
+Simplified STA HT peer state installed at last initialization stage.
+
+%contains: stdout
+Simplified STA AP-side association and HT peer state removed after shutdown.
+
+%contains: stdout
+Simplified STA association and HT peer state restored after shutdown restart.
+
+%contains: stdout
+Simplified STA AP-side association and HT peer state removed after resolvable crash.
+
+%contains: stdout
+Simplified STA association and HT peer state restored after crash restart.
+
+%contains: stdout
+Simplified STA recorded BSSID made unresolvable before crash.
+
+%contains: stdout
+Simplified STA crash tolerated missing AP lookup and cleared local HT peer state.

--- a/tests/module/Ieee80211PacketDomainTagBoundary_1.test
+++ b/tests/module/Ieee80211PacketDomainTagBoundary_1.test
@@ -1,0 +1,196 @@
+%description:
+Verify that a packet-domain IEEE 802.11 OFDM receiver removes sender-local
+packet tags while retaining the protocol and receiver indication tags required
+by the upper layers.
+
+%file: TestIeee80211PacketDomainTagBoundary.cc
+
+#include "inet/applications/base/ApplicationPacket_m.h"
+#include "inet/applications/udpapp/UdpBasicApp.h"
+#include "inet/applications/udpapp/UdpSink.h"
+#include "inet/common/ProtocolTag_m.h"
+#include "inet/common/Simsignals.h"
+#include "inet/common/TimeTag_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+class TaggedUdpBasicApp : public UdpBasicApp
+{
+  protected:
+    virtual void sendPacket() override
+    {
+        std::ostringstream str;
+        str << packetName << "-" << numSent;
+        auto packet = new Packet(str.str().c_str());
+        const auto& payload = makeShared<ApplicationPacket>();
+        payload->setChunkLength(B(par("messageLength")));
+        payload->setSequenceNumber(numSent);
+        payload->addTag<CreationTimeTag>()->setCreationTime(simTime());
+        packet->insertAtBack(payload);
+        packet->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(0x1234);
+        L3Address destAddr = chooseDestAddr();
+        emit(packetSentSignal, packet);
+        socket.sendTo(packet, destAddr, destPort);
+        numSent++;
+    }
+};
+
+Define_Module(TaggedUdpBasicApp);
+
+class CheckingUdpSink : public UdpSink
+{
+  protected:
+    virtual void processPacket(Packet *packet) override
+    {
+        ASSERT(packet->findTag<Ieee80211MgmtTransactionTag>() == nullptr);
+        UdpSink::processPacket(packet);
+    }
+};
+
+Define_Module(CheckingUdpSink);
+
+class Ieee80211PacketDomainTagBoundaryTest : public cSimpleModule, public cListener
+{
+  public:
+    Ieee80211PacketDomainTagBoundaryTest() : cSimpleModule(65536) {}
+
+  protected:
+    cModule *sourceRadio = nullptr;
+    cModule *destinationRadio = nullptr;
+    int sourcePacketsWithTransactionTag = 0;
+    int destinationPackets = 0;
+
+    virtual void initialize() override
+    {
+        sourceRadio = getModuleByPath("^.sourceHost.wlan[0].radio");
+        destinationRadio = getModuleByPath("^.destinationHost.wlan[0].radio");
+        sourceRadio->subscribe(packetReceivedFromUpperSignal, this);
+        destinationRadio->subscribe(packetSentToUpperSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        auto packet = check_and_cast<Packet *>(value);
+        if (source == sourceRadio && signalID == packetReceivedFromUpperSignal) {
+            if (packet->findTag<Ieee80211MgmtTransactionTag>() != nullptr)
+                sourcePacketsWithTransactionTag++;
+        }
+        else if (source == destinationRadio && signalID == packetSentToUpperSignal) {
+            ASSERT(packet->findTag<Ieee80211MgmtTransactionTag>() == nullptr);
+            ASSERT(packet->findTag<PacketProtocolTag>() != nullptr);
+            ASSERT(packet->findTag<SnirInd>() != nullptr);
+            ASSERT(packet->findTag<ErrorRateInd>() != nullptr);
+            ASSERT(packet->findTag<physicallayer::Ieee80211ModeInd>() != nullptr);
+            ASSERT(packet->findTag<physicallayer::Ieee80211ChannelInd>() != nullptr);
+            destinationPackets++;
+        }
+    }
+
+    virtual void activity() override
+    {
+        wait(SimTime(100, SIMTIME_MS));
+        ASSERT(sourcePacketsWithTransactionTag > 0);
+        ASSERT(destinationPackets > 0);
+        std::cout << "Packet-domain receiver tag boundary verified.\n";
+    }
+};
+
+Define_Module(Ieee80211PacketDomainTagBoundaryTest);
+
+%file: test.ned
+
+import inet.applications.udpapp.UdpBasicApp;
+import inet.applications.udpapp.UdpSink;
+import inet.common.SimpleModule;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.AdhocHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211DimensionalRadioMedium;
+
+simple TaggedUdpBasicApp extends UdpBasicApp
+{
+    parameters:
+        @class(::TaggedUdpBasicApp);
+}
+
+simple CheckingUdpSink extends UdpSink
+{
+    parameters:
+        @class(::CheckingUdpSink);
+}
+
+simple Ieee80211PacketDomainTagBoundaryTest extends SimpleModule
+{
+    parameters:
+        @class(::Ieee80211PacketDomainTagBoundaryTest);
+}
+
+network Ieee80211PacketDomainTagBoundaryTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211DimensionalRadioMedium;
+        configurator: Ipv4NetworkConfigurator;
+        sourceHost: AdhocHost;
+        destinationHost: AdhocHost;
+        test: Ieee80211PacketDomainTagBoundaryTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211PacketDomainTagBoundaryTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 200ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+**.arp.typename = "GlobalArp"
+**.checksumMode = "computed"
+**.fcsMode = "computed"
+**.mobility.initFromDisplayString = false
+**.mobility.typename = "StationaryMobility"
+*.sourceHost.mobility.initialX = 0m
+*.sourceHost.mobility.initialY = 0m
+*.destinationHost.mobility.initialX = 100m
+*.destinationHost.mobility.initialY = 0m
+**.constraintAreaMinX = 0m
+**.constraintAreaMinY = 0m
+**.constraintAreaMinZ = 0m
+**.constraintAreaMaxX = 200m
+**.constraintAreaMaxY = 100m
+**.constraintAreaMaxZ = 0m
+
+*.sourceHost.numApps = 1
+*.sourceHost.app[0].typename = "TaggedUdpBasicApp"
+*.sourceHost.app[0].destAddresses = "destinationHost"
+*.sourceHost.app[0].destPort = 5000
+*.sourceHost.app[0].messageLength = 100B
+*.sourceHost.app[0].sendInterval = 1s
+*.sourceHost.app[0].startTime = 10ms
+
+*.destinationHost.numApps = 1
+*.destinationHost.app[0].typename = "CheckingUdpSink"
+*.destinationHost.app[0].localPort = 5000
+
+*.sourceHost.wlan[*].typename = "Ieee80211Interface"
+*.destinationHost.wlan[*].typename = "Ieee80211Interface"
+**.wlan[*].radio.typename = "Ieee80211OfdmRadio"
+**.wlan[*].radio.transmitter.power = 0.1mW
+**.wlan[*].radio.receiver.sensitivity = -109dBm
+**.wlan[*].radio.receiver.snirThreshold = 0.1dB
+**.wlan[*].radio.receiver.energyDetection = -90dBm
+**.wlan[*].radio.bandwidth = 20MHz
+**.wlan[*].radio.centerFrequency = 2.412GHz
+**.wlan[*].radio.receiver.channelSpacing = 5MHz
+**.wlan[*].radio.receiver.levelOfDetail = "packet"
+**.wlan[*].radio.receiver.errorModel.snirOffset = -2dB
+**.wlan[*].bitrate = 6Mbps
+**.wlan[*].mac.**.responseAckFrameBitrate = 6Mbps
+**.wlan[*].mac.**.*Retry* = 0
+
+%contains: stdout
+Packet-domain receiver tag boundary verified.

--- a/tests/unit/Ieee80211HtModeSet_1.test
+++ b/tests/unit/Ieee80211HtModeSet_1.test
@@ -84,6 +84,23 @@ sparseEntries.push_back({true, htModeSet->getMode(Mbps(1)), true});
 SparseModeSet sparse(sparseEntries, sparseEntries[0].mode);
 ASSERT(sparse.isHtOperationSupported());
 ASSERT(sparse.getLegacyOperationalModes().size() == 1);
+ASSERT(sparse.getFastestLegacyOperationalMode() == sparse.getLegacyOperationalModes().front());
+
+// The peer-HT fallback is the fastest mandatory legacy operational mode, not
+// merely the last rate in the complete (mandatory plus optional) list.
+SparseModeSet legacyFallback({
+        { true, findHtMode(htModeSet, 0, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
+        { true, htModeSet->getMode(Mbps(1)), true },
+        { true, htModeSet->getMode(Mbps(2)), true },
+        { false, htModeSet->getMode(Mbps(5.5)), true },
+    }, findHtMode(htModeSet, 0, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG), false);
+ASSERT(legacyFallback.getFastestLegacyOperationalMode() == htModeSet->getMode(Mbps(2)));
+
+SparseModeSet optionalOnlyFallback({
+        { true, findHtMode(htModeSet, 0, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG) },
+        { false, htModeSet->getMode(Mbps(1)), true },
+    }, findHtMode(htModeSet, 0, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG), false);
+ASSERT(optionalOnlyFallback.getFastestLegacyOperationalMode() == htModeSet->getMode(Mbps(1)));
 for (int mcsIndex = 0; mcsIndex < 77; mcsIndex++) {
     bool expected = mcsIndex < 8 || mcsIndex == 8 || mcsIndex == 10;
     ASSERT(sparse.getHtMcsSupported()[mcsIndex] == expected);

--- a/tests/unit/Ieee80211MgmtFrameSerializer_1.test
+++ b/tests/unit/Ieee80211MgmtFrameSerializer_1.test
@@ -2,7 +2,8 @@
 Test that raw IEEE 802.11 management frame bodies deserialize as the exact requested registered
 subtype, consume and preserve trailing information elements, safely reject malformed SSID and
 supported-rate elements, use little-endian numeric fields, serialize Timestamp fields in
-microseconds independently of the simulation-time resolution, and round-trip through serialization.
+microseconds independently of the simulation-time resolution, validate Association-ID wire
+markers, and round-trip through serialization.
 
 %inifile: omnetpp.ini
 [General]
@@ -230,16 +231,16 @@ static void checkMalformedSupportedRates(const std::vector<uint8_t>& prefix)
 
 {
     const std::vector<uint8_t> body = {
-        0x00, 0x00, 0x00, 0x00, 0x34, 0x12,
+        0x00, 0x00, 0x00, 0x00, 0x23, 0xC1,
         0x01, 0x01, 0x0C
     };
     auto frame = deserializeBody<Ieee80211AssociationResponseFrame>(appendTrailingInformationElement(body));
     ASSERT(frame->getStatusCode() == SC_SUCCESSFUL);
-    ASSERT(frame->getAid() == 0x1234);
+    ASSERT(frame->getAid() == 0x0123);
 
     auto serializedFrame = makeShared<Ieee80211AssociationResponseFrame>();
     serializedFrame->setStatusCode(SC_SUCCESSFUL);
-    serializedFrame->setAid(0x1234);
+    serializedFrame->setAid(0x0123);
     Ieee80211SupportedRatesElement supportedRates;
     supportedRates.numRates = 1;
     supportedRates.rate[0] = 6;
@@ -248,13 +249,67 @@ static void checkMalformedSupportedRates(const std::vector<uint8_t>& prefix)
 }
 
 {
+    const std::vector<uint8_t> body = {
+        0x00, 0x00, 0x34, 0x12, 0x00, 0x00,
+        0x01, 0x01, 0x0C
+    };
+    auto frame = deserializeBody<Ieee80211AssociationResponseFrame>(body);
+    ASSERT(frame->getStatusCode() == static_cast<Ieee80211StatusCode>(0x1234));
+    ASSERT(frame->getAid() == 0);
+}
+
+{
     auto frame = deserializeBody<Ieee80211ReassociationResponseFrame>(appendTrailingInformationElement({
-        0x00, 0x00, 0x00, 0x00, 0x45, 0x23,
+        0x00, 0x00, 0x00, 0x00, 0x45, 0xC2,
         0x01, 0x01, 0x0C
     }));
     ASSERT(frame->getStatusCode() == SC_SUCCESSFUL);
-    ASSERT(frame->getAid() == 0x2345);
+    ASSERT(frame->getAid() == 0x0245);
 }
+
+bool missingAssociationIdMarkerRejected = false;
+try {
+    deserializeBody<Ieee80211AssociationResponseFrame>({
+        0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+        0x01, 0x01, 0x0C
+    });
+}
+catch (const cRuntimeError&) {
+    missingAssociationIdMarkerRejected = true;
+}
+ASSERT(missingAssociationIdMarkerRejected);
+
+bool successfulZeroAssociationIdRejected = false;
+try {
+    auto frame = makeShared<Ieee80211AssociationResponseFrame>();
+    frame->setStatusCode(SC_SUCCESSFUL);
+    frame->setAid(0);
+    Ieee80211SupportedRatesElement supportedRates;
+    supportedRates.numRates = 1;
+    supportedRates.rate[0] = 6;
+    frame->setSupportedRates(supportedRates);
+    assertSerializedBody(frame, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x0C});
+}
+catch (const cRuntimeError&) {
+    successfulZeroAssociationIdRejected = true;
+}
+ASSERT(successfulZeroAssociationIdRejected);
+
+bool unsuccessfulNonzeroAssociationIdRejected = false;
+try {
+    auto frame = makeShared<Ieee80211AssociationResponseFrame>();
+    frame->setStatusCode(static_cast<Ieee80211StatusCode>(0x1234));
+    frame->setAid(1);
+    Ieee80211SupportedRatesElement supportedRates;
+    supportedRates.numRates = 1;
+    supportedRates.rate[0] = 6;
+    frame->setSupportedRates(supportedRates);
+    assertSerializedBody(frame, {0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x01, 0x01, 0x0C});
+}
+catch (const cRuntimeError&) {
+    unsuccessfulNonzeroAssociationIdRejected = true;
+}
+ASSERT(unsuccessfulNonzeroAssociationIdRejected);
 
 {
     auto frame = deserializeBody<Ieee80211BeaconFrame>(appendTrailingInformationElement({
@@ -337,8 +392,8 @@ checkMalformedSupportedRates<Ieee80211ReassociationRequestFrame>({
     0x02, 0x00, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x01, 'R'
 });
-checkMalformedSupportedRates<Ieee80211AssociationResponseFrame>({0x00, 0x00, 0x00, 0x00, 0x34, 0x12});
-checkMalformedSupportedRates<Ieee80211ReassociationResponseFrame>({0x00, 0x00, 0x00, 0x00, 0x45, 0x23});
+checkMalformedSupportedRates<Ieee80211AssociationResponseFrame>({0x00, 0x00, 0x00, 0x00, 0x23, 0xC1});
+checkMalformedSupportedRates<Ieee80211ReassociationResponseFrame>({0x00, 0x00, 0x00, 0x00, 0x45, 0xC2});
 checkMalformedSupportedRates<Ieee80211BeaconFrame>({
     0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x64, 0x00, 0x00, 0x00,

--- a/tests/unit/Ieee80211MgmtStaDiscovery_1.test
+++ b/tests/unit/Ieee80211MgmtStaDiscovery_1.test
@@ -1,0 +1,276 @@
+%description:
+Verify that serialized Beacon and Probe Response discovery preserves the HT
+Operation primary channel as the cached AP channel, while legacy discovery
+continues to use channelNumber (including channel 0).
+
+%includes:
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Channel.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+using namespace inet::units::values;
+
+%global:
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  public:
+    using Ieee80211MgmtSta::lookupAP;
+    using Ieee80211MgmtSta::storeAPInfo;
+
+    int changedChannel = -1;
+
+    virtual void changeChannel(int channel) override { changedChannel = channel; }
+};
+
+static Ptr<Ieee80211BeaconFrame> makeDiscovery(bool probeResponse, int channelNumber, int primaryChannel, bool withHt)
+{
+    Ptr<Ieee80211BeaconFrame> body = probeResponse ? staticPtrCast<Ieee80211BeaconFrame>(makeShared<Ieee80211ProbeResponseFrame>()) : makeShared<Ieee80211BeaconFrame>();
+    body->setSSID("serialized");
+    Ieee80211SupportedRatesElement rates;
+    rates.numRates = 1;
+    rates.rate[0] = 6;
+    body->setSupportedRates(rates);
+    body->setBeaconInterval(SimTime(100, SIMTIME_MS));
+    body->setChannelNumber(channelNumber);
+    if (withHt) {
+        Ieee80211HtCapabilities capabilities;
+        capabilities.supportedChannelWidths.insert(MHz(20));
+        capabilities.rxMcsSupported[0] = true;
+        capabilities.txMcsNss.maxMcsPerNss[0] = 0;
+        setHtCapabilities(body, capabilities);
+        Ieee80211HtOperation operation;
+        operation.primaryChannel = primaryChannel;
+        operation.basicMcsSupported[0] = true;
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        setHtOperation(body, band, operation);
+    }
+    body->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(body));
+    return body;
+}
+
+static void storeSerializedDiscovery(TestIeee80211MgmtSta& sta, const Ptr<Ieee80211BeaconFrame>& original,
+        const MacAddress& address)
+{
+    Packet packet("discovery", original);
+    auto bytes = packet.peekAllAsBytes()->getBytes();
+    Packet encoded("encoded", makeShared<BytesChunk>(bytes));
+    encoded.addTag<SignalPowerInd>()->setPower(mW(1));
+    Ptr<const Ieee80211BeaconFrame> decoded;
+    if (dynamicPtrCast<const Ieee80211ProbeResponseFrame>(original) != nullptr)
+        decoded = encoded.popAtFront<Ieee80211ProbeResponseFrame>(B(bytes.size()));
+    else
+        decoded = encoded.popAtFront<Ieee80211BeaconFrame>(B(bytes.size()));
+    if (original->getHtOperationPresent()) {
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        physicallayer::Ieee80211Channel channel(band, band->getChannelIndex(original->getHtOperation().primaryChannel));
+        encoded.addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        sta.storeAPInfo(&encoded, header, decoded);
+    }
+    else {
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        sta.storeAPInfo(&encoded, header, decoded);
+    }
+}
+
+static bool storePacketDomainDiscovery(TestIeee80211MgmtSta& sta, const Ptr<Ieee80211BeaconFrame>& body,
+        const MacAddress& address, int receivedChannelIndex = -1, bool addChannelInd = true,
+        int signalPowerMilliwatts = 1)
+{
+    Packet packet("packet-domain-discovery", body);
+    packet.addTag<SignalPowerInd>()->setPower(mW(signalPowerMilliwatts));
+    const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+    int channelIndex = body->getHtOperationPresent() ?
+            (receivedChannelIndex >= 0 ? receivedChannelIndex : band->getChannelIndex(body->getHtOperation().primaryChannel)) : 0;
+    physicallayer::Ieee80211Channel channel(band, channelIndex);
+    if (body->getHtOperationPresent() && addChannelInd)
+        packet.addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+    auto header = makeShared<Ieee80211MgmtHeader>();
+    header->setTransmitterAddress(address);
+    return sta.storeAPInfo(&packet, header, body);
+}
+
+%activity:
+
+TestIeee80211MgmtSta sta;
+const MacAddress beaconAddress("02:00:00:00:00:01");
+const MacAddress probeAddress("02:00:00:00:00:02");
+const MacAddress legacyAddress("02:00:00:00:00:03");
+
+// The serialized body has the fixed channelNumber at its default value, but
+// HT Operation carries the standards-facing primary channel (Table 9-230/11.14),
+// which is converted to the internal received channel index.
+storeSerializedDiscovery(sta, makeDiscovery(false, 0, 6, true), beaconAddress);
+ASSERT(sta.lookupAP(beaconAddress)->channel == 6);
+sta.changeChannel(sta.lookupAP(beaconAddress)->channel);
+ASSERT(sta.changedChannel == 6);
+
+// Probe Response follows the same discovery rule. Its concrete subtype is
+// decoded above, and the serialized fixed channel field is ignored in favor
+// of HT Operation.
+storeSerializedDiscovery(sta, makeDiscovery(true, 3, 13, true), probeAddress);
+ASSERT(sta.lookupAP(probeAddress)->channel == 13);
+sta.changeChannel(sta.lookupAP(probeAddress)->channel);
+ASSERT(sta.changedChannel == 13);
+
+// When both packet-domain fields are available, the HT primary remains the
+// deterministic authority even if the legacy field disagrees.
+storePacketDomainDiscovery(sta, makeDiscovery(true, 3, 13, true), probeAddress);
+ASSERT(sta.lookupAP(probeAddress)->channel == 13);
+
+// Invalid refreshes are rejected without changing the existing cached AP or
+// raising a runtime error at the peer-input boundary.
+auto cachedProbe = sta.lookupAP(probeAddress);
+cachedProbe->isAuthenticated = true;
+cachedProbe->authSeqExpected = 3;
+cachedProbe->authTimeoutMsg = new cMessage("authentication-timeout");
+int cachedChannel = cachedProbe->channel;
+auto cachedSsid = cachedProbe->ssid;
+auto cachedSupportedRates = cachedProbe->supportedRates;
+bool cachedExtendedSupportedRatesPresent = cachedProbe->extendedSupportedRatesPresent;
+bool cachedHtCapabilitiesPresent = cachedProbe->htCapabilitiesPresent;
+auto cachedHtCapabilities = cachedProbe->htCapabilities;
+bool cachedHtOperationPresent = cachedProbe->htOperationPresent;
+auto cachedHtOperation = cachedProbe->htOperation;
+auto cachedBeaconInterval = cachedProbe->beaconInterval;
+double cachedRxPower = cachedProbe->rxPower;
+bool cachedIsAuthenticated = cachedProbe->isAuthenticated;
+int cachedAuthSeqExpected = cachedProbe->authSeqExpected;
+auto cachedAuthTimeout = cachedProbe->authTimeoutMsg;
+ASSERT(cachedSsid == "serialized");
+ASSERT(cachedBeaconInterval == SimTime(100, SIMTIME_MS));
+ASSERT(cachedRxPower == mW(1).get<W>());
+auto invalidRefresh = makeDiscovery(true, 3, 6, true);
+invalidRefresh->setSSID("changed");
+Ieee80211SupportedRatesElement changedRates;
+changedRates.numRates = 1;
+changedRates.rate[0] = 12;
+invalidRefresh->setSupportedRates(changedRates);
+invalidRefresh->setBeaconInterval(SimTime(200, SIMTIME_MS));
+invalidRefresh->setChannelNumber(11);
+ASSERT(!storePacketDomainDiscovery(sta, invalidRefresh, probeAddress, 13, true, 7));
+auto unchangedProbe = sta.lookupAP(probeAddress);
+ASSERT(unchangedProbe->channel == cachedChannel);
+ASSERT(unchangedProbe->ssid == cachedSsid);
+ASSERT(unchangedProbe->supportedRates.numRates == cachedSupportedRates.numRates);
+ASSERT(unchangedProbe->supportedRates.rate[0] == cachedSupportedRates.rate[0]);
+ASSERT(unchangedProbe->extendedSupportedRatesPresent == cachedExtendedSupportedRatesPresent);
+ASSERT(unchangedProbe->htCapabilitiesPresent == cachedHtCapabilitiesPresent);
+ASSERT(unchangedProbe->htCapabilities.supportedChannelWidths == cachedHtCapabilities.supportedChannelWidths);
+ASSERT(unchangedProbe->htCapabilities.rxMcsSupported == cachedHtCapabilities.rxMcsSupported);
+ASSERT(unchangedProbe->htCapabilities.maxAmpduLengthExponent == cachedHtCapabilities.maxAmpduLengthExponent);
+ASSERT(unchangedProbe->htOperationPresent == cachedHtOperationPresent);
+ASSERT(unchangedProbe->htOperation.primaryChannel == cachedHtOperation.primaryChannel);
+ASSERT(unchangedProbe->htOperation.secondaryChannelOffset == cachedHtOperation.secondaryChannelOffset);
+ASSERT(unchangedProbe->htOperation.operatingChannelWidth == cachedHtOperation.operatingChannelWidth);
+ASSERT(unchangedProbe->beaconInterval == cachedBeaconInterval);
+ASSERT(unchangedProbe->rxPower == cachedRxPower);
+ASSERT(unchangedProbe->isAuthenticated == cachedIsAuthenticated);
+ASSERT(unchangedProbe->authSeqExpected == cachedAuthSeqExpected);
+ASSERT(sta.lookupAP(probeAddress)->authTimeoutMsg == cachedAuthTimeout);
+ASSERT(!storePacketDomainDiscovery(sta, makeDiscovery(true, 3, 6, true), probeAddress, -1, false));
+ASSERT(sta.lookupAP(probeAddress)->channel == 13);
+
+// A malformed typed capability is also rejected atomically. The new AP must
+// not be inserted before the conversion has succeeded.
+auto malformedCapabilities = makeDiscovery(true, 3, 13, true);
+auto capabilitiesElement = malformedCapabilities->getHtCapabilities();
+capabilitiesElement.maxAmpduLengthExponent = 4;
+malformedCapabilities->setHtCapabilities(capabilitiesElement);
+const MacAddress malformedCapabilitiesAddress("02:00:00:00:00:04");
+ASSERT(!storePacketDomainDiscovery(sta, malformedCapabilities, malformedCapabilitiesAddress));
+ASSERT(sta.lookupAP(malformedCapabilitiesAddress) == nullptr);
+
+auto malformedOperation = makeDiscovery(true, 3, 13, true);
+auto malformedOperationElement = malformedOperation->getHtOperation();
+malformedOperationElement.secondaryChannelOffset = 2;
+malformedOperation->setHtOperation(malformedOperationElement);
+const MacAddress malformedOperationAddress("02:00:00:00:00:05");
+ASSERT(!storePacketDomainDiscovery(sta, malformedOperation, malformedOperationAddress));
+ASSERT(sta.lookupAP(malformedOperationAddress) == nullptr);
+
+auto unmappablePrimary = makeDiscovery(true, 3, 6, true);
+auto unmappablePrimaryElement = unmappablePrimary->getHtOperation();
+unmappablePrimaryElement.primaryChannel = 99;
+unmappablePrimary->setHtOperation(unmappablePrimaryElement);
+const MacAddress unmappablePrimaryAddress("02:00:00:00:00:06");
+// Supply a valid received channel explicitly so the fixture does not try to
+// convert the deliberately unmappable standards-facing primary itself.
+ASSERT(!storePacketDomainDiscovery(sta, unmappablePrimary, unmappablePrimaryAddress, 6));
+ASSERT(sta.lookupAP(unmappablePrimaryAddress) == nullptr);
+
+// A 20 MHz advertisement cannot carry a secondary offset. The same complete
+// tuple validation is applied to 40 MHz operation, including the band edges.
+auto inconsistent20 = makeDiscovery(true, 3, 13, true);
+auto inconsistent20Element = inconsistent20->getHtOperation();
+inconsistent20Element.secondaryChannelOffset = 1;
+inconsistent20->setHtOperation(inconsistent20Element);
+ASSERT(!storePacketDomainDiscovery(sta, inconsistent20, probeAddress));
+ASSERT(sta.lookupAP(probeAddress)->channel == 13);
+
+auto validHt40Above = makeDiscovery(true, 3, 0, true);
+auto validHt40AboveCapabilities = validHt40Above->getHtCapabilities();
+validHt40AboveCapabilities.supportedChannelWidth40Mhz = true;
+validHt40Above->setHtCapabilities(validHt40AboveCapabilities);
+auto validHt40AboveOperation = validHt40Above->getHtOperation();
+validHt40AboveOperation.staChannelWidth40Mhz = true;
+validHt40AboveOperation.secondaryChannelOffset = 1;
+validHt40Above->setHtOperation(validHt40AboveOperation);
+ASSERT(storePacketDomainDiscovery(sta, validHt40Above, probeAddress, 0));
+ASSERT(sta.lookupAP(probeAddress)->channel == 0);
+
+auto validHt40Below = makeDiscovery(true, 3, 12, true);
+auto validHt40BelowCapabilities = validHt40Below->getHtCapabilities();
+validHt40BelowCapabilities.supportedChannelWidth40Mhz = true;
+validHt40Below->setHtCapabilities(validHt40BelowCapabilities);
+auto validHt40BelowOperation = validHt40Below->getHtOperation();
+validHt40BelowOperation.staChannelWidth40Mhz = true;
+validHt40BelowOperation.secondaryChannelOffset = 3;
+validHt40Below->setHtOperation(validHt40BelowOperation);
+ASSERT(storePacketDomainDiscovery(sta, validHt40Below, probeAddress, 12));
+ASSERT(sta.lookupAP(probeAddress)->channel == 12);
+
+auto inconsistent40 = makeDiscovery(true, 3, 12, true);
+auto inconsistent40Capabilities = inconsistent40->getHtCapabilities();
+inconsistent40Capabilities.supportedChannelWidth40Mhz = true;
+inconsistent40->setHtCapabilities(inconsistent40Capabilities);
+auto inconsistent40Operation = inconsistent40->getHtOperation();
+inconsistent40Operation.staChannelWidth40Mhz = true;
+inconsistent40Operation.secondaryChannelOffset = 0;
+inconsistent40->setHtOperation(inconsistent40Operation);
+ASSERT(!storePacketDomainDiscovery(sta, inconsistent40, probeAddress, 12));
+ASSERT(sta.lookupAP(probeAddress)->channel == 12);
+
+auto invalidHt40Edge = makeDiscovery(true, 3, 13, true);
+auto invalidHt40EdgeCapabilities = invalidHt40Edge->getHtCapabilities();
+invalidHt40EdgeCapabilities.supportedChannelWidth40Mhz = true;
+invalidHt40Edge->setHtCapabilities(invalidHt40EdgeCapabilities);
+auto invalidHt40EdgeOperation = invalidHt40Edge->getHtOperation();
+invalidHt40EdgeOperation.staChannelWidth40Mhz = true;
+invalidHt40EdgeOperation.secondaryChannelOffset = 1;
+invalidHt40Edge->setHtOperation(invalidHt40EdgeOperation);
+ASSERT(!storePacketDomainDiscovery(sta, invalidHt40Edge, probeAddress, 13));
+ASSERT(sta.lookupAP(probeAddress)->channel == 12);
+
+// Without HT Operation, preserve the packet-domain channelNumber exactly,
+// including its legal/default value of zero. The management-body serializer
+// does not encode the legacy field, so these assertions intentionally use the
+// original packet-domain body.
+storePacketDomainDiscovery(sta, makeDiscovery(false, 7, 0, false), legacyAddress);
+ASSERT(sta.lookupAP(legacyAddress)->channel == 7);
+storePacketDomainDiscovery(sta, makeDiscovery(false, 0, 0, false), legacyAddress);
+ASSERT(sta.lookupAP(legacyAddress)->channel == 0);
+
+EV << "Serialized HT discovery channel and legacy fallback checks passed.\n";
+
+%contains: stdout
+Serialized HT discovery channel and legacy fallback checks passed.

--- a/tests/unit/Ieee80211MgmtStaPrimitiveDispatch_1.test
+++ b/tests/unit/Ieee80211MgmtStaPrimitiveDispatch_1.test
@@ -1,0 +1,250 @@
+%description:
+Verify that association and reassociation management primitives are dispatched
+to their most-derived handlers, including the distinct reassociation confirm
+primitive emitted by the station agent. Verify association timeout ownership,
+confirm typing, AP-list cleanup, restart eligibility, and late-response rejection.
+
+%includes:
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211AgentSta.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+class TestIeee80211AgentSta : public Ieee80211AgentSta
+{
+  public:
+    using Ieee80211AgentSta::handleResponse;
+
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+    int scanRequests = 0;
+    Ieee80211PrimResultCode lastReassociateResult = PRC_SUCCESS;
+
+  protected:
+    virtual void processAssociateConfirm(Ieee80211Prim_AssociateConfirm *resp) override
+    {
+        associateConfirms++;
+    }
+
+    virtual void processReassociateConfirm(Ieee80211Prim_ReassociateConfirm *resp) override
+    {
+        reassociateConfirms++;
+        lastReassociateResult = resp->getResultCode();
+    }
+
+    virtual void sendScanRequest() override
+    {
+        scanRequests++;
+    }
+};
+
+class TestIeee80211MgmtSta : public Ieee80211MgmtSta
+{
+  public:
+    using Ieee80211MgmtSta::handleCommand;
+    using Ieee80211MgmtSta::shouldDisassociateOnReassociationFailure;
+
+    int associateRequests = 0;
+    int reassociateRequests = 0;
+    int associateConfirms = 0;
+    int reassociateConfirms = 0;
+    int reassociationFailures = 0;
+    Ieee80211PrimResultCode lastAssociationResult = PRC_SUCCESS;
+    Ieee80211PrimResultCode lastReassociationResult = PRC_SUCCESS;
+
+    void prepareAssociationTimeout(ApInfo *ap, bool reassociation)
+    {
+        ASSERT(assocTimeoutMsg == nullptr);
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+    }
+
+    void prepareAssociationTimeoutInApList(const MacAddress& address, bool reassociation)
+    {
+        apList.push_back(ApInfo());
+        apList.back().address = address;
+        prepareAssociationTimeout(&apList.back(), reassociation);
+    }
+
+    void clearKnownAccessPoints() { clearAPList(); }
+    void abandonPendingAssociation() { cancelPendingAssociation(); }
+    size_t getKnownAccessPointCount() const { return apList.size(); }
+
+    void deliverAssociationTimeout()
+    {
+        ASSERT(assocTimeoutMsg != nullptr);
+        handleTimer(assocTimeoutMsg);
+    }
+
+    bool canStartAnotherAssociation() const { return assocTimeoutMsg == nullptr; }
+    bool isReassociationInProgress() const { return reassociationInProgress; }
+
+    void deliverLateAssociationResponse(bool reassociation)
+    {
+        auto packet = new Packet("LateAssocResp");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    void deliverMismatchedAssociationResponse(const MacAddress& address, bool reassociation)
+    {
+        auto packet = new Packet("MismatchedAssocResp");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    void deliverPendingAssociationResponse(bool reassociation)
+    {
+        auto packet = new Packet("PendingAssocResp");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        auto ap = static_cast<ApInfo *>(assocTimeoutMsg->getContextPointer());
+        header->setTransmitterAddress(ap->address);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+  protected:
+    virtual void processAssociateCommand(Ieee80211Prim_AssociateRequest *ctrl) override
+    {
+        associateRequests++;
+    }
+
+    virtual void processReassociateCommand(Ieee80211Prim_ReassociateRequest *ctrl) override
+    {
+        reassociateRequests++;
+    }
+
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associateConfirms++;
+        lastAssociationResult = resultCode;
+    }
+
+    virtual void sendReassociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        reassociateConfirms++;
+        lastReassociationResult = resultCode;
+    }
+
+    virtual void handleReassociationFailure(ApInfo *ap) override
+    {
+        reassociationFailures++;
+    }
+};
+
+static void deliverConfirm(TestIeee80211AgentSta& agent, Ieee80211PrimConfirm *confirm)
+{
+    auto message = new cMessage("confirm");
+    message->setControlInfo(confirm);
+    agent.handleResponse(message);
+}
+
+%activity:
+
+TestIeee80211AgentSta agent;
+deliverConfirm(agent, new Ieee80211Prim_AssociateConfirm());
+ASSERT(agent.associateConfirms == 1);
+ASSERT(agent.reassociateConfirms == 0);
+
+auto reassociateConfirm = new Ieee80211Prim_ReassociateConfirm();
+reassociateConfirm->setResultCode(PRC_SUCCESS);
+deliverConfirm(agent, reassociateConfirm);
+ASSERT(agent.associateConfirms == 1);
+ASSERT(agent.reassociateConfirms == 1);
+ASSERT(agent.lastReassociateResult == PRC_SUCCESS);
+
+auto refusedReassociateConfirm = new Ieee80211Prim_ReassociateConfirm();
+refusedReassociateConfirm->setResultCode(PRC_REFUSED);
+deliverConfirm(agent, refusedReassociateConfirm);
+ASSERT(agent.associateConfirms == 1);
+ASSERT(agent.reassociateConfirms == 2);
+ASSERT(agent.lastReassociateResult == PRC_REFUSED);
+ASSERT(agent.scanRequests == 0);
+
+TestIeee80211MgmtSta mgmt;
+mgmt.handleCommand(PR_ASSOCIATE_REQUEST, new Ieee80211Prim_AssociateRequest());
+ASSERT(mgmt.associateRequests == 1);
+ASSERT(mgmt.reassociateRequests == 0);
+
+mgmt.handleCommand(PR_REASSOCIATE_REQUEST, new Ieee80211Prim_ReassociateRequest());
+ASSERT(mgmt.associateRequests == 1);
+ASSERT(mgmt.reassociateRequests == 1);
+
+Ieee80211MgmtSta::ApInfo timeoutAp;
+timeoutAp.address = MacAddress("02:00:00:00:00:01");
+MacAddress otherApAddress("02:00:00:00:00:02");
+ASSERT(TestIeee80211MgmtSta::shouldDisassociateOnReassociationFailure(true, timeoutAp.address, timeoutAp.address));
+ASSERT(!TestIeee80211MgmtSta::shouldDisassociateOnReassociationFailure(true, timeoutAp.address, otherApAddress));
+ASSERT(!TestIeee80211MgmtSta::shouldDisassociateOnReassociationFailure(false, timeoutAp.address, timeoutAp.address));
+mgmt.prepareAssociationTimeout(&timeoutAp, false);
+mgmt.deliverMismatchedAssociationResponse(otherApAddress, false);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.associateConfirms == 0);
+mgmt.deliverAssociationTimeout();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 1);
+ASSERT(mgmt.reassociateConfirms == 0);
+ASSERT(mgmt.lastAssociationResult == PRC_TIMEOUT);
+ASSERT(mgmt.reassociationFailures == 0);
+
+mgmt.deliverLateAssociationResponse(false);
+ASSERT(mgmt.associateConfirms == 1);
+ASSERT(mgmt.reassociateConfirms == 0);
+
+// IEEE Std 802.11-2024, 11.3.5.2 and 11.3.5.4 correlate the response
+// procedure with the corresponding association or reassociation request.
+mgmt.prepareAssociationTimeout(&timeoutAp, false);
+mgmt.deliverPendingAssociationResponse(true);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 1);
+ASSERT(mgmt.reassociateConfirms == 0);
+mgmt.deliverAssociationTimeout();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 0);
+ASSERT(mgmt.lastAssociationResult == PRC_TIMEOUT);
+
+mgmt.prepareAssociationTimeout(&timeoutAp, true);
+mgmt.deliverPendingAssociationResponse(false);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 0);
+mgmt.deliverAssociationTimeout();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 1);
+ASSERT(mgmt.lastReassociationResult == PRC_TIMEOUT);
+ASSERT(mgmt.reassociationFailures == 1);
+
+mgmt.deliverLateAssociationResponse(true);
+ASSERT(mgmt.associateConfirms == 2);
+ASSERT(mgmt.reassociateConfirms == 1);
+
+mgmt.prepareAssociationTimeoutInApList(otherApAddress, true);
+ASSERT(mgmt.getKnownAccessPointCount() == 1);
+ASSERT(!mgmt.canStartAnotherAssociation());
+ASSERT(mgmt.isReassociationInProgress());
+mgmt.clearKnownAccessPoints();
+ASSERT(mgmt.getKnownAccessPointCount() == 0);
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+
+mgmt.prepareAssociationTimeoutInApList(otherApAddress, true);
+ASSERT(!mgmt.canStartAnotherAssociation());
+mgmt.abandonPendingAssociation();
+ASSERT(mgmt.canStartAnotherAssociation());
+ASSERT(!mgmt.isReassociationInProgress());
+mgmt.clearKnownAccessPoints();
+
+EV << "Association and reassociation primitive dispatch and timeout ownership verified.\n";
+
+%contains: stdout
+Association and reassociation primitive dispatch and timeout ownership verified.

--- a/tests/unit/Ieee80211MgmtTransactionTag_1.test
+++ b/tests/unit/Ieee80211MgmtTransactionTag_1.test
@@ -1,0 +1,59 @@
+%description:
+Verify that the local IEEE 802.11 management transaction identity is retained
+when a management frame is replaced by fragmentation packets, and that a
+generic body region tag is clipped and rebased for each fragment.
+
+%includes:
+#include <vector>
+
+#include "inet/common/TimeTag_m.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mac/fragmentation/Fragmentation.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%activity:
+
+auto frame = new Packet("AssocResp-OK");
+frame->insertAtBack(makeShared<BytesChunk>(std::vector<uint8_t>(9, 0)));
+frame->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(42);
+frame->addRegionTag<CreationTimeTag>(B(2), B(5));
+
+auto header = makeShared<Ieee80211MgmtHeader>();
+header->setType(ST_ASSOCIATIONRESPONSE);
+header->setReceiverAddress(MacAddress("02:00:00:00:00:01"));
+frame->insertAtFront(header);
+frame->insertAtBack(makeShared<Ieee80211MacTrailer>());
+auto headerLength = header->getChunkLength();
+
+Fragmentation fragmentation;
+auto fragments = fragmentation.fragmentFrame(frame, {4, 5});
+ASSERT(fragments->size() == 2);
+for (auto fragment : *fragments) {
+    auto tag = fragment->findTag<Ieee80211MgmtTransactionTag>();
+    ASSERT(tag != nullptr);
+    ASSERT(tag->getTransactionId() == 42);
+}
+ASSERT(fragments->front()->peekAtFront<Ieee80211MgmtHeader>()->getMoreFragments());
+ASSERT(!fragments->back()->peekAtFront<Ieee80211MgmtHeader>()->getMoreFragments());
+
+auto firstRegionTags = fragments->front()->getAllRegionTags<CreationTimeTag>();
+ASSERT(firstRegionTags.size() == 1);
+ASSERT(firstRegionTags.front().getStartOffset() == headerLength + B(2));
+ASSERT(firstRegionTags.front().getLength() == B(2));
+auto secondRegionTags = fragments->back()->getAllRegionTags<CreationTimeTag>();
+ASSERT(secondRegionTags.size() == 1);
+ASSERT(secondRegionTags.front().getStartOffset() == headerLength);
+ASSERT(secondRegionTags.front().getLength() == B(3));
+
+for (auto fragment : *fragments)
+    delete fragment;
+delete fragments;
+
+EV << "Management transaction packet tag survived frame replacement.\n";
+
+%contains: stdout
+Management transaction packet tag survived frame replacement.

--- a/tests/unit/Ieee80211PeerModeSelection_1.test
+++ b/tests/unit/Ieee80211PeerModeSelection_1.test
@@ -1,0 +1,174 @@
+%description:
+Verify that peer HT mode selection honors negotiated MCS, channel width,
+operation width, and receiver short-guard-interval capabilities.
+
+%includes:
+#include <initializer_list>
+
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+using namespace inet::physicallayer;
+using namespace inet::units::values;
+
+%global:
+
+static const IIeee80211Mode *findHtMode(const Ieee80211ModeSet *modeSet, int mcsIndex, Hz bandwidth,
+        Ieee80211HtModeBase::GuardIntervalType guardIntervalType)
+{
+    for (int i = 0; i < modeSet->getNumModes(); i++) {
+        const auto *mode = modeSet->getMode(i);
+        if (mode->getHtMcsIndex() == mcsIndex && mode->getDataMode()->getBandwidth() == bandwidth &&
+                mode->isHtShortGuardInterval() == (guardIntervalType == Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT))
+            return mode;
+    }
+    return nullptr;
+}
+
+static Ieee80211Mib::PeerHtState makePeerState(std::initializer_list<int> mcsIndexes,
+        std::initializer_list<Hz> bandwidths, Hz operatingChannelWidth, bool shortGi20 = false, bool shortGi40 = false)
+{
+    Ieee80211Mib::PeerHtState state;
+    state.valid = true;
+    auto& receiverCapabilities = state.negotiatedCapabilities.localTxPeerRx;
+    receiverCapabilities.valid = true;
+    for (int mcsIndex : mcsIndexes)
+        receiverCapabilities.supportedMcs[mcsIndex] = true;
+    for (auto bandwidth : bandwidths)
+        receiverCapabilities.supportedChannelWidths.insert(bandwidth);
+    receiverCapabilities.receiverShortGi20 = shortGi20;
+    receiverCapabilities.receiverShortGi40 = shortGi40;
+    state.negotiatedCapabilities.operation.operatingChannelWidth = operatingChannelWidth;
+    return state;
+}
+
+%activity:
+
+const auto *modeSet = Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+const auto *mcs0Long = findHtMode(modeSet, 0, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+const auto *mcs0Short = findHtMode(modeSet, 0, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
+const auto *mcs1Long = findHtMode(modeSet, 1, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+const auto *mcs2Long = findHtMode(modeSet, 2, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+const auto *mcs8Long = findHtMode(modeSet, 8, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+const auto *mcs8Short = findHtMode(modeSet, 8, MHz(20), Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
+const auto *mcs0_40Long = findHtMode(modeSet, 0, MHz(40), Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+const auto *mcs0_40Short = findHtMode(modeSet, 0, MHz(40), Ieee80211HtModeBase::HT_GUARD_INTERVAL_SHORT);
+ASSERT(mcs0Long != nullptr);
+ASSERT(mcs0Short != nullptr);
+ASSERT(mcs1Long != nullptr);
+ASSERT(mcs2Long != nullptr);
+ASSERT(mcs8Long != nullptr);
+ASSERT(mcs8Short != nullptr);
+ASSERT(mcs0_40Long != nullptr);
+ASSERT(mcs0_40Short != nullptr);
+ASSERT(!mcs0Long->isHtShortGuardInterval());
+ASSERT(mcs0Short->isHtShortGuardInterval());
+ASSERT(!mcs8Long->isHtShortGuardInterval());
+ASSERT(mcs8Short->isHtShortGuardInterval());
+ASSERT(!mcs0_40Long->isHtShortGuardInterval());
+ASSERT(mcs0_40Short->isHtShortGuardInterval());
+ASSERT(mcs8Short->getDataMode()->getBandwidth() == MHz(20));
+ASSERT(mcs0_40Short->getDataMode()->getBandwidth() == MHz(40));
+
+const auto *modeOutsideSet = Ieee80211HtCompliantModes::getCompliantMode(&Ieee80211HtmcsTable::htMcs32BW40MHz,
+        Ieee80211HtMode::BAND_2_4GHZ, Ieee80211HtPreambleMode::HT_PREAMBLE_MIXED,
+        Ieee80211HtModeBase::HT_GUARD_INTERVAL_LONG);
+ASSERT(!modeSet->containsMode(modeOutsideSet));
+
+const MacAddress peer("02:00:00:00:00:01");
+
+auto shortGiPeer = makePeerState({8}, {MHz(20)}, MHz(20), true);
+const auto *shortGiSelection = selectPeerCompatibleMode(modeSet, &shortGiPeer, mcs8Short, peer);
+ASSERT(shortGiSelection == mcs8Short);
+ASSERT(shortGiSelection->isHtShortGuardInterval());
+ASSERT(shortGiSelection->getDataMode()->getBandwidth() == MHz(20));
+auto fortyMhzPeer = makePeerState({0}, {MHz(20), MHz(40)}, MHz(40), false, true);
+const auto *fortyMhzSelection = selectPeerCompatibleMode(modeSet, &fortyMhzPeer, mcs0_40Short, peer);
+ASSERT(fortyMhzSelection == mcs0_40Short);
+ASSERT(fortyMhzSelection->isHtShortGuardInterval());
+ASSERT(fortyMhzSelection->getDataMode()->getBandwidth() == MHz(40));
+
+// The complementary long-GI and short-GI variants are selectable when the
+// peer capabilities permit the corresponding exact mode.
+auto longGiMcs8Peer = makePeerState({8}, {MHz(20)}, MHz(20));
+ASSERT(selectPeerCompatibleMode(modeSet, &longGiMcs8Peer, mcs8Long, peer) == mcs8Long);
+auto shortGiMcs0Peer = makePeerState({0}, {MHz(20)}, MHz(20), true);
+ASSERT(selectPeerCompatibleMode(modeSet, &shortGiMcs0Peer, mcs0Short, peer) == mcs0Short);
+auto longGiFortyPeer = makePeerState({0}, {MHz(20), MHz(40)}, MHz(40));
+ASSERT(selectPeerCompatibleMode(modeSet, &longGiFortyPeer, mcs0_40Long, peer) == mcs0_40Long);
+
+bool outsideModeRejected = false;
+try {
+    auto compatiblePeer = makePeerState({0}, {MHz(20)}, MHz(20));
+    selectPeerCompatibleMode(modeSet, &compatiblePeer, modeOutsideSet, peer);
+}
+catch (const cRuntimeError&) {
+    outsideModeRejected = true;
+}
+ASSERT(outsideModeRejected);
+
+// The exact negotiated bitmap is not a contiguous maximum-MCS value: MCS 0
+// and 2 are usable while MCS 1 is not (IEEE Std 802.11-2024, 10.6.5.8).
+auto sparsePeer = makePeerState({0, 2}, {MHz(20)}, MHz(20));
+ASSERT(selectPeerCompatibleMode(modeSet, &sparsePeer, mcs2Long, peer) == mcs2Long);
+ASSERT(selectPeerCompatibleMode(modeSet, &sparsePeer, mcs1Long, peer) == mcs0Long);
+
+// A 20 MHz-only receiver cannot use a 40 MHz candidate, even when the BSS
+// itself permits 40 MHz operation.
+auto twentyOnlyPeer = makePeerState({0}, {MHz(20)}, MHz(40));
+const auto *twentyFallback = selectPeerCompatibleMode(modeSet, &twentyOnlyPeer, mcs0_40Short, peer);
+ASSERT(twentyFallback == mcs0Long);
+ASSERT(twentyFallback->getDataMode()->getBandwidth() == MHz(20));
+
+// The negotiated HT Operation width is an additional BSS-level limit over
+// the common capability widths.
+auto twentyOperationPeer = makePeerState({0}, {MHz(20), MHz(40)}, MHz(20));
+ASSERT(selectPeerCompatibleMode(modeSet, &twentyOperationPeer, mcs0_40Short, peer) == mcs0Long);
+
+// A short-GI candidate falls back to the same-MCS long-GI variant when the
+// peer did not advertise the matching receiver capability bit.
+auto shortGiDisabledPeer = makePeerState({0, 8}, {MHz(20)}, MHz(20));
+const auto *shortGiFallback = selectPeerCompatibleMode(modeSet, &shortGiDisabledPeer, mcs8Short, peer);
+ASSERT(shortGiFallback == mcs8Long);
+ASSERT(!shortGiFallback->isHtShortGuardInterval());
+
+auto compatiblePeer = makePeerState({2}, {MHz(20)}, MHz(40));
+ASSERT(selectPeerCompatibleMode(modeSet, &compatiblePeer, mcs2Long, peer) == mcs2Long);
+
+// Missing or invalid negotiated state keeps unicast HT selection on a legacy
+// operational fallback without increasing the caller's candidate bitrate.
+const auto *legacy12Mbps = modeSet->getMode(Mbps(12));
+const auto *legacy6Mbps = modeSet->getMode(Mbps(6));
+ASSERT(selectPeerCompatibleMode(modeSet, nullptr, mcs2Long, peer) == legacy12Mbps);
+auto invalidPeer = makePeerState({2}, {MHz(20)}, MHz(20));
+invalidPeer.valid = false;
+ASSERT(selectPeerCompatibleMode(modeSet, &invalidPeer, mcs2Long, peer) == legacy12Mbps);
+auto invalidDirectionalPeer = makePeerState({2}, {MHz(20)}, MHz(20));
+invalidDirectionalPeer.negotiatedCapabilities.localTxPeerRx.valid = false;
+ASSERT(selectPeerCompatibleMode(modeSet, &invalidDirectionalPeer, mcs2Long, peer) == legacy12Mbps);
+
+const auto *boundedMcs0Fallback = selectPeerCompatibleMode(modeSet, nullptr, mcs0Long, peer);
+ASSERT(boundedMcs0Fallback == legacy6Mbps);
+ASSERT(boundedMcs0Fallback->getDataMode()->getNetBitrate() <= mcs0Long->getDataMode()->getNetBitrate());
+
+// If no compatible HT mode is at or below the candidate bitrate, the result
+// is legacy rather than an HT mode that violates the negotiated bitmap.
+auto noHtFallbackPeer = makePeerState({76}, {MHz(20)}, MHz(20));
+const auto *noHtFallback = selectPeerCompatibleMode(modeSet, &noHtFallbackPeer, mcs0Long, peer);
+ASSERT(noHtFallback == legacy6Mbps);
+ASSERT(noHtFallback->getHtMcsIndex() < 0);
+
+// Mode-set traversal and tie-breaks are stable and never depend on pointers.
+auto deterministicPeer = makePeerState({0, 2, 8}, {MHz(20)}, MHz(20));
+const auto *firstSelection = selectPeerCompatibleMode(modeSet, &deterministicPeer, mcs8Short, peer);
+const auto *secondSelection = selectPeerCompatibleMode(modeSet, &deterministicPeer, mcs8Short, peer);
+ASSERT(firstSelection == secondSelection);
+ASSERT(firstSelection->getHtMcsIndex() == 8);
+ASSERT(!firstSelection->isHtShortGuardInterval());
+
+EV << "Peer-compatible HT mode selection checks verified.\n";
+
+%contains: stdout
+Peer-compatible HT mode selection checks verified.

--- a/tests/unit/Ieee80211SupportedRates_1.test
+++ b/tests/unit/Ieee80211SupportedRates_1.test
@@ -1,6 +1,7 @@
 %description:
 Verify Supported Rates and Extended Supported Rates lengths, basic-rate
-membership, split/merge behavior, and malformed-element rejection.
+membership, split/merge behavior, malformed-element rejection, and logical
+Association/Reassociation Response AID encoding.
 
 %includes:
 #include <algorithm>
@@ -32,6 +33,21 @@ static Ptr<Ieee80211AssociationResponseFrame> makeResponse(short numRates,
     }
     frame->setSupportedRates(rates);
     frame->setChunkLength(B(8 + std::max(0, (int)numRates)));
+    return frame;
+}
+
+static Ptr<Ieee80211ReassociationResponseFrame> makeReassociationResponse(short aid,
+        Ieee80211StatusCode statusCode = SC_SUCCESSFUL)
+{
+    auto frame = makeShared<Ieee80211ReassociationResponseFrame>();
+    frame->setStatusCode(statusCode);
+    frame->setAid(aid);
+    Ieee80211SupportedRatesElement rates;
+    rates.numRates = 1;
+    rates.rate[0] = 0.5;
+    rates.basicRate[0] = true;
+    frame->setSupportedRates(rates);
+    frame->setChunkLength(B(9));
     return frame;
 }
 
@@ -67,6 +83,7 @@ static Ptr<const Frame> deserializeFrame(const std::vector<uint8_t>& bytes)
 auto oneRateFrame = makeResponse(1);
 auto oneRateBytes = serializeFrame(oneRateFrame);
 ASSERT(oneRateBytes.size() == 9);
+ASSERT(oneRateBytes[4] == 1 && oneRateBytes[5] == 0xC0);
 ASSERT(oneRateBytes[6] == 1 && oneRateBytes[7] == 1);
 ASSERT(oneRateBytes[8] == (0x80 | 1));
 auto oneRateDecoded = deserializeFrame<Ieee80211AssociationResponseFrame>(oneRateBytes);
@@ -97,7 +114,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(zeroRateSerializationRejected);
 
-auto nineRateRaw = makeRawResponse(1, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+auto nineRateRaw = makeRawResponse(0xC001, {1, 2, 3, 4, 5, 6, 7, 8, 9});
 bool nineRateDeserializationRejected = false;
 try {
     deserializeFrame<Ieee80211AssociationResponseFrame>(nineRateRaw);
@@ -107,7 +124,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(nineRateDeserializationRejected);
 
-auto truncatedPrimary = makeRawResponse(1, {1});
+auto truncatedPrimary = makeRawResponse(0xC001, {1});
 truncatedPrimary[7] = 2;
 bool truncatedPrimaryRejected = false;
 try {
@@ -132,7 +149,7 @@ splitFrame->setExtendedSupportedRates(extendedRates);
 splitFrame->setChunkLength(B(6) + B(2 + 8) + B(2 + 5));
 auto splitBytes = serializeFrame(splitFrame);
 ASSERT(splitBytes.size() == 23);
-ASSERT(splitBytes[4] == 0xD7 && splitBytes[5] == 0x07);
+ASSERT(splitBytes[4] == 0xD7 && splitBytes[5] == 0xC7);
 ASSERT(splitBytes[16] == 50 && splitBytes[17] == 5);
 for (int i = 0; i < 5; i++)
     ASSERT(splitBytes[18 + i] == (static_cast<uint8_t>(i + 9) | ((i == 1 || i == 4) ? 0x80 : 0)));
@@ -145,7 +162,7 @@ for (int i = 0; i < 5; i++) {
     ASSERT(splitDecoded->getExtendedSupportedRates().basicRate[i] == (i == 1 || i == 4));
 }
 
-auto extendedZero = makeRawResponse(1, {1});
+auto extendedZero = makeRawResponse(0xC001, {1});
 extendedZero.push_back(50);
 extendedZero.push_back(0);
 bool extendedZeroRejected = false;
@@ -157,7 +174,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(extendedZeroRejected);
 
-auto extendedTruncated = makeRawResponse(1, {1});
+auto extendedTruncated = makeRawResponse(0xC001, {1});
 extendedTruncated.push_back(50);
 extendedTruncated.push_back(2);
 extendedTruncated.push_back(2);
@@ -170,7 +187,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(extendedTruncatedRejected);
 
-auto extendedDuplicate = makeRawResponse(1, {1});
+auto extendedDuplicate = makeRawResponse(0xC001, {1});
 extendedDuplicate.insert(extendedDuplicate.end(), {50, 1, 2, 50, 1, 3});
 bool extendedDuplicateRejected = false;
 try {
@@ -181,7 +198,7 @@ catch (const cRuntimeError&) {
 }
 ASSERT(extendedDuplicateRejected);
 
-auto primaryDuplicate = makeRawResponse(1, {1});
+auto primaryDuplicate = makeRawResponse(0xC001, {1});
 primaryDuplicate.insert(primaryDuplicate.end(), {1, 1, 2});
 bool primaryDuplicateRejected = false;
 try {
@@ -191,6 +208,91 @@ catch (const cRuntimeError&) {
     primaryDuplicateRejected = true;
 }
 ASSERT(primaryDuplicateRejected);
+
+// IEEE Std 802.11-2024, 9.2.2, 9.3.3.6/Table 9-65,
+// 9.3.3.8/Table 9-67, and 9.4.1.8/Figure 9-146 require the marked
+// multi-octet AID to be transmitted least-significant octet first.
+// Decode independently supplied compliant vectors so a reciprocal
+// serializer/deserializer bug cannot pass.
+for (short aid : {short(1), short(2007)}) {
+    auto association = makeResponse(1, SC_SUCCESSFUL, aid);
+    auto associationBytes = serializeFrame(association);
+    uint16_t wireAid = static_cast<uint16_t>(0xC000 | aid);
+    ASSERT(associationBytes[4] == static_cast<uint8_t>(wireAid));
+    ASSERT(associationBytes[5] == static_cast<uint8_t>(wireAid >> 8));
+    ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(associationBytes)->getAid() == aid);
+    auto reassociation = makeReassociationResponse(aid);
+    auto reassociationBytes = serializeFrame(reassociation);
+    ASSERT(reassociationBytes[4] == static_cast<uint8_t>(wireAid));
+    ASSERT(reassociationBytes[5] == static_cast<uint8_t>(wireAid >> 8));
+    ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(reassociationBytes)->getAid() == aid);
+}
+
+const std::vector<uint8_t> compliantAidOne = {0, 0, 0, 0, 0x01, 0xC0, 1, 1, 1};
+ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(compliantAidOne)->getAid() == 1);
+ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(compliantAidOne)->getAid() == 1);
+const std::vector<uint8_t> compliantAid2007 = {0, 0, 0, 0, 0xD7, 0xC7, 1, 1, 1};
+ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(compliantAid2007)->getAid() == 2007);
+ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(compliantAid2007)->getAid() == 2007);
+
+auto unsuccessful = makeResponse(1, SC_DATARATE_UNSUP, 0);
+auto unsuccessfulBytes = serializeFrame(unsuccessful);
+ASSERT(unsuccessfulBytes[4] == 0 && unsuccessfulBytes[5] == 0);
+ASSERT(deserializeFrame<Ieee80211AssociationResponseFrame>(unsuccessfulBytes)->getAid() == 0);
+auto unsuccessfulReassociation = makeReassociationResponse(0, SC_DATARATE_UNSUP);
+auto unsuccessfulReassociationBytes = serializeFrame(unsuccessfulReassociation);
+ASSERT(deserializeFrame<Ieee80211ReassociationResponseFrame>(unsuccessfulReassociationBytes)->getAid() == 0);
+
+for (uint16_t invalidWireAid : {uint16_t(1), uint16_t(0x8001), uint16_t(0xC000), uint16_t(0xC7D8)}) {
+    auto invalidWire = makeRawResponse(invalidWireAid, {1});
+    bool rejected = false;
+    try {
+        deserializeFrame<Ieee80211AssociationResponseFrame>(invalidWire);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+    rejected = false;
+    try {
+        deserializeFrame<Ieee80211ReassociationResponseFrame>(invalidWire);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+}
+
+for (short invalidLogicalAid : {short(0), short(2008)}) {
+    auto invalidAssociation = makeResponse(1, SC_SUCCESSFUL, invalidLogicalAid);
+    bool rejected = false;
+    try {
+        serializeFrame(invalidAssociation);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+    auto invalidReassociation = makeReassociationResponse(invalidLogicalAid);
+    rejected = false;
+    try {
+        serializeFrame(invalidReassociation);
+    }
+    catch (const cRuntimeError&) {
+        rejected = true;
+    }
+    ASSERT(rejected);
+}
+
+auto unsuccessfulWithAid = makeRawResponse(1, {1}, SC_DATARATE_UNSUP);
+bool unsuccessfulAidRejected = false;
+try {
+    deserializeFrame<Ieee80211AssociationResponseFrame>(unsuccessfulWithAid);
+}
+catch (const cRuntimeError&) {
+    unsuccessfulAidRejected = true;
+}
+ASSERT(unsuccessfulAidRejected);
 
 // IEEE Std 802.11-2024, 9.4.2.3 and 11.1.4.6 encode legacy rates in 500 kb/s
 // units up to 63.5 Mb/s. HT MCS 7 is 65 Mb/s and remains an HT MCS.


### PR DESCRIPTION
Association responses must match the pending procedure and peer, and HT negotiation must reject malformed advertisements without corrupting discovery or retained associations. Add correlated STA transactions, validated discovery, lifecycle cleanup, committed-state reassociation handling, peer-aware rates, AID wire validation, and simplified association restoration.

## Stack and reading order

PR 2/4. Head: `pr/ht-02-sta-association`. Target: `master` (PR 1/4 [#1167](https://github.com/inet-framework/inet/pull/1167) merged). Range: `b61cd671d429..1ded7e8cdd1b`. Read the following commits in order:

- `441ff2701b` — ieee80211: keep management transaction metadata local
- `fe876073fc` — ieee80211: model detailed association transactions
- `2108cb5ec5` — ieee80211: negotiate HT from validated discovery state
- `80d1c66987` — ieee80211: preserve peer ownership during STA teardown
- `cfcd73de3b` — ieee80211: report reassociation completion from committed state
- `74b40b81b8` — ieee80211: select rates from negotiated HT capabilities
- `6627fcf3f1` — ieee80211: validate association ID wire encoding
- `1ded7e8cdd` — ieee80211: restore simplified associations across lifecycle changes

## Architectural surface

Local transaction tags and fragmentation/receive boundaries, STA management primitives and lifecycle, peer HT state, DCF/HCF rate selection, and Association ID serialization.

## Baselines

C16 (`74b40b81b8`) carries the TXOP fingerprint transition caused by peer-aware rate selection. C17 (`6627fcf3f1`) carries thirty data-byte transitions for corrected Association ID encoding. No other baseline changes are included.

## Verification

C11–C12 have passing per-commit debug builds and scoped opp_repl tests. C13–C18 and this PR tip were not tested separately, per the requested final-only verification. The complete stack passed the final build and test union.

The full-stack recorded build command was `make MODE=debug -j$(nproc)`. The scoped unit/module/queueing runs used `opp_repl --load @opp -p inet`, with exact `run_opp_tests` calls in the retained `.final.tests.py` execution artifact. Fingerprints used `fingerprinttest -d -q -f tplx -f "~tNl" -f "~tND"` with the retained explicit 37-row CSV. Exact commands, selectors, statuses, and source-tree mappings are in the accompanying execution report.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/inet-framework/inet/pull/1172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->