### PR TITLE
IEEE 802.11: complete AP association transactions from MAC outcomes

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
@@ -74,8 +74,10 @@ void Ieee80211Mac::initialize(int stage)
                 modeSet->getMaximumNumberOfSpatialStreams());
         std::set<Hz> operationalChannelWidths;
         if (modeSet->isHtOperationSupported()) {
-            const auto *transmitter = check_and_cast<const Ieee80211Transmitter *>(radio->getTransmitter());
-            const auto *receiver = check_and_cast<const Ieee80211Receiver *>(radio->getReceiver());
+            const auto *transmitter = dynamic_cast<const Ieee80211Transmitter *>(radio->getTransmitter());
+            const auto *receiver = dynamic_cast<const Ieee80211Receiver *>(radio->getReceiver());
+            if (transmitter == nullptr || receiver == nullptr)
+                throw cRuntimeError("HT operation requires Ieee80211Transmitter and Ieee80211Receiver");
             for (auto channelWidth : modeSet->getHtSupportedChannelWidths())
                 if (transmitter->isHtChannelWidthSupported(channelWidth) &&
                         receiver->isHtChannelWidthSupported(channelWidth))

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
@@ -23,7 +23,6 @@
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mac/Rx.h"
 #include "inet/linklayer/ieee80211/mac/contract/IContention.h"
-#include "inet/linklayer/ieee80211/mac/contract/IFrameSequence.h"
 #include "inet/linklayer/ieee80211/mac/contract/IRx.h"
 #include "inet/linklayer/ieee80211/mac/contract/ITx.h"
 #include "inet/networklayer/contract/IInterfaceTable.h"
@@ -38,6 +37,8 @@ namespace ieee80211 {
 using namespace inet::physicallayer;
 
 Define_Module(Ieee80211Mac);
+
+simsignal_t Ieee80211Mac::frameTransmissionOutcomeSignal = cComponent::registerSignal("frameTransmissionOutcome");
 
 Ieee80211Mac::Ieee80211Mac()
 {

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.cc
@@ -27,10 +27,10 @@
 #include "inet/linklayer/ieee80211/mac/contract/IRx.h"
 #include "inet/linklayer/ieee80211/mac/contract/ITx.h"
 #include "inet/networklayer/contract/IInterfaceTable.h"
-#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Receiver.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211ControlInfo_m.h"
-#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Receiver.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h"
 
 namespace inet {
 namespace ieee80211 {

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.h
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.h
@@ -37,6 +37,9 @@ class Ieee80211MacHeader;
  */
 class INET_API Ieee80211Mac : public MacProtocolBase
 {
+  public:
+    static simsignal_t frameTransmissionOutcomeSignal;
+
   protected:
     FcsMode fcsMode;
 

--- a/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.ned
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211Mac.ned
@@ -93,11 +93,16 @@ module Ieee80211Mac extends MacProtocolBase like IIeee80211Mac
         @class(Ieee80211Mac);
         @signal[linkBroken](type=inet::Packet); // TODO this signal is only present for the statistic to pass the signal check, to be removed
         @signal[modesetChanged](type=inet::physicallayer::Ieee80211ModeSet);
+        @signal[frameTransmissionOutcome](type=inet::Packet);
         @statistic[packetSentToUpper](title="packets sent to upper layer"; record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetSentToLower](title="packets sent to lower layer"; record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetReceivedFromUpper](title="packets received from upper layer"; record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetReceivedFromLower](title="packets received from lower layer"; record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[linkBroken](title="link breaks"; record=count,vector?; interpolationmode=none);
+        @statistic[frameTransmissionOutcome](title="frame transmission outcomes"; record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
+        @statistic[frameAcked](title="frames acknowledged"; source=frameTransmissionStatusIsAcknowledged(frameTransmissionOutcome); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
+        @statistic[frameRetryLimitReached](title="frames dropped: retry limit reached"; source=frameTransmissionStatusIsRetryLimitReached(frameTransmissionOutcome); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
+        @statistic[frameDroppedBeforeTx](title="frames dropped: before transmission"; source=frameTransmissionStatusIsDroppedBeforeTransmission(frameTransmissionOutcome); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetDrop](title="packet drops"; source=packetDropped; record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetDropIncorrectlyReceived](title="packet drops: incorrectly received"; source=packetDropReasonIsIncorrectlyReceived(packetDropped); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);
         @statistic[packetDropNotAddressedToUs](title="packet drops: not addressed to us"; source=packetDropReasonIsNotAddressedToUs(packetDropped); record=count,sum(packetBytes),vector(packetBytes); interpolationmode=none);

--- a/src/inet/linklayer/ieee80211/mac/common/ResultFilters.cc
+++ b/src/inet/linklayer/ieee80211/mac/common/ResultFilters.cc
@@ -72,6 +72,26 @@ void Ieee80211NotRetryFilter::receiveSignal(cResultFilter *prev, simtime_t_cref 
     }
 }
 
+void FrameTransmissionStatusFilter::receiveSignal(cResultFilter *prev, simtime_t_cref t, cObject *object, cObject *details)
+{
+    auto transDetails = dynamic_cast<FrameTransmissionDetails *>(details);
+    if (transDetails == nullptr)
+        transDetails = dynamic_cast<FrameTransmissionDetails *>(object);
+    if (transDetails != nullptr && transDetails->getStatus() == status) {
+        cObject *forwardObj = object != nullptr ? object : transDetails;
+        fire(this, t, forwardObj, details);
+    }
+}
+
+class FrameTransmissionStatusIsAcknowledgedFilter : public FrameTransmissionStatusFilter { public: FrameTransmissionStatusIsAcknowledgedFilter() : FrameTransmissionStatusFilter(FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) {} };
+Register_ResultFilter("frameTransmissionStatusIsAcknowledged", FrameTransmissionStatusIsAcknowledgedFilter);
+
+class FrameTransmissionStatusIsRetryLimitReachedFilter : public FrameTransmissionStatusFilter { public: FrameTransmissionStatusIsRetryLimitReachedFilter() : FrameTransmissionStatusFilter(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED) {} };
+Register_ResultFilter("frameTransmissionStatusIsRetryLimitReached", FrameTransmissionStatusIsRetryLimitReachedFilter);
+
+class FrameTransmissionStatusIsDroppedBeforeTransmissionFilter : public FrameTransmissionStatusFilter { public: FrameTransmissionStatusIsDroppedBeforeTransmissionFilter() : FrameTransmissionStatusFilter(FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION) {} };
+Register_ResultFilter("frameTransmissionStatusIsDroppedBeforeTransmission", FrameTransmissionStatusIsDroppedBeforeTransmissionFilter);
+
 } // namespace ieee80211
 
 } // namespace inet

--- a/src/inet/linklayer/ieee80211/mac/common/ResultFilters.h
+++ b/src/inet/linklayer/ieee80211/mac/common/ResultFilters.h
@@ -9,6 +9,7 @@
 #define __INET_RESULTFILTERS_H
 
 #include "inet/common/INETDefs.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
 
 namespace inet {
 
@@ -41,6 +42,16 @@ class INET_API Ieee80211RetryFilter : public cObjectResultFilter
 class INET_API Ieee80211NotRetryFilter : public cObjectResultFilter
 {
   public:
+    virtual void receiveSignal(cResultFilter *prev, simtime_t_cref t, cObject *object, cObject *details) override;
+};
+
+class INET_API FrameTransmissionStatusFilter : public cObjectResultFilter
+{
+  protected:
+    FrameTransmissionStatus status;
+
+  public:
+    FrameTransmissionStatusFilter(FrameTransmissionStatus status) : status(status) {}
     virtual void receiveSignal(cResultFilter *prev, simtime_t_cref t, cObject *object, cObject *details) override;
 };
 

--- a/src/inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails.msg
+++ b/src/inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails.msg
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2026 OpenSim Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+import inet.common.INETDefs;
+
+namespace inet::ieee80211;
+
+enum FrameTransmissionStatus
+{
+    FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED = 0;
+    FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED = 1;
+    FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION = 2;
+}
+
+//
+// Details payload emitted with frameTransmissionOutcomeSignal.
+// The payload is created synchronously by the coordination function and is valid only for
+// the duration of the notification.
+//
+class FrameTransmissionDetails extends cObject
+{
+    FrameTransmissionStatus status;
+}

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.cc
@@ -8,10 +8,13 @@
 #include "inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h"
 
 #include "inet/common/ModuleAccess.h"
+#include "inet/common/Simsignals.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/DcfFs.h"
 #include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
 #include "inet/linklayer/ieee80211/mac/recipient/RecipientAckProcedure.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 
 namespace inet {
 namespace ieee80211 {
@@ -46,6 +49,11 @@ void Dcf::initialize(int stage)
         stationRetryCounters = new StationRetryCounters();
         originatorProtectionMechanism = check_and_cast<OriginatorProtectionMechanism *>(getSubmodule("originatorProtectionMechanism"));
         WATCH_EXPR("frameSequenceInfo", frameSequenceHandler->isSequenceRunning() ? "Fs: " + frameSequenceHandler->getFrameSequence()->getHistory() : "");
+    }
+    else if (stage == INITSTAGE_LAST) {
+        // Dcaf resolves its pending queue at the link-layer stage. Install
+        // this signal listener after all child initialization has completed.
+        check_and_cast<cModule *>(channelAccess->getPendingQueue())->subscribe(packetDroppedSignal, this);
     }
 }
 
@@ -111,6 +119,21 @@ void Dcf::transmitControlResponseFrame(Packet *responsePacket, const Ptr<const I
 void Dcf::processMgmtFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& mgmtHeader)
 {
     throw cRuntimeError("Unknown management frame");
+}
+
+void Dcf::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
+{
+    if (signalID == packetDroppedSignal) {
+        Enter_Method("%s", cComponent::getSignalName(signalID));
+        auto packet = check_and_cast<Packet *>(obj);
+        if (packet->findTag<Ieee80211MgmtTransactionTag>() != nullptr) {
+            FrameTransmissionDetails transmissionDetails;
+            transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+            emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet, &transmissionDetails);
+        }
+    }
+    else
+        ModeSetListener::receiveSignal(source, signalID, obj, details);
 }
 
 void Dcf::recipientProcessTransmittedControlResponseFrame(Packet *packet, const Ptr<const Ieee80211MacHeader>& header)
@@ -267,6 +290,11 @@ void Dcf::originatorProcessRtsProtectionFailed(Packet *packet)
         details.setLimit(recoveryProcedure->getShortRetryLimit());
         emit(packetDroppedSignal, packet, &details);
         emit(linkBrokenSignal, packet);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(protectedHeader)) {
+            FrameTransmissionDetails transmissionDetails;
+            transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+            emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet, &transmissionDetails);
+        }
     }
 }
 
@@ -311,6 +339,11 @@ void Dcf::originatorProcessReceivedFrame(Packet *receivedPacket, Packet *lastTra
         ackHandler->processReceivedAck(dynamicPtrCast<const Ieee80211AckFrame>(receivedHeader), lastTransmittedDataOrMgmtHeader);
         channelAccess->getInProgressFrames()->dropFrame(lastTransmittedPacket);
         ackHandler->dropFrame(lastTransmittedDataOrMgmtHeader);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(lastTransmittedDataOrMgmtHeader)) {
+            FrameTransmissionDetails transmissionDetails;
+            transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+            emit(Ieee80211Mac::frameTransmissionOutcomeSignal, lastTransmittedPacket, &transmissionDetails);
+        }
     }
     else if (receivedHeader->getType() == ST_RTS)
         ; // void
@@ -344,6 +377,11 @@ void Dcf::originatorProcessFailedFrame(Packet *failedPacket)
         details.setLimit(-1); // TODO
         emit(packetDroppedSignal, failedPacket, &details);
         emit(linkBrokenSignal, failedPacket);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(failedHeader)) {
+            FrameTransmissionDetails transmissionDetails;
+            transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+            emit(Ieee80211Mac::frameTransmissionOutcomeSignal, failedPacket, &transmissionDetails);
+        }
     }
     else {
         EV_INFO << "Retrying frame " << failedPacket->getName() << ".\n";

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.h
@@ -87,6 +87,7 @@ class INET_API Dcf : public ICoordinationFunction, public IFrameSequenceHandler:
     virtual void initialize(int stage) override;
     virtual void forEachChild(cVisitor *v) override;
     virtual void handleMessage(cMessage *msg) override;
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
 
     virtual void sendUp(const std::vector<Packet *>& completeFrames);
     virtual bool hasFrameToTransmit();

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Dcf.ned
@@ -43,6 +43,7 @@ module Dcf extends Module like IDcf
         @signal[packetReceivedFromPeer](type=inet::Packet);
         @signal[linkBroken](type=inet::Packet);
         @signal[packetDropped](type=inet::Packet);
+        @signal[frameTransmissionOutcome](type=inet::Packet);
         @signal[frameSequenceStarted];
         @signal[frameSequenceFinished];
         @signal[datarateSelected](type=double);

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -265,8 +265,7 @@ void Hcf::handleInternalCollision(std::vector<Edcaf *> internallyCollidedEdcafs)
             retryLimitReached = dataRecoveryProcedure->isRetryLimitReached(internallyCollidedFrame, dataHeader);
         }
         else if (auto mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(internallyCollidedHeader)) {
-            ASSERT(ac == AccessCategory::AC_BE);
-            edca->getMgmtAndNonQoSRecoveryProcedure()->dataOrMgmtFrameTransmissionFailed(internallyCollidedFrame, mgmtHeader, edca->getEdcaf(AccessCategory::AC_BE)->getStationRetryCounters());
+            edca->getMgmtAndNonQoSRecoveryProcedure()->dataOrMgmtFrameTransmissionFailed(internallyCollidedFrame, mgmtHeader, edcaf->getStationRetryCounters());
             retryLimitReached = edca->getMgmtAndNonQoSRecoveryProcedure()->isRetryLimitReached(internallyCollidedFrame, mgmtHeader);
         }
         else // TODO + NonQoSDataFrame

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -392,7 +392,7 @@ void Hcf::originatorProcessRtsProtectionFailed(Packet *packet)
         }
         else if (auto mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(protectedHeader)) {
             edca->getMgmtAndNonQoSRecoveryProcedure()->rtsFrameTransmissionFailed(mgmtHeader, edcaf->getStationRetryCounters());
-            retryLimitReached = edca->getMgmtAndNonQoSRecoveryProcedure()->isRtsFrameRetryLimitReached(packet, dataHeader);
+            retryLimitReached = edca->getMgmtAndNonQoSRecoveryProcedure()->isRtsFrameRetryLimitReached(packet, mgmtHeader);
         }
         else
             throw cRuntimeError("Unknown frame"); // TODO QoSDataFrame, NonQoSDataFrame
@@ -586,7 +586,7 @@ void Hcf::originatorProcessReceivedControlFrame(Packet *packet, const Ptr<const 
         }
         else if (auto mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(lastTransmittedHeader)) {
             if (dataAndMgmtRateControl) {
-                int retryCount = edca->getMgmtAndNonQoSRecoveryProcedure()->getRetryCount(lastTransmittedPacket, dataHeader);
+                int retryCount = edca->getMgmtAndNonQoSRecoveryProcedure()->getRetryCount(lastTransmittedPacket, mgmtHeader);
                 dataAndMgmtRateControl->frameTransmitted(lastTransmittedPacket, retryCount, true, false);
             }
             edca->getMgmtAndNonQoSRecoveryProcedure()->ackFrameReceived(lastTransmittedPacket, mgmtHeader, edcaf->getStationRetryCounters());

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.cc
@@ -8,13 +8,16 @@
 #include "inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.h"
 
 #include "inet/common/ModuleAccess.h"
+#include "inet/common/Simsignals.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
 #include "inet/linklayer/ieee80211/mac/blockack/OriginatorBlockAckAgreementHandler.h"
 #include "inet/linklayer/ieee80211/mac/blockack/OriginatorBlockAckProcedure.h"
 #include "inet/linklayer/ieee80211/mac/blockack/RecipientBlockAckAgreementHandler.h"
 #include "inet/linklayer/ieee80211/mac/framesequence/HcfFs.h"
 #include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
 #include "inet/linklayer/ieee80211/mac/recipient/RecipientAckProcedure.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 #include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
 
 namespace inet {
@@ -61,6 +64,12 @@ void Hcf::initialize(int stage)
             originatorBlockAckProcedure = new OriginatorBlockAckProcedure();
             recipientBlockAckProcedure = new RecipientBlockAckProcedure();
         }
+    }
+    else if (stage == INITSTAGE_LAST) {
+        // Edca resolves its Edcaf array at the link-layer stage. Install the
+        // queue signal listeners after all child initialization has completed.
+        for (int ac = 0; ac < AC_NUMCATEGORIES; ac++)
+            check_and_cast<cModule *>(edca->getEdcaf(static_cast<AccessCategory>(ac))->getPendingQueue())->subscribe(packetDroppedSignal, this);
     }
 }
 
@@ -143,6 +152,21 @@ void Hcf::processUpperFrame(Packet *packet, const Ptr<const Ieee80211DataOrMgmtH
             edca->requestChannelAccess(ac, this);
         }
     }
+}
+
+void Hcf::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
+{
+    if (signalID == packetDroppedSignal) {
+        Enter_Method("%s", cComponent::getSignalName(signalID));
+        auto packet = check_and_cast<Packet *>(obj);
+        if (packet->findTag<Ieee80211MgmtTransactionTag>() != nullptr) {
+            FrameTransmissionDetails transmissionDetails;
+            transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+            emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet, &transmissionDetails);
+        }
+    }
+    else
+        ModeSetListener::receiveSignal(source, signalID, obj, details);
 }
 
 void Hcf::scheduleStartRxTimer(simtime_t timeout)
@@ -261,6 +285,11 @@ void Hcf::handleInternalCollision(std::vector<Edcaf *> internallyCollidedEdcafs)
             details.setLimit(-1); // TODO
             emit(packetDroppedSignal, internallyCollidedFrame, &details);
             emit(linkBrokenSignal, internallyCollidedFrame);
+            if (dynamicPtrCast<const Ieee80211MgmtHeader>(internallyCollidedHeader)) {
+                FrameTransmissionDetails transmissionDetails;
+                transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+                emit(Ieee80211Mac::frameTransmissionOutcomeSignal, internallyCollidedFrame, &transmissionDetails);
+            }
             if (hasFrameToTransmit(ac))
                 edcaf->requestChannel(this);
         }
@@ -410,6 +439,11 @@ void Hcf::originatorProcessRtsProtectionFailed(Packet *packet)
             details.setLimit(-1); // TODO
             emit(packetDroppedSignal, packet, &details);
             emit(linkBrokenSignal, packet);
+            if (dynamicPtrCast<const Ieee80211MgmtHeader>(protectedHeader)) {
+                FrameTransmissionDetails transmissionDetails;
+                transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+                emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet, &transmissionDetails);
+            }
         }
     }
     else
@@ -531,6 +565,11 @@ void Hcf::originatorProcessFailedFrame(Packet *failedPacket)
             details.setLimit(-1); // TODO
             emit(packetDroppedSignal, failedPacket, &details);
             emit(linkBrokenSignal, failedPacket);
+            if (dynamicPtrCast<const Ieee80211MgmtHeader>(failedHeader)) {
+                FrameTransmissionDetails transmissionDetails;
+                transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+                emit(Ieee80211Mac::frameTransmissionOutcomeSignal, failedPacket, &transmissionDetails);
+            }
         }
         else {
             EV_INFO << "Retrying frame " << failedPacket->getName() << ".\n";
@@ -597,6 +636,11 @@ void Hcf::originatorProcessReceivedControlFrame(Packet *packet, const Ptr<const 
         edcaf->getAckHandler()->processReceivedAck(ackFrame, lastTransmittedDataOrMgmtHeader);
         edcaf->getInProgressFrames()->dropFrame(lastTransmittedPacket);
         edcaf->getAckHandler()->dropFrame(lastTransmittedDataOrMgmtHeader);
+        if (dynamicPtrCast<const Ieee80211MgmtHeader>(lastTransmittedHeader)) {
+            FrameTransmissionDetails transmissionDetails;
+            transmissionDetails.setStatus(FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+            emit(Ieee80211Mac::frameTransmissionOutcomeSignal, lastTransmittedPacket, &transmissionDetails);
+        }
     }
     else if (auto blockAck = dynamicPtrCast<const Ieee80211BasicBlockAck>(header)) {
         EV_INFO << "BasicBlockAck has arrived" << std::endl;

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.h
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.h
@@ -107,6 +107,7 @@ class INET_API Hcf : public ICoordinationFunction, public IFrameSequenceHandler:
     virtual void initialize(int stage) override;
     virtual void forEachChild(cVisitor *v) override;
     virtual void handleMessage(cMessage *msg) override;
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
     virtual void refreshDisplay() const override;
 
     void startFrameSequence(AccessCategory ac);

--- a/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.ned
+++ b/src/inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.ned
@@ -46,6 +46,7 @@ module Hcf extends Module like IHcf
         @signal[packetReceivedFromPeer](type=inet::Packet);
         @signal[linkBroken](type=inet::Packet);
         @signal[packetDropped](type=inet::Packet);
+        @signal[frameTransmissionOutcome](type=inet::Packet);
         @signal[edcaCollisionDetected](type=unsigned long);
         @signal[frameSequenceStarted];
         @signal[frameSequenceFinished];

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -17,8 +17,8 @@
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
 #include "inet/networklayer/common/NetworkInterface.h"
-#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
 
 namespace inet {
 
@@ -51,9 +51,7 @@ void Ieee80211MgmtAp::initialize(int stage)
         numAuthSteps = par("numAuthSteps");
         if (numAuthSteps != 2 && numAuthSteps != 4)
             throw cRuntimeError("parameter 'numAuthSteps' (number of frames exchanged during authentication) must be 2 or 4, not %d", numAuthSteps);
-        channelNumber = -1; // value will arrive from physical layer in receiveChangeNotification()
         WATCH(ssid);
-        WATCH(channelNumber);
         WATCH(beaconInterval);
         WATCH(numAuthSteps);
         WATCH(staList);
@@ -82,17 +80,6 @@ void Ieee80211MgmtAp::handleTimer(cMessage *msg)
 void Ieee80211MgmtAp::handleCommand(int msgkind, cObject *ctrl)
 {
     throw cRuntimeError("handleCommand(): no commands supported");
-}
-
-void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details)
-{
-    Enter_Method("%s", cComponent::getSignalName(signalID));
-
-    if (signalID == Ieee80211Radio::radioChannelChangedSignal) {
-        EV << "updating channel number\n";
-        channelNumber = value;
-    }
-    Ieee80211MgmtApBase::receiveSignal(source, signalID, value, details);
 }
 
 void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
@@ -141,12 +128,17 @@ void Ieee80211MgmtAp::sendManagementFrame(const char *name, const Ptr<Ieee80211M
 void Ieee80211MgmtAp::sendBeacon()
 {
     EV << "Sending beacon\n";
+    // Generic radios may not publish an IEEE channel; retain the legacy unknown value.
+    int primaryChannel = mib->hasPrimaryChannel() ? mib->requirePrimaryChannel() : -1;
     const auto& body = makeShared<Ieee80211BeaconFrame>();
     body->setSSID(ssid.c_str());
     setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
-    body->setChannelNumber(channelNumber);
-    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body));
+    body->setChannelNumber(primaryChannel);
+    addHtCapabilities(body);
+    if (mib->isHtOperationSupported())
+        setHtOperation(body, getHtOperationBand(), mib->getHtOperation());
+    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("Beacon", body, ST_BEACON, MacAddress::BROADCAST_ADDRESS);
 }
 
@@ -337,12 +329,17 @@ void Ieee80211MgmtAp::handleProbeRequestFrame(Packet *packet, const Ptr<const Ie
     delete packet;
 
     EV << "Sending ProbeResponse frame\n";
+    // Generic radios may not publish an IEEE channel; retain the legacy unknown value.
+    int primaryChannel = mib->hasPrimaryChannel() ? mib->requirePrimaryChannel() : -1;
     const auto& body = makeShared<Ieee80211ProbeResponseFrame>();
     body->setSSID(ssid.c_str());
     setSupportedRateElements(body);
     body->setBeaconInterval(beaconInterval);
-    body->setChannelNumber(channelNumber);
-    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body));
+    body->setChannelNumber(primaryChannel);
+    addHtCapabilities(body);
+    if (mib->isHtOperationSupported())
+        setHtOperation(body, getHtOperationBand(), mib->getHtOperation());
+    body->setChunkLength(B(8 + 2 + 2 + (2 + ssid.length())) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
     sendManagementFrame("ProbeResp", body, ST_PROBERESPONSE, staAddress);
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -12,12 +12,12 @@
 #include "inet/linklayer/ethernet/common/EthernetMacHeader_m.h"
 #endif // ifdef INET_WITH_ETHERNET
 
-#include "inet/linklayer/ieee80211/mac/contract/IFrameSequenceHandler.h"
-#include "inet/linklayer/ieee80211/mac/framesequence/FrameSequenceContext.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
 #include "inet/linklayer/ieee80211/mac/Ieee80211SubtypeTag_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
 #include "inet/networklayer/common/NetworkInterface.h"
 
 namespace inet {
@@ -58,11 +58,10 @@ void Ieee80211MgmtAp::initialize(int stage)
 
         // TODO fill in supportedRates
 
-        // subscribe for notifications
-        getContainingNicModule(this)->subscribe(IFrameSequenceHandler::frameSequenceFinishedSignal, this);
-
         // start beacon timer (randomize startup time)
         beaconTimer = new cMessage("beaconTimer");
+        auto macModule = getModuleFromPar<cModule>(par("macModule"), this);
+        macModule->subscribe(Ieee80211Mac::frameTransmissionOutcomeSignal, this);
     }
 }
 
@@ -84,30 +83,88 @@ void Ieee80211MgmtAp::handleCommand(int msgkind, cObject *ctrl)
 
 void Ieee80211MgmtAp::receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details)
 {
-    Enter_Method("%s", cComponent::getSignalName(signalID));
-
-    if (signalID == IFrameSequenceHandler::frameSequenceFinishedSignal) {
-        auto context = check_and_cast<FrameSequenceContext *>(obj);
-        if (context->getNumSteps() >= 2) {
-            auto transmitStep = dynamic_cast<ITransmitStep *>(context->getStepBeforeLast());
-            auto receiveStep = dynamic_cast<IReceiveStep *>(context->getLastStep());
-            if (transmitStep && receiveStep &&
-                transmitStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED &&
-                receiveStep->getCompletion() == IFrameSequenceStep::Completion::ACCEPTED) {
-                auto responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(transmitStep->getFrameToTransmit()->peekAtFront<Ieee80211MacHeader>());
-                if (responseHeader != nullptr && (responseHeader->getType() == ST_ASSOCIATIONRESPONSE || responseHeader->getType() == ST_REASSOCIATIONRESPONSE)) {
-                    auto ackHeader = receiveStep->getReceivedFrame()->peekAtFront<Ieee80211MacHeader>();
-                    if (ackHeader->getType() == ST_ACK) {
-                        if (responseHeader->getType() == ST_ASSOCIATIONRESPONSE && mib->bssAccessPointData.stations[responseHeader->getReceiverAddress()] != Ieee80211Mib::ASSOCIATED)
-                            sendAssocNotification(responseHeader->getReceiverAddress());
-                        mib->bssAccessPointData.stations[responseHeader->getReceiverAddress()] = Ieee80211Mib::ASSOCIATED;
-                    }
-                }
-            }
-        }
+    if (signalID == Ieee80211Mac::frameTransmissionOutcomeSignal) {
+        Enter_Method("%s", cComponent::getSignalName(signalID));
+        auto packet = check_and_cast_nullable<const Packet *>(obj);
+        auto transDetails = check_and_cast<const FrameTransmissionDetails *>(details);
+        frameTransmissionFinished(packet, transDetails->getStatus());
     }
     else
         Ieee80211MgmtApBase::receiveSignal(source, signalID, obj, details);
+}
+
+Ieee80211MgmtAp::AssociationResponseDisposition Ieee80211MgmtAp::getAssociationResponseDisposition(const Packet *responseFrame,
+        uint64_t pendingTransactionId, FrameTransmissionStatus status)
+{
+    if (responseFrame == nullptr || pendingTransactionId == 0)
+        return AssociationResponseDisposition::IGNORE;
+    const auto& transactionTag = responseFrame->findTag<Ieee80211MgmtTransactionTag>();
+    if (transactionTag == nullptr || transactionTag->getTransactionId() != pendingTransactionId)
+        return AssociationResponseDisposition::IGNORE;
+    const auto& frontChunk = responseFrame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR);
+    const auto& responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(frontChunk);
+    if (responseHeader == nullptr || (responseHeader->getType() != ST_ASSOCIATIONRESPONSE && responseHeader->getType() != ST_REASSOCIATIONRESPONSE))
+        return AssociationResponseDisposition::IGNORE;
+    if (status == FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED && responseHeader->getMoreFragments())
+        return AssociationResponseDisposition::RETAIN;
+    return AssociationResponseDisposition::COMPLETE;
+}
+
+void Ieee80211MgmtAp::frameTransmissionFinished(const Packet *responseFrame, FrameTransmissionStatus status)
+{
+    Enter_Method("frameTransmissionFinished");
+    if (responseFrame == nullptr)
+        return;
+    const auto& responseHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(responseFrame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR));
+    if (responseHeader == nullptr || (responseHeader->getType() != ST_ASSOCIATIONRESPONSE && responseHeader->getType() != ST_REASSOCIATIONRESPONSE))
+        return;
+    auto address = responseHeader->getReceiverAddress();
+    auto sta = staList.find(address);
+    uint64_t pendingTransactionId = sta == staList.end() ? 0 : sta->second.pendingAssociationTransactionId;
+    auto disposition = getAssociationResponseDisposition(responseFrame, pendingTransactionId, status);
+    if (disposition == AssociationResponseDisposition::IGNORE)
+        return;
+    ASSERT(sta != staList.end());
+    if (disposition == AssociationResponseDisposition::RETAIN)
+        return;
+
+    if (status == FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) {
+        if (sta->second.pendingAssociationSuccessful) {
+            bool wasAssociated = mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED;
+            mib->commitAssociationId(address);
+            mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
+            if (sta->second.pendingHtStateAvailable) {
+                // IEEE Std 802.11-2024, 11.3.5.3: association state becomes effective only after the successful response exchange.
+                if (sta->second.pendingHtCapabilitiesValid) {
+                    ASSERT(sta->second.pendingHtOperationValid);
+                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, sta->second.pendingHtOperation);
+                }
+                else
+                    mib->removePeerHtCapabilities(address);
+            }
+            clearPendingAssociation(&sta->second);
+            // Signal delivery is synchronous; observers must see committed
+            // station/peer state and no pending response transaction.
+            if (!wasAssociated)
+                sendAssocNotification(address);
+        }
+        else if (mib->bssAccessPointData.stations[address] == Ieee80211Mib::ASSOCIATED) {
+            // This model does not implement negotiated management-frame protection.
+            // IEEE Std 802.11-2024, 11.3.5.3(p) for association and 11.3.5.5(n)
+            // for same-AP reassociation therefore require the existing association
+            // state to be cleared after this acknowledged refusal.
+            mib->releaseAssociationId(address);
+            mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+            clearPendingAssociation(&sta->second);
+            // Signal delivery is synchronous; observers must see the complete
+            // downgraded state and no pending response transaction.
+            sendDisAssocNotification(address);
+        }
+        else
+            clearPendingAssociation(&sta->second);
+    }
+    else
+        clearPendingAssociation(&sta->second);
 }
 
 Ieee80211MgmtAp::StaInfo *Ieee80211MgmtAp::lookupSenderSTA(const Ptr<const Ieee80211MgmtHeader>& header)
@@ -116,13 +173,34 @@ Ieee80211MgmtAp::StaInfo *Ieee80211MgmtAp::lookupSenderSTA(const Ptr<const Ieee8
     return it == staList.end() ? nullptr : &(it->second);
 }
 
-void Ieee80211MgmtAp::sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr)
+void Ieee80211MgmtAp::sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr, uint64_t transactionId)
 {
     auto packet = new Packet(name);
     packet->addTag<MacAddressReq>()->setDestAddress(destAddr);
     packet->addTag<Ieee80211SubtypeReq>()->setSubtype(subtype);
     packet->insertAtBack(body);
+    if (transactionId != 0)
+        packet->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
     sendDown(packet);
+}
+
+uint64_t Ieee80211MgmtAp::createAssociationTransactionId()
+{
+    if (++nextAssociationTransactionId == 0)
+        ++nextAssociationTransactionId;
+    return nextAssociationTransactionId;
+}
+
+void Ieee80211MgmtAp::clearPendingAssociation(StaInfo *sta)
+{
+    mib->cancelAssociationIdReservation(sta->address);
+    sta->pendingAssociationSuccessful = false;
+    sta->pendingAssociationTransactionId = 0;
+    sta->pendingHtStateAvailable = false;
+    sta->pendingHtCapabilitiesValid = false;
+    sta->pendingHtCapabilities = Ieee80211HtCapabilities();
+    sta->pendingHtOperationValid = false;
+    sta->pendingHtOperation = Ieee80211HtOperation();
 }
 
 void Ieee80211MgmtAp::sendBeacon()
@@ -165,12 +243,19 @@ void Ieee80211MgmtAp::handleAuthenticationFrame(Packet *packet, const Ptr<const 
     // receives authentication frame number 1 from STA, which will cause the AP to return an Auth-Error
     // making the MN STA to start the handover process all over again.
     if (frameAuthSeq == 1) {
-        if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
-            sendDisAssocNotification(sta->address);
+        // INET policy: an accepted new authentication sequence supersedes any
+        // association response that is still owned by the MAC. IEEE 802.11-2024
+        // 11.3.4 does not require an associated peer to downgrade on frame 1;
+        // keep this cancellation scoped to this existing model transition.
+        clearPendingAssociation(sta);
+        bool wasAssociated = mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED;
+        if (wasAssociated)
             mib->releaseAssociationId(sta->address);
-        }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::NOT_AUTHENTICATED;
+        mib->removePeerHtCapabilities(sta->address);
         sta->authSeqExpected = 1;
+        if (wasAssociated)
+            sendDisAssocNotification(sta->address);
     }
 
     // check authentication sequence number is OK
@@ -202,11 +287,13 @@ void Ieee80211MgmtAp::handleAuthenticationFrame(Packet *packet, const Ptr<const 
 
     // update status
     if (isLast) {
-        if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
-            sendDisAssocNotification(sta->address);
+        bool wasAssociated = mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED;
+        if (wasAssociated)
             mib->releaseAssociationId(sta->address);
-        }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::AUTHENTICATED; // TODO only when ACK of this frame arrives
+        mib->removePeerHtCapabilities(sta->address);
+        if (wasAssociated)
+            sendDisAssocNotification(sta->address);
         EV << "STA authenticated\n";
     }
     else {
@@ -223,13 +310,16 @@ void Ieee80211MgmtAp::handleDeauthenticationFrame(Packet *packet, const Ptr<cons
     delete packet;
 
     if (sta) {
+        clearPendingAssociation(sta);
+        bool wasAssociated = mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED;
         // mark STA as not authenticated; alternatively, it could also be removed from staList
-        if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
-            sendDisAssocNotification(sta->address);
+        if (wasAssociated)
             mib->releaseAssociationId(sta->address);
-        }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::NOT_AUTHENTICATED;
         sta->authSeqExpected = 1;
+        mib->removePeerHtCapabilities(sta->address);
+        if (wasAssociated)
+            sendDisAssocNotification(sta->address);
     }
 }
 
@@ -239,6 +329,15 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
 
     // "11.3.2 AP association procedures"
     StaInfo *sta = lookupSenderSTA(header);
+    if (sta != nullptr && sta->pendingAssociationTransactionId != 0) {
+        // A response transaction is MAC-owned until its terminal completion.
+        // Coalesce a retransmitted request instead of replacing its response
+        // or allocating another association ID.
+        delete packet;
+        return;
+    }
+    if (sta != nullptr)
+        clearPendingAssociation(sta);
     if (!sta || mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::NOT_AUTHENTICATED) {
         // STA not authenticated: send error and return
         const auto& body = makeShared<Ieee80211DeauthenticationFrame>();
@@ -248,15 +347,58 @@ void Ieee80211MgmtAp::handleAssociationRequestFrame(Packet *packet, const Ptr<co
         return;
     }
 
+    const auto& requestBody = packet->peekData<Ieee80211AssociationRequestFrame>();
+    bool pendingHtOperationValid = mib->isHtOperationSupported();
+    Ieee80211HtOperation pendingHtOperation;
+    if (pendingHtOperationValid)
+        pendingHtOperation = mib->getHtOperation();
+    bool htCapabilitiesPresent = requestBody->getHtCapabilitiesPresent();
+    bool pendingHtCapabilitiesValid = false;
+    Ieee80211HtCapabilities pendingHtCapabilities;
+    bool htCapabilitiesMalformed = false;
+    std::string htCapabilitiesError;
+    if (pendingHtOperationValid && htCapabilitiesPresent) {
+        if (decodeHtCapabilities(requestBody->getHtCapabilities(), pendingHtCapabilities, htCapabilitiesError))
+            pendingHtCapabilitiesValid = true;
+        else {
+            EV_WARN << "Malformed HT Capabilities in AssociationRequest from "
+                    << header->getTransmitterAddress() << ": " << htCapabilitiesError << "\n";
+            htCapabilitiesMalformed = true;
+        }
+    }
+    bool basicHtMcsSupported = !htCapabilitiesMalformed &&
+            (!pendingHtCapabilitiesValid || supportsBasicHtMcsSet(pendingHtCapabilities, pendingHtOperation));
     delete packet;
 
-    // send OK response
+    // IEEE Std 802.11-2024, 11.3.5.3 g): an HT STA must support every Basic HT-MCS.
     const auto& body = makeShared<Ieee80211AssociationResponseFrame>();
-    body->setStatusCode(SC_SUCCESSFUL);
-    body->setAid(mib->allocateAssociationId(sta->address));
+    // Constructing an HT response requires an authoritative primary channel.
+    // Do this before reserving an AID or publishing pending transaction state,
+    // so an unavailable channel cannot leave a half-created association.
+    if (pendingHtOperationValid) {
+        auto responseHtOperation = pendingHtOperation;
+        responseHtOperation.basicMcsSupported.fill(false);
+        setHtOperation(body, getHtOperationBand(), responseHtOperation);
+    }
+    Ieee80211StatusCode statusCode = htCapabilitiesMalformed ? SC_UNSUP_CAP :
+            (basicHtMcsSupported ? SC_SUCCESSFUL : SC_DATARATE_UNSUP);
+    body->setStatusCode(statusCode);
+    bool associationSuccessful = statusCode == SC_SUCCESSFUL;
+    short associationId = associationSuccessful ? mib->reserveAssociationId(sta->address) : 0;
+    body->setAid(associationId);
+    sta->pendingAssociationSuccessful = associationSuccessful;
+    sta->pendingHtStateAvailable = true;
+    sta->pendingHtCapabilitiesValid = pendingHtCapabilitiesValid;
+    sta->pendingHtCapabilities = pendingHtCapabilities;
+    sta->pendingHtOperationValid = pendingHtOperationValid;
+    sta->pendingHtOperation = pendingHtOperation;
+    sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
-    sendManagementFrame("AssocResp-OK", body, ST_ASSOCIATIONRESPONSE, sta->address);
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
+    const char *frameName = associationSuccessful ? "AssocResp-OK" :
+            (htCapabilitiesMalformed ? "AssocResp-UnsupportedHtCap" : "AssocResp-UnsupportedHtMcs");
+    sendManagementFrame(frameName, body, ST_ASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
 
 void Ieee80211MgmtAp::handleAssociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -270,6 +412,12 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
 
     // "11.3.4 AP reassociation procedures" -- almost the same as AssociationRequest processing
     StaInfo *sta = lookupSenderSTA(header);
+    if (sta != nullptr && sta->pendingAssociationTransactionId != 0) {
+        delete packet;
+        return;
+    }
+    if (sta != nullptr)
+        clearPendingAssociation(sta);
     if (!sta || mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::NOT_AUTHENTICATED) {
         // STA not authenticated: send error and return
         const auto& body = makeShared<Ieee80211DeauthenticationFrame>();
@@ -279,15 +427,57 @@ void Ieee80211MgmtAp::handleReassociationRequestFrame(Packet *packet, const Ptr<
         return;
     }
 
+    const auto& requestBody = packet->peekData<Ieee80211ReassociationRequestFrame>();
+    bool pendingHtOperationValid = mib->isHtOperationSupported();
+    Ieee80211HtOperation pendingHtOperation;
+    if (pendingHtOperationValid)
+        pendingHtOperation = mib->getHtOperation();
+    bool htCapabilitiesPresent = requestBody->getHtCapabilitiesPresent();
+    bool pendingHtCapabilitiesValid = false;
+    Ieee80211HtCapabilities pendingHtCapabilities;
+    bool htCapabilitiesMalformed = false;
+    std::string htCapabilitiesError;
+    if (pendingHtOperationValid && htCapabilitiesPresent) {
+        if (decodeHtCapabilities(requestBody->getHtCapabilities(), pendingHtCapabilities, htCapabilitiesError))
+            pendingHtCapabilitiesValid = true;
+        else {
+            EV_WARN << "Malformed HT Capabilities in ReassociationRequest from "
+                    << header->getTransmitterAddress() << ": " << htCapabilitiesError << "\n";
+            htCapabilitiesMalformed = true;
+        }
+    }
+    bool basicHtMcsSupported = !htCapabilitiesMalformed &&
+            (!pendingHtCapabilitiesValid || supportsBasicHtMcsSet(pendingHtCapabilities, pendingHtOperation));
     delete packet;
 
     // send OK response
     const auto& body = makeShared<Ieee80211ReassociationResponseFrame>();
-    body->setStatusCode(SC_SUCCESSFUL);
-    body->setAid(mib->allocateAssociationId(sta->address));
+    // See the association response path above: fail while constructing the
+    // response, before mutating association bookkeeping.
+    if (pendingHtOperationValid) {
+        auto responseHtOperation = pendingHtOperation;
+        responseHtOperation.basicMcsSupported.fill(false);
+        setHtOperation(body, getHtOperationBand(), responseHtOperation);
+    }
+    Ieee80211StatusCode statusCode = htCapabilitiesMalformed ? SC_UNSUP_CAP :
+            (basicHtMcsSupported ? SC_SUCCESSFUL : SC_DATARATE_UNSUP);
+    body->setStatusCode(statusCode);
+    bool associationSuccessful = statusCode == SC_SUCCESSFUL;
+    short associationId = associationSuccessful ? mib->reserveAssociationId(sta->address) : 0;
+    body->setAid(associationId);
+    sta->pendingAssociationSuccessful = associationSuccessful;
+    sta->pendingHtStateAvailable = true;
+    sta->pendingHtCapabilitiesValid = pendingHtCapabilitiesValid;
+    sta->pendingHtCapabilities = pendingHtCapabilities;
+    sta->pendingHtOperationValid = pendingHtOperationValid;
+    sta->pendingHtOperation = pendingHtOperation;
+    sta->pendingAssociationTransactionId = createAssociationTransactionId();
     setSupportedRateElements(body);
-    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body));
-    sendManagementFrame("ReassocResp-OK", body, ST_REASSOCIATIONRESPONSE, sta->address);
+    addHtCapabilities(body);
+    body->setChunkLength(B(2 + 2 + 2) + getSupportedRateElementsLength(body) + getHtMgmtElementsLength(body));
+    const char *frameName = associationSuccessful ? "ReassocResp-OK" :
+            (htCapabilitiesMalformed ? "ReassocResp-UnsupportedHtCap" : "ReassocResp-UnsupportedHtMcs");
+    sendManagementFrame(frameName, body, ST_REASSOCIATIONRESPONSE, sta->address, sta->pendingAssociationTransactionId);
 }
 
 void Ieee80211MgmtAp::handleReassociationResponseFrame(Packet *packet, const Ptr<const Ieee80211MgmtHeader>& header)
@@ -301,11 +491,14 @@ void Ieee80211MgmtAp::handleDisassociationFrame(Packet *packet, const Ptr<const 
     delete packet;
 
     if (sta) {
-        if (mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED) {
-            sendDisAssocNotification(sta->address);
+        clearPendingAssociation(sta);
+        bool wasAssociated = mib->bssAccessPointData.stations[sta->address] == Ieee80211Mib::ASSOCIATED;
+        if (wasAssociated)
             mib->releaseAssociationId(sta->address);
-        }
         mib->bssAccessPointData.stations[sta->address] = Ieee80211Mib::AUTHENTICATED;
+        mib->removePeerHtCapabilities(sta->address);
+        if (wasAssociated)
+            sendDisAssocNotification(sta->address);
     }
 }
 
@@ -374,7 +567,8 @@ void Ieee80211MgmtAp::stop()
 {
     cancelEvent(beaconTimer);
     staList.clear();
-    mib->bssAccessPointData.associationIds.clear();
+    nextAssociationTransactionId = 0;
+    mib->clearAssociationIds();
     Ieee80211MgmtApBase::stop();
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
@@ -51,7 +51,6 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
   protected:
     // configuration
     std::string ssid;
-    int channelNumber = -1;
     simtime_t beaconInterval;
     int numAuthSteps = 0;
 
@@ -73,8 +72,7 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     /** Implements abstract Ieee80211MgmtBase method -- throws an error (no commands supported) */
     virtual void handleCommand(int msgkind, cObject *ctrl) override;
 
-    /** Called by the signal handler whenever a change occurs we're interested in */
-    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override;
+    using Ieee80211MgmtApBase::receiveSignal;
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
 
     /** Utility function: return sender STA's entry from our STA list, or nullptr if not in there */

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h
@@ -10,6 +10,7 @@
 
 #include <map>
 
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
 #include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.h"
 
 namespace inet {
@@ -22,11 +23,25 @@ namespace ieee80211 {
  */
 class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
 {
+  protected:
+    enum class AssociationResponseDisposition {
+        IGNORE,
+        RETAIN,
+        COMPLETE,
+    };
+
   public:
     /** Describes a STA */
     struct StaInfo {
         MacAddress address;
         int authSeqExpected; // when NOT_AUTHENTICATED: transaction sequence number of next expected auth frame
+        bool pendingAssociationSuccessful = false;
+        uint64_t pendingAssociationTransactionId = 0;
+        bool pendingHtStateAvailable = false;
+        bool pendingHtCapabilitiesValid = false;
+        Ieee80211HtCapabilities pendingHtCapabilities;
+        bool pendingHtOperationValid = false;
+        Ieee80211HtOperation pendingHtOperation;
 //        int consecFailedTrans; // TODO
 //        double expiry; // TODO association should expire after a while if STA is silent?
     };
@@ -57,6 +72,7 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     // state
     StaList staList; ///< list of STAs
     cMessage *beaconTimer = nullptr;
+    uint64_t nextAssociationTransactionId = 0;
 
   public:
     Ieee80211MgmtAp() {}
@@ -75,11 +91,20 @@ class INET_API Ieee80211MgmtAp : public Ieee80211MgmtApBase
     using Ieee80211MgmtApBase::receiveSignal;
     virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
 
+    virtual void frameTransmissionFinished(const Packet *responseFrame, FrameTransmissionStatus status);
+
     /** Utility function: return sender STA's entry from our STA list, or nullptr if not in there */
     virtual StaInfo *lookupSenderSTA(const Ptr<const Ieee80211MgmtHeader>& header);
 
     /** Utility function: set fields in the given frame and send it out to the address */
-    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr);
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype, const MacAddress& destAddr, uint64_t transactionId = 0);
+
+    virtual uint64_t createAssociationTransactionId();
+    virtual void clearPendingAssociation(StaInfo *sta);
+
+    /** Classifies a terminal management-MPDU result using its transaction tag and fragment state. */
+    static AssociationResponseDisposition getAssociationResponseDisposition(const Packet *responseFrame,
+            uint64_t pendingTransactionId, FrameTransmissionStatus status);
 
     /** Utility function: creates and sends a beacon frame */
     virtual void sendBeacon();

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -30,6 +30,7 @@ void Ieee80211Mib::initialize(int stage)
         WATCH(bssStationData.isAssociated);
         WATCH(bssAccessPointData.stations);
         WATCH(bssAccessPointData.associationIds);
+        WATCH(associationIdReservations);
         WATCH_EXPR("modeStr", getModeStr(mode));
         WATCH_EXPR("stationTypeStr", getStationTypeStr(bssStationData.stationType));
         WATCH_EXPR("qosStr", qos ? ", QoS" : ", Non-QoS");
@@ -194,30 +195,75 @@ const char *Ieee80211Mib::getStationTypeStr(Ieee80211Mib::BssStationType station
     }
 }
 
-short Ieee80211Mib::allocateAssociationId(const MacAddress& address)
+short Ieee80211Mib::reserveAssociationId(const MacAddress& address)
 {
-    auto existing = bssAccessPointData.associationIds.find(address);
-    if (existing != bssAccessPointData.associationIds.end())
-        return existing->second;
+    // IEEE Std 802.11-2024, 9.4.1.8: an AP assigns AID values in the range 1 through 2007.
+    auto committed = bssAccessPointData.associationIds.find(address);
+    if (committed != bssAccessPointData.associationIds.end())
+        return committed->second;
+    auto reserved = associationIdReservations.find(address);
+    if (reserved != associationIdReservations.end())
+        return reserved->second;
+
+    std::array<bool, 2008> used = {};
+    for (const auto& entry : bssAccessPointData.associationIds)
+        if (entry.second >= 1 && entry.second <= 2007)
+            used[entry.second] = true;
+    for (const auto& entry : associationIdReservations)
+        if (entry.second >= 1 && entry.second <= 2007)
+            used[entry.second] = true;
     for (short aid = 1; aid <= 2007; aid++) {
-        bool used = false;
-        for (const auto& entry : bssAccessPointData.associationIds)
-            if (entry.second == aid) {
-                used = true;
-                break;
-            }
-        if (!used) {
-            bssAccessPointData.associationIds[address] = aid;
+        if (!used[aid]) {
+            associationIdReservations[address] = aid;
             return aid;
         }
     }
     throw cRuntimeError("No IEEE 802.11 association ID is available");
 }
 
+short Ieee80211Mib::commitAssociationId(const MacAddress& address)
+{
+    auto committed = bssAccessPointData.associationIds.find(address);
+    if (committed != bssAccessPointData.associationIds.end()) {
+        associationIdReservations.erase(address);
+        return committed->second;
+    }
+    auto reserved = associationIdReservations.find(address);
+    if (reserved == associationIdReservations.end())
+        throw cRuntimeError("No IEEE 802.11 association ID is reserved for %s", address.str().c_str());
+    short aid = reserved->second;
+    for (const auto& entry : bssAccessPointData.associationIds)
+        if (entry.second == aid)
+            throw cRuntimeError("Reserved IEEE 802.11 association ID %d is already committed", aid);
+    bssAccessPointData.associationIds[address] = aid;
+    associationIdReservations.erase(reserved);
+    return aid;
+}
+
+void Ieee80211Mib::cancelAssociationIdReservation(const MacAddress& address)
+{
+    associationIdReservations.erase(address);
+}
+
+short Ieee80211Mib::allocateAssociationId(const MacAddress& address)
+{
+    reserveAssociationId(address);
+    return commitAssociationId(address);
+}
+
 void Ieee80211Mib::releaseAssociationId(const MacAddress& address)
 {
+    associationIdReservations.erase(address);
     bssAccessPointData.associationIds.erase(address);
     removePeerHtCapabilities(address);
+}
+
+void Ieee80211Mib::clearAssociationIds()
+{
+    bssAccessPointData.stations.clear();
+    associationIdReservations.clear();
+    bssAccessPointData.associationIds.clear();
+    clearPeerHtCapabilities();
 }
 
 } // namespace ieee80211

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
@@ -82,6 +82,7 @@ class INET_API Ieee80211Mib : public SimpleModule
   private:
     Ieee80211HtOperation htOperation;
     bool primaryChannelAvailable = false;
+    std::map<MacAddress, short> associationIdReservations;
     std::map<MacAddress, PeerHtState> peerHtStates;
 
   protected:
@@ -91,8 +92,12 @@ class INET_API Ieee80211Mib : public SimpleModule
     static const char *getModeStr(Ieee80211Mib::Mode mode);
     static const char *getStationTypeStr(Ieee80211Mib::BssStationType stationType);
     std::string getSsidStr() const;
+    short reserveAssociationId(const MacAddress& address);
+    short commitAssociationId(const MacAddress& address);
+    void cancelAssociationIdReservation(const MacAddress& address);
     short allocateAssociationId(const MacAddress& address);
     void releaseAssociationId(const MacAddress& address);
+    void clearAssociationIds();
     void updateLocalHtCapabilities(const physicallayer::Ieee80211ModeSet *modeSet,
             const std::set<Hz>& operationalChannelWidths, int operationalHtSpatialStreamLimit);
     bool isHtOperationSupported() const { return localHtCapabilitiesValid; }

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Receiver.h
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Receiver.h
@@ -49,3 +49,4 @@ class INET_API Ieee80211Receiver : public FlatReceiverBase
 } // namespace inet
 
 #endif
+

--- a/tests/fingerprint/store.json
+++ b/tests/fingerprint/store.json
@@ -55,7 +55,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "3e42-6e3c",
+  "fingerprint": "b364-e54a",
   "timestamp": 1681992799.9495935,
   "itervars": "$repetition==0"
  },
@@ -103,7 +103,7 @@
   "sim_time_limit": "1000s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "26e4-a191",
+  "fingerprint": "8668-d4e7",
   "timestamp": 1681992799.9509377,
   "itervars": "$repetition==0"
  },
@@ -1207,7 +1207,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "e4f0-d0a0",
+  "fingerprint": "4c65-91ae",
   "timestamp": 1681992799.9826574,
   "itervars": "$repetition==0"
  },
@@ -1255,7 +1255,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "e4f0-d0a0",
+  "fingerprint": "4c65-91ae",
   "timestamp": 1681992799.98157,
   "itervars": "$repetition==0"
  },
@@ -1303,7 +1303,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "e4f0-d0a0",
+  "fingerprint": "4c65-91ae",
   "timestamp": 1681992799.9840045,
   "itervars": "$repetition==0"
  },
@@ -1399,7 +1399,7 @@
   "sim_time_limit": "5000s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "692e-b59f",
+  "fingerprint": "df67-0fe0",
   "timestamp": 1681992799.985232,
   "itervars": "$repetition==0"
  },
@@ -1447,7 +1447,7 @@
   "sim_time_limit": "500s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "eedb-ac8a",
+  "fingerprint": "c440-71e7",
   "timestamp": 1681992799.9870448,
   "itervars": "$repetition==0"
  },
@@ -1495,7 +1495,7 @@
   "sim_time_limit": "500s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "9099-bbb8",
+  "fingerprint": "a931-fbf9",
   "timestamp": 1681992799.9861557,
   "itervars": "$repetition==0"
  },
@@ -8023,7 +8023,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "75d0-cba9",
+  "fingerprint": "d3d9-7959",
   "timestamp": 1681992800.0367525,
   "itervars": "$repetition==0"
  },
@@ -16039,7 +16039,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "4d24-d5b6",
+  "fingerprint": "a35f-3c51",
   "timestamp": 1681992800.3045096,
   "itervars": "$repetition==0"
  },
@@ -16159,7 +16159,7 @@
   "sim_time_limit": "22s",
   "test_result": "ERROR",
   "ingredients": "tplx",
-  "fingerprint": "5fe9-22ea",
+  "fingerprint": "1e32-4f69",
   "timestamp": 1681992800.3171349,
   "itervars": "$repetition==0"
  },
@@ -16267,7 +16267,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8ec2-b70f",
+  "fingerprint": "d3ef-c8cf",
   "timestamp": 1681992800.3085063,
   "itervars": "$repetition==0"
  },
@@ -16303,7 +16303,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "b832-1954",
+  "fingerprint": "0354-6dd4",
   "timestamp": 1681992800.3148339,
   "itervars": "$repetition==0"
  },
@@ -16339,7 +16339,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "40d1-e3f0",
+  "fingerprint": "b346-3570",
   "timestamp": 1681992800.31257,
   "itervars": "$repetition==0"
  },
@@ -16375,7 +16375,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8ec2-b70f",
+  "fingerprint": "d3ef-c8cf",
   "timestamp": 1681992800.3137789,
   "itervars": "$repetition==0"
  },
@@ -16483,7 +16483,7 @@
   "sim_time_limit": "20s",
   "test_result": "ERROR",
   "ingredients": "tplx",
-  "fingerprint": "0000-0000",
+  "fingerprint": "6299-3bf9",
   "timestamp": 1681992800.3321059,
   "itervars": "$repetition==0"
  },
@@ -16591,7 +16591,7 @@
   "sim_time_limit": "20s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "6f35-2f25",
+  "fingerprint": "5a83-8612",
   "timestamp": 1681992800.32101,
   "itervars": "$repetition==0"
  },
@@ -16663,7 +16663,7 @@
   "sim_time_limit": "20s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "d87a-f4ab",
+  "fingerprint": "5c6b-556c",
   "timestamp": 1681992800.3262296,
   "itervars": "$repetition==0"
  },
@@ -16699,7 +16699,7 @@
   "sim_time_limit": "20s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "6ae2-6e71",
+  "fingerprint": "d4a1-5cf9",
   "timestamp": 1681992800.3233144,
   "itervars": "$repetition==0"
  },
@@ -16735,7 +16735,7 @@
   "sim_time_limit": "20s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "6f35-2f25",
+  "fingerprint": "5a83-8612",
   "timestamp": 1681992800.3244052,
   "itervars": "$repetition==0"
  },
@@ -35371,7 +35371,7 @@
   "sim_time_limit": "1500s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "7cc6-715e",
+  "fingerprint": "eee3-0da3",
   "timestamp": 1681992800.5725446,
   "itervars": "$repetition==0"
  },
@@ -35515,7 +35515,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "7ba1-5f14",
+  "fingerprint": "774c-9780",
   "timestamp": 1681992800.581954,
   "itervars": "$repetition==0"
  },
@@ -35551,7 +35551,7 @@
   "sim_time_limit": "50s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "6bec-e742",
+  "fingerprint": "7517-ff4b",
   "timestamp": 1681992800.5835197,
   "itervars": "$repetition==0"
  },
@@ -35623,7 +35623,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "c9a8-e487",
+  "fingerprint": "bb14-f903",
   "timestamp": 1681992800.58698,
   "itervars": "$repetition==0"
  },
@@ -36031,7 +36031,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "aa02-d13c",
+  "fingerprint": "5582-99d1",
   "timestamp": 1681992800.613443,
   "itervars": "$repetition==0"
  },
@@ -36079,7 +36079,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "aa02-d13c",
+  "fingerprint": "5582-99d1",
   "timestamp": 1681992800.6099937,
   "itervars": "$repetition==0"
  },
@@ -36127,7 +36127,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "aa02-d13c",
+  "fingerprint": "5582-99d1",
   "timestamp": 1681992800.6069913,
   "itervars": "$repetition==0"
  },
@@ -36175,7 +36175,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "c6b1-9638",
+  "fingerprint": "2db0-de11",
   "timestamp": 1681992800.6396616,
   "itervars": "$repetition==0"
  },
@@ -36211,7 +36211,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "c6b1-9638",
+  "fingerprint": "2db0-de11",
   "timestamp": 1681992800.6365852,
   "itervars": "$repetition==0"
  },
@@ -36247,7 +36247,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8192-d648",
+  "fingerprint": "7743-0a38",
   "timestamp": 1681992800.6330538,
   "itervars": "$repetition==0"
  },
@@ -36283,7 +36283,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "499d-93c4",
+  "fingerprint": "2be3-22d6",
   "timestamp": 1681992800.6233041,
   "itervars": "$repetition==0"
  },
@@ -36331,7 +36331,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "499d-93c4",
+  "fingerprint": "2be3-22d6",
   "timestamp": 1681992800.6220226,
   "itervars": "$repetition==0"
  },
@@ -36379,7 +36379,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "499d-93c4",
+  "fingerprint": "2be3-22d6",
   "timestamp": 1681992800.6209667,
   "itervars": "$repetition==0"
  },
@@ -36427,7 +36427,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "5365-9610",
+  "fingerprint": "4397-39a5",
   "timestamp": 1681992800.629837,
   "itervars": "$repetition==0"
  },
@@ -36463,7 +36463,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "5365-9610",
+  "fingerprint": "4397-39a5",
   "timestamp": 1681992800.6275058,
   "itervars": "$repetition==0"
  },
@@ -36499,7 +36499,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "5365-9610",
+  "fingerprint": "4397-39a5",
   "timestamp": 1681992800.6249704,
   "itervars": "$repetition==0"
  },
@@ -36583,7 +36583,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "ac49-fb67",
+  "fingerprint": "ac92-009c",
   "timestamp": 1681992800.6555994,
   "itervars": "$repetition==0"
  },
@@ -36631,7 +36631,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "4828-9707",
+  "fingerprint": "1e64-2bbd",
   "timestamp": 1681992800.6573653,
   "itervars": "$repetition==0"
  },
@@ -36679,7 +36679,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "4f6c-58ca",
+  "fingerprint": "18e0-fd73",
   "timestamp": 1681992800.6531584,
   "itervars": "$repetition==0"
  },
@@ -36727,7 +36727,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "340e-9ace",
+  "fingerprint": "78f9-82af",
   "timestamp": 1681992800.6199017,
   "itervars": "$repetition==0"
  },
@@ -36763,7 +36763,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "340e-9ace",
+  "fingerprint": "78f9-82af",
   "timestamp": 1681992800.6183043,
   "itervars": "$repetition==0"
  },
@@ -36799,7 +36799,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "ae44-849a",
+  "fingerprint": "27ba-6e6a",
   "timestamp": 1681992800.6160967,
   "itervars": "$repetition==0"
  },
@@ -36835,7 +36835,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "37a8-c2c5",
+  "fingerprint": "c1b4-d21b",
   "timestamp": 1681992800.6482565,
   "itervars": "$repetition==0"
  },
@@ -36883,7 +36883,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "37a8-c2c5",
+  "fingerprint": "c1b4-d21b",
   "timestamp": 1681992800.6458638,
   "itervars": "$repetition==0"
  },
@@ -36931,7 +36931,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "37a8-c2c5",
+  "fingerprint": "c1b4-d21b",
   "timestamp": 1681992800.6424267,
   "itervars": "$repetition==0"
  },
@@ -37147,7 +37147,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8ba5-cbbd",
+  "fingerprint": "f252-8a4b",
   "timestamp": 1681992800.6690032,
   "itervars": "$repetition==0"
  },
@@ -37195,7 +37195,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "5e57-04bd",
+  "fingerprint": "31b0-6212",
   "timestamp": 1681992800.6730847,
   "itervars": "$repetition==0"
  },
@@ -37243,7 +37243,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8306-3cd3",
+  "fingerprint": "d094-b008",
   "timestamp": 1681992800.6819687,
   "itervars": "$repetition==0"
  },
@@ -37291,7 +37291,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "b762-75c3",
+  "fingerprint": "9ece-fbfb",
   "timestamp": 1681992800.6788037,
   "itervars": "$repetition==0"
  },
@@ -37339,7 +37339,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "4119-7162",
+  "fingerprint": "acd6-0108",
   "timestamp": 1681992800.6757183,
   "itervars": "$repetition==0"
  },
@@ -37747,7 +37747,7 @@
   "sim_time_limit": "2s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8a77-1ff3",
+  "fingerprint": "6f66-ec37",
   "timestamp": 1681992800.7077973,
   "itervars": "$repetition==0"
  },
@@ -41575,7 +41575,7 @@
   "sim_time_limit": "500s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "96f0-642e",
+  "fingerprint": "6362-d00a",
   "timestamp": 1681992799.6278305,
   "itervars": "$repetition==0"
  },
@@ -41755,7 +41755,7 @@
   "sim_time_limit": "5s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "aaa1-4cb4",
+  "fingerprint": "5f98-cd05",
   "timestamp": 1681992799.629166,
   "itervars": "$repetition==0"
  },
@@ -41803,7 +41803,7 @@
   "sim_time_limit": "5s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "6f7b-642f",
+  "fingerprint": "d8ed-768c",
   "timestamp": 1681992799.6288059,
   "itervars": "$repetition==0"
  },
@@ -41851,7 +41851,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "0c7a-d45b",
+  "fingerprint": "8782-6f1c",
   "timestamp": 1681992799.6298487,
   "itervars": "$repetition==0"
  },
@@ -41899,7 +41899,7 @@
   "sim_time_limit": "250s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "0712-b574",
+  "fingerprint": "0f01-f016",
   "timestamp": 1681992799.629509,
   "itervars": "$repetition==0"
  },
@@ -41995,7 +41995,7 @@
   "sim_time_limit": "5s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "f8cd-9bfe",
+  "fingerprint": "dfdf-7e0e",
   "timestamp": 1681992799.631983,
   "itervars": "$repetition==0"
  },
@@ -42139,7 +42139,7 @@
   "sim_time_limit": "250s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "4f8d-b26b",
+  "fingerprint": "94b6-d4ca",
   "timestamp": 1681992799.6370811,
   "itervars": "$repetition==0"
  },
@@ -42235,7 +42235,7 @@
   "sim_time_limit": "500s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "8323-4f51",
+  "fingerprint": "cbb7-c036",
   "timestamp": 1681992799.636637,
   "itervars": "$repetition==0"
  },
@@ -42511,7 +42511,7 @@
   "sim_time_limit": "2002ms",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "3995-cc34",
+  "fingerprint": "835e-80ed",
   "timestamp": 1681992799.6375818,
   "itervars": "$repetition==0"
  },
@@ -42607,7 +42607,7 @@
   "sim_time_limit": "250s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "1c3a-6a2f",
+  "fingerprint": "b91f-f443",
   "timestamp": 1681992799.6401956,
   "itervars": "$repetition==0"
  },
@@ -42655,7 +42655,7 @@
   "sim_time_limit": "500s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "73db-6871",
+  "fingerprint": "a437-919f",
   "timestamp": 1681992799.640631,
   "itervars": "$repetition==0"
  },
@@ -43243,7 +43243,7 @@
   "sim_time_limit": "25s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "d182-c474",
+  "fingerprint": "9349-7ae5",
   "timestamp": 1681992799.6503963,
   "itervars": "$repetition==0"
  },
@@ -45895,7 +45895,7 @@
   "sim_time_limit": "250s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "47b6-4dfd",
+  "fingerprint": "b287-6940",
   "timestamp": 1681992799.6907628,
   "itervars": "$repetition==0"
  },
@@ -46171,7 +46171,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "0d58-00d3",
+  "fingerprint": "6f2f-9b0b",
   "timestamp": 1681992799.695733,
   "itervars": "$repetition==0"
  },
@@ -46303,7 +46303,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "f7da-716f",
+  "fingerprint": "37fd-5401",
   "timestamp": 1681992799.6971657,
   "itervars": "$repetition==0"
  },
@@ -46351,7 +46351,7 @@
   "sim_time_limit": "10s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "1294-b639",
+  "fingerprint": "1a49-72b3",
   "timestamp": 1681992799.6976697,
   "itervars": "$repetition==0"
  },
@@ -46975,7 +46975,7 @@
   "sim_time_limit": "5s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "9fdc-f33e",
+  "fingerprint": "d2b6-a5d1",
   "timestamp": 1681992799.7074933,
   "itervars": "$repetition==0"
  },
@@ -50179,7 +50179,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "e6ab-f59b",
+  "fingerprint": "a186-bbc1",
   "timestamp": 1681992799.8166804,
   "itervars": "$repetition==0"
  },
@@ -50707,7 +50707,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "84ac-6cbf",
+  "fingerprint": "f99c-9e43",
   "timestamp": 1681992799.805858,
   "itervars": "$repetition==0"
  },
@@ -50755,7 +50755,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "e6d7-97c8",
+  "fingerprint": "6daa-17f7",
   "timestamp": 1681992799.806759,
   "itervars": "$repetition==0"
  },
@@ -50803,7 +50803,7 @@
   "sim_time_limit": "100s",
   "test_result": "PASS",
   "ingredients": "tplx",
-  "fingerprint": "daa5-f273",
+  "fingerprint": "7f72-228e",
   "timestamp": 1681992799.808365,
   "itervars": "$repetition==0"
  },

--- a/tests/module/Ieee80211FrameTransmissionStats_1.test
+++ b/tests/module/Ieee80211FrameTransmissionStats_1.test
@@ -1,0 +1,192 @@
+%description:
+Verify that Dcf/Hcf frameTransmissionOutcome emissions with FrameTransmissionDetails
+propagate to the parent MAC and
+are properly filtered by frameTransmissionStatusIs* result filters and recorded
+by the @statistic declarations on Ieee80211Mac (frameTransmissionOutcome,
+frameAcked, frameRetryLimitReached, and frameDroppedBeforeTx).
+
+%file: TestIeee80211FrameTransmissionStats.cc
+
+#include <omnetpp/cresultfilter.h>
+#include <omnetpp/resultrecorders.h>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/ByteCountChunk.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class Ieee80211FrameTransmissionStatsTest : public cSimpleModule
+{
+  public:
+    Ieee80211FrameTransmissionStatsTest() : cSimpleModule(65536) {}
+
+  protected:
+    TotalCountRecorder *findCountRecorder(cResultListener *resultListener, const char *statisticName)
+    {
+        if (auto recorder = dynamic_cast<TotalCountRecorder *>(resultListener)) {
+            if (!strcmp(statisticName, recorder->getStatisticName()))
+                return recorder;
+            return nullptr;
+        }
+        else if (auto resultFilter = dynamic_cast<cResultFilter *>(resultListener)) {
+            for (auto delegate : resultFilter->getDelegates()) {
+                auto found = findCountRecorder(delegate, statisticName);
+                if (found != nullptr)
+                    return found;
+            }
+        }
+        return nullptr;
+    }
+
+    virtual void activity() override
+    {
+        // 1. Verify result filter factory registrations
+        ASSERT(cResultFilterType::find("frameTransmissionStatusIsAcknowledged") != nullptr);
+        ASSERT(cResultFilterType::find("frameTransmissionStatusIsRetryLimitReached") != nullptr);
+        ASSERT(cResultFilterType::find("frameTransmissionStatusIsDroppedBeforeTransmission") != nullptr);
+
+        // 2. Locate MAC and its signal listeners on Ieee80211Mac::frameTransmissionOutcomeSignal
+        auto mac = check_and_cast<Ieee80211Mac *>(getModuleByPath("^.ap.wlan[0].mac"));
+        auto listeners = mac->getLocalSignalListeners(Ieee80211Mac::frameTransmissionOutcomeSignal);
+        ASSERT(!listeners.empty());
+
+        TotalCountRecorder *outcomeRecorder = nullptr;
+        TotalCountRecorder *ackRecorder = nullptr;
+        TotalCountRecorder *retryRecorder = nullptr;
+        TotalCountRecorder *dropRecorder = nullptr;
+
+        for (auto listener : listeners) {
+            if (auto resultListener = dynamic_cast<cResultListener *>(listener)) {
+                if (!outcomeRecorder)
+                    outcomeRecorder = findCountRecorder(resultListener, "frameTransmissionOutcome");
+                if (!ackRecorder)
+                    ackRecorder = findCountRecorder(resultListener, "frameAcked");
+                if (!retryRecorder)
+                    retryRecorder = findCountRecorder(resultListener, "frameRetryLimitReached");
+                if (!dropRecorder)
+                    dropRecorder = findCountRecorder(resultListener, "frameDroppedBeforeTx");
+            }
+        }
+
+        ASSERT(outcomeRecorder != nullptr);
+        ASSERT(outcomeRecorder->getCount() == 0);
+        ASSERT(ackRecorder != nullptr);
+        ASSERT(retryRecorder != nullptr);
+        ASSERT(dropRecorder != nullptr);
+
+        ASSERT(ackRecorder->getCount() == 0);
+        ASSERT(retryRecorder->getCount() == 0);
+        ASSERT(dropRecorder->getCount() == 0);
+
+        auto dcf = mac->getSubmodule("dcf");
+        auto hcf = mac->getSubmodule("hcf");
+        ASSERT(dcf != nullptr && hcf != nullptr);
+        FrameTransmissionDetails details;
+
+        // 3. Emit status=ACKNOWLEDGED
+        auto packet1 = new Packet("frame1");
+        packet1->insertAtBack(makeShared<ByteCountChunk>(B(100)));
+        details.setStatus(FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        dcf->emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet1, &details);
+        delete packet1;
+
+        ASSERT(ackRecorder->getCount() == 1);
+        ASSERT(retryRecorder->getCount() == 0);
+        ASSERT(dropRecorder->getCount() == 0);
+
+        // 4. Emit status=RETRY_LIMIT_REACHED
+        auto packet2 = new Packet("frame2");
+        packet2->insertAtBack(makeShared<ByteCountChunk>(B(200)));
+        details.setStatus(FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+        hcf->emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet2, &details);
+        delete packet2;
+
+        ASSERT(ackRecorder->getCount() == 1);
+        ASSERT(retryRecorder->getCount() == 1);
+        ASSERT(dropRecorder->getCount() == 0);
+
+        // 5. Emit status=DROPPED_BEFORE_TRANSMISSION
+        auto packet3 = new Packet("frame3");
+        packet3->insertAtBack(makeShared<ByteCountChunk>(B(300)));
+        details.setStatus(FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+        dcf->emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet3, &details);
+        delete packet3;
+
+        ASSERT(ackRecorder->getCount() == 1);
+        ASSERT(retryRecorder->getCount() == 1);
+        ASSERT(dropRecorder->getCount() == 1);
+
+        // 6. Emit another ACKNOWLEDGED and another DROPPED_BEFORE_TRANSMISSION
+        auto packet4 = new Packet("frame4");
+        packet4->insertAtBack(makeShared<ByteCountChunk>(B(150)));
+        details.setStatus(FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        hcf->emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet4, &details);
+        delete packet4;
+
+        auto packet5 = new Packet("frame5");
+        packet5->insertAtBack(makeShared<ByteCountChunk>(B(250)));
+        details.setStatus(FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+        hcf->emit(Ieee80211Mac::frameTransmissionOutcomeSignal, packet5, &details);
+        delete packet5;
+
+        ASSERT(ackRecorder->getCount() == 2);
+        ASSERT(retryRecorder->getCount() == 1);
+        ASSERT(dropRecorder->getCount() == 2);
+
+        ASSERT(outcomeRecorder->getCount() == 5);
+
+        std::cout << "Frame transmission statistics and result filters verified.\n";
+    }
+};
+
+Define_Module(Ieee80211FrameTransmissionStatsTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple Ieee80211FrameTransmissionStatsTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211FrameTransmissionStatsTest);
+}
+
+network Ieee80211FrameTransmissionStatsTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint;
+        test: Ieee80211FrameTransmissionStatsTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211FrameTransmissionStatsTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-scalar-results = true
+record-vector-results = true
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].mac.qosStation = true
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+
+%contains: stdout
+Frame transmission statistics and result filters verified.

--- a/tests/module/Ieee80211HcfInternalCollision_1.test
+++ b/tests/module/Ieee80211HcfInternalCollision_1.test
@@ -1,0 +1,146 @@
+%description:
+Exercise the HCF internal-collision recovery owner with an AC_VO management
+frame. The colliding EDCAF's station retry counters must be used, retry-limit
+drop must occur, and the typed terminal callback must be delivered exactly once.
+
+%file: TestIeee80211HcfInternalCollision.cc
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mac/coordinationfunction/Hcf.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211HcfInternalCollision : public Hcf
+{
+  public:
+    void injectVoManagementCollision(const MacAddress& receiverAddress)
+    {
+        Enter_Method("injectVoManagementCollision");
+        auto packet = new Packet("internally-collided-management");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_ASSOCIATIONRESPONSE);
+        header->setReceiverAddress(receiverAddress);
+        packet->insertAtFront(header);
+        auto edcaf = edca->getEdcaf(AccessCategory::AC_VO);
+        edcaf->getPendingQueue()->enqueuePacket(packet);
+        handleInternalCollision({edcaf});
+    }
+
+    int getStationShortRetryCount(AccessCategory ac) const
+    {
+        return edca->getEdcaf(ac)->getStationRetryCounters()->getStationShortRetryCount();
+    }
+};
+
+Define_Module(TestIeee80211HcfInternalCollision);
+
+class TestIeee80211MgmtApInternalCollision : public Ieee80211MgmtAp
+{
+  public:
+    int terminalCallbacks = 0;
+    FrameTransmissionStatus lastStatus = FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED;
+
+  protected:
+    virtual void frameTransmissionFinished(const Packet *responseFrame, FrameTransmissionStatus status) override
+    {
+        terminalCallbacks++;
+        lastStatus = status;
+        Ieee80211MgmtAp::frameTransmissionFinished(responseFrame, status);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApInternalCollision);
+
+class Ieee80211HcfInternalCollisionTest : public cSimpleModule
+{
+  public:
+    Ieee80211HcfInternalCollisionTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto hcf = check_and_cast<TestIeee80211HcfInternalCollision *>(getModuleByPath("^.ap.wlan[0].mac.hcf"));
+        auto mgmt = check_and_cast<TestIeee80211MgmtApInternalCollision *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        ASSERT(hcf->getStationShortRetryCount(AccessCategory::AC_BE) == 0);
+        ASSERT(hcf->getStationShortRetryCount(AccessCategory::AC_VO) == 0);
+
+        hcf->injectVoManagementCollision(MacAddress("02:00:00:00:00:09"));
+
+        ASSERT(hcf->getStationShortRetryCount(AccessCategory::AC_BE) == 0);
+        ASSERT(hcf->getStationShortRetryCount(AccessCategory::AC_VO) == 1);
+        ASSERT(mgmt->terminalCallbacks == 1);
+        ASSERT(mgmt->lastStatus == FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+        std::cout << "HCF AC_VO management internal-collision retry ownership verified.\n";
+    }
+};
+
+Define_Module(Ieee80211HcfInternalCollisionTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mac.coordinationfunction.Hcf;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+module TestIeee80211HcfInternalCollision extends Hcf
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211HcfInternalCollision);
+}
+
+simple TestIeee80211MgmtApInternalCollision extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApInternalCollision);
+}
+
+simple Ieee80211HcfInternalCollisionTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211HcfInternalCollisionTest);
+}
+
+network Ieee80211HcfInternalCollisionTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApInternalCollision";
+                wlan[*].mac.qosStation = true;
+                wlan[*].mac.hcf.typename = "TestIeee80211HcfInternalCollision";
+        }
+        test: Ieee80211HcfInternalCollisionTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211HcfInternalCollisionTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 1ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].mac.hcf.rtsPolicy.rtsThreshold = 4096B
+*.ap.wlan[0].mac.hcf.edca.mgmtAndNonQoSRecoveryProcedure.shortRetryLimit = 1
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+HCF AC_VO management internal-collision retry ownership verified.

--- a/tests/module/Ieee80211HtAntennaRateControl_1.test
+++ b/tests/module/Ieee80211HtAntennaRateControl_1.test
@@ -1,0 +1,279 @@
+%description:
+Verify that a one-antenna HT station advertises only its operational spatial
+stream capability, while peer-aware rate selection keeps data transmissions
+within that capability after a full infrastructure association.
+
+%file: Ieee80211HtAntennaRateControl.cc
+
+#include <utility>
+#include <vector>
+
+#include "inet/applications/udpapp/UdpSink.h"
+#include "inet/common/SimpleModule.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
+#include "inet/linklayer/ieee80211/mac/ratecontrol/AarfRateControl.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class RecordingAarfRateControl : public AarfRateControl
+{
+  public:
+    std::vector<int> rawHtMcs;
+
+    virtual const physicallayer::IIeee80211Mode *getRate(const MacAddress& receiverAddress) override
+    {
+        auto mode = AarfRateControl::getRate(receiverAddress);
+        if (mode->getHtMcsIndex() >= 0)
+            rawHtMcs.push_back(mode->getHtMcsIndex());
+        return mode;
+    }
+};
+
+Define_Module(RecordingAarfRateControl);
+
+class RecordingIeee80211Mac : public Ieee80211Mac
+{
+  public:
+    std::vector<std::pair<int, int>> transmittedDataModes;
+
+  protected:
+    virtual void sendDownFrame(Packet *frame) override
+    {
+        const auto& header = frame->peekAtFront<Ieee80211MacHeader>();
+        if (auto dataHeader = dynamicPtrCast<const Ieee80211DataHeader>(header)) {
+            ASSERT(!dataHeader->getReceiverAddress().isMulticast());
+            const auto& modeReq = frame->findTag<physicallayer::Ieee80211ModeReq>();
+            ASSERT(modeReq != nullptr);
+            const auto *mode = modeReq->getMode();
+            ASSERT(mode != nullptr);
+            transmittedDataModes.emplace_back(mode->getHtMcsIndex(), mode->getDataMode()->getNumberOfSpatialStreams());
+        }
+        Ieee80211Mac::sendDownFrame(frame);
+    }
+};
+
+Define_Module(RecordingIeee80211Mac);
+
+class CheckingUdpSink : public UdpSink
+{
+  public:
+    int getNumReceivedForTest() const { return numReceived; }
+};
+
+Define_Module(CheckingUdpSink);
+
+class Ieee80211HtAntennaRateControlTest : public cSimpleModule
+{
+  protected:
+    static void checkCapabilities(const Ieee80211HtCapabilities& capabilities)
+    {
+        ASSERT(capabilities.txMcsSetDefined);
+        ASSERT(!capabilities.txRxMcsSetNotEqual);
+        ASSERT(capabilities.txMaxNss == 0);
+        ASSERT(!capabilities.txUnequalModulation);
+        ASSERT(capabilities.supportedChannelWidths.count(MHz(20)) == 1);
+        ASSERT(capabilities.supportedChannelWidths.count(MHz(40)) == 0);
+        ASSERT(capabilities.txMcsNss.maxMcsPerNss[0] == 7);
+        for (int nss = 1; nss < 4; nss++)
+            ASSERT(capabilities.txMcsNss.maxMcsPerNss[nss] == -1);
+        for (int mcs = 0; mcs < 77; mcs++)
+            ASSERT(capabilities.rxMcsSupported[mcs] == (mcs < 8));
+    }
+
+    static void checkBasicMcs(const Ieee80211HtOperation& operation)
+    {
+        for (int mcs = 0; mcs < 77; mcs++)
+            ASSERT(operation.basicMcsSupported[mcs] == (mcs < 8));
+    }
+
+    virtual void finish() override
+    {
+        auto staInterface = getModuleByPath("^.sta.wlan[0]");
+        auto apInterface = getModuleByPath("^.ap.wlan[0]");
+        auto staRadio = check_and_cast<physicallayer::IRadio *>(staInterface->getSubmodule("radio"));
+        auto apRadio = check_and_cast<physicallayer::IRadio *>(apInterface->getSubmodule("radio"));
+        ASSERT(staRadio->getAntenna()->getNumAntennas() == 1);
+        ASSERT(apRadio->getAntenna()->getNumAntennas() == 1);
+
+        auto staMib = check_and_cast<Ieee80211Mib *>(staInterface->getSubmodule("mib"));
+        auto apMib = check_and_cast<Ieee80211Mib *>(apInterface->getSubmodule("mib"));
+        ASSERT(staMib->bssStationData.isAssociated);
+        ASSERT(apMib->bssAccessPointData.stations.at(staMib->address) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(staMib->localHtCapabilitiesValid);
+        ASSERT(apMib->localHtCapabilitiesValid);
+        checkCapabilities(staMib->localHtCapabilities);
+        checkCapabilities(apMib->localHtCapabilities);
+        checkBasicMcs(apMib->getHtOperation());
+
+        auto staPeer = staMib->findPeerHtState(apMib->address);
+        auto apPeer = apMib->findPeerHtState(staMib->address);
+        ASSERT(staPeer != nullptr);
+        ASSERT(apPeer != nullptr);
+        checkCapabilities(staPeer->advertisedCapabilities);
+        checkBasicMcs(staPeer->negotiatedCapabilities.operation);
+        checkCapabilities(apPeer->advertisedCapabilities);
+        checkBasicMcs(apPeer->negotiatedCapabilities.operation);
+        for (int mcs = 8; mcs < 77; mcs++) {
+            ASSERT(!staPeer->negotiatedCapabilities.localTxPeerRx.supportedMcs[mcs]);
+            ASSERT(!staPeer->negotiatedCapabilities.localRxPeerTx.supportedMcs[mcs]);
+            ASSERT(!apPeer->negotiatedCapabilities.localTxPeerRx.supportedMcs[mcs]);
+            ASSERT(!apPeer->negotiatedCapabilities.localRxPeerTx.supportedMcs[mcs]);
+        }
+
+        auto rateControl = check_and_cast<RecordingAarfRateControl *>(getModuleByPath("^.sta.wlan[0].mac.dcf.rateControl"));
+        bool sawLowMcs = false;
+        bool advancedBeyondLowMcs = false;
+        for (int mcs : rateControl->rawHtMcs) {
+            if (mcs <= 7)
+                sawLowMcs = true;
+            else if (sawLowMcs) {
+                advancedBeyondLowMcs = true;
+                break;
+            }
+        }
+        ASSERT(sawLowMcs);
+        ASSERT(advancedBeyondLowMcs);
+        auto mac = check_and_cast<RecordingIeee80211Mac *>(staInterface->getSubmodule("mac"));
+        ASSERT(!mac->transmittedDataModes.empty());
+        for (const auto& mode : mac->transmittedDataModes) {
+            ASSERT(mode.first >= 0 && mode.first <= 7);
+            ASSERT(mode.second == 1);
+        }
+
+        auto sink = check_and_cast<CheckingUdpSink *>(getModuleByPath("^.server.app[0]"));
+        ASSERT(sink->getNumReceivedForTest() > 0);
+        std::cout << "HT antenna-limited capabilities, peer-safe data modes, delivery, and no transmitter exception verified.\n";
+    }
+};
+
+Define_Module(Ieee80211HtAntennaRateControlTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.applications.udpapp.UdpSink;
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mac.Ieee80211Mac;
+import inet.linklayer.ieee80211.mac.ratecontrol.AarfRateControl;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.ethernet.Eth100M;
+import inet.node.inet.StandardHost;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+module RecordingIeee80211Mac extends Ieee80211Mac
+{
+    parameters:
+        @class(::inet::ieee80211::RecordingIeee80211Mac);
+}
+
+simple RecordingAarfRateControl extends AarfRateControl
+{
+    parameters:
+        @class(::inet::ieee80211::RecordingAarfRateControl);
+}
+
+simple CheckingUdpSink extends UdpSink
+{
+    parameters:
+        @class(::inet::ieee80211::CheckingUdpSink);
+}
+
+simple Ieee80211HtAntennaRateControlTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211HtAntennaRateControlTest);
+}
+
+network Ieee80211HtAntennaRateControlTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        configurator: Ipv4NetworkConfigurator;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtSta";
+                wlan[*].agent.typename = "Ieee80211AgentSta";
+                wlan[*].mac.typename = "RecordingIeee80211Mac";
+        }
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtAp";
+        }
+        server: StandardHost;
+        test: Ieee80211HtAntennaRateControlTest;
+    connections:
+        ap.ethg++ <--> Eth100M <--> server.ethg++;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211HtAntennaRateControlTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 100ms
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+*.configurator.addStaticRoutes = true
+*.configurator.assignDisjunctSubnetAddresses = false
+**.arp.typename = "GlobalArp"
+
+**.mobility.initFromDisplayString = false
+**.sta.mobility.initialX = 10m
+**.sta.mobility.initialY = 10m
+**.ap.mobility.initialX = 20m
+**.ap.mobility.initialY = 10m
+
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = -1bps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+*.sta.wlan[0].radio.channelNumber = 6
+*.ap.wlan[0].radio.channelNumber = 6
+**.radio.transmitter.power = 100mW
+**.radio.receiver.sensitivity = -85dBm
+**.radio.receiver.snirThreshold = 4dB
+
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:02"
+*.ap.wlan[0].mgmt.ssid = "ht-rate-control"
+*.ap.wlan[0].mgmt.beaconInterval = 5ms
+*.sta.wlan[0].mgmt.numChannels = 1
+*.sta.wlan[0].agent.startingTime = 0s
+*.sta.wlan[0].agent.defaultSsid = "ht-rate-control"
+*.sta.wlan[0].agent.channelsToScan = "6"
+*.sta.wlan[0].agent.probeDelay = 1ms
+*.sta.wlan[0].agent.minChannelTime = 5ms
+*.sta.wlan[0].agent.maxChannelTime = 5ms
+*.sta.wlan[0].agent.authenticationTimeout = 20ms
+*.sta.wlan[0].agent.associationTimeout = 20ms
+
+*.sta.wlan[0].mac.dcf.rateControl.typename = "RecordingAarfRateControl"
+*.sta.wlan[0].mac.dcf.rateControl.initialRate = 65Mbps
+*.sta.wlan[0].mac.dcf.rateControl.interval = 1ms
+*.sta.wlan[0].mac.dcf.rateControl.increaseThreshold = 1
+*.sta.wlan[0].mac.dcf.rateSelection.dataFrameBitrate = -1bps
+
+*.sta.numApps = 1
+*.sta.app[0].typename = "UdpBasicApp"
+*.sta.app[0].destAddresses = "server"
+*.sta.app[0].destPort = 5000
+*.sta.app[0].messageLength = 1000B
+*.sta.app[0].sendInterval = 1ms
+*.sta.app[0].startTime = 40ms
+*.sta.app[0].stopTime = 90ms
+*.server.numApps = 1
+*.server.app[0].typename = "CheckingUdpSink"
+*.server.app[0].localPort = 5000
+
+%contains: stdout
+HT antenna-limited capabilities, peer-safe data modes, delivery, and no transmitter exception verified.

--- a/tests/module/Ieee80211HtAssociation_1.test
+++ b/tests/module/Ieee80211HtAssociation_1.test
@@ -1,0 +1,272 @@
+%description:
+Verify the RTS/CTS-protected detailed IEEE 802.11 management exchange carries
+the standard HT element presence matrix and commits mutually usable peer state
+at both ends.
+
+%file: Ieee80211HtAssociationChecker.cc
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Mac.h"
+#include "inet/common/Simsignals.h"
+#include "inet/common/SimpleModule.h"
+#include "inet/common/packet/Packet.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtFrame_m.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+class Ieee80211HcfRtsFailureMac : public Ieee80211Mac
+{
+  protected:
+    bool firstRtsBlocked = false;
+
+    virtual void handleLowerPacket(Packet *packet) override
+    {
+        const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+        if (!firstRtsBlocked && header->getType() == ST_RTS) {
+            firstRtsBlocked = true;
+            EV_INFO << "Intentionally blocking the first RTS frame.\n";
+            delete packet;
+        }
+        else
+            Ieee80211Mac::handleLowerPacket(packet);
+    }
+};
+
+Define_Module(Ieee80211HcfRtsFailureMac);
+
+class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
+{
+    using cListener::finish;
+
+  protected:
+    int apAssociationNotifications = 0;
+    bool associationResponseWireChannelChecked = false;
+    bool staTunedToInternalChannelSix = false;
+    cMessage *channelChangeTimer = nullptr;
+    cModule *apQosEdcaf = nullptr;
+
+  public:
+    virtual ~Ieee80211HtAssociationChecker()
+    {
+        if (channelChangeTimer != nullptr)
+            cancelAndDelete(channelChangeTimer);
+    }
+
+  protected:
+    virtual void initialize() override
+    {
+        getModuleByPath("^.ap.wlan[0].mgmt")->subscribe(l2ApAssociatedSignal, this);
+        apQosEdcaf = getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3]");
+        apQosEdcaf->subscribe(packetSentToPeerSignal, this);
+        auto staRadio = getModuleByPath("^.sta.wlan[0].radio");
+        staRadio->subscribe(physicallayer::Ieee80211Radio::radioChannelChangedSignal, this);
+        channelChangeTimer = new cMessage("channelChange");
+    }
+
+    virtual void handleMessage(cMessage *message) override
+    {
+        if (message != channelChangeTimer)
+            throw cRuntimeError("Unexpected message");
+        auto apMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto apRadio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.ap.wlan[0].radio"));
+        auto staRadio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.sta.wlan[0].radio"));
+        ASSERT(apMib->requirePrimaryChannel() == 6);
+        apRadio->setChannelNumber(11);
+        // Keep the response exchange on-air after the AP's channel update so
+        // the terminal ACK can still be received while the pending operation
+        // snapshot is committed.
+        staRadio->setChannelNumber(11);
+        ASSERT(apMib->requirePrimaryChannel() == 11);
+        delete message;
+        channelChangeTimer = nullptr;
+        std::cout << "AP primary channel follows a dynamic radio change from 6 to 11 before association ACK.\n";
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (source == apQosEdcaf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE) {
+                const auto& responseBody = packet->peekAt<Ieee80211AssociationResponseFrame>(header->getChunkLength());
+                ASSERT(responseBody->getHtOperationPresent());
+                ASSERT(responseBody->getHtOperation().primaryChannel == 7);
+                for (bool supported : responseBody->getHtOperation().basicMcsSupported)
+                    ASSERT(!supported);
+                associationResponseWireChannelChecked = true;
+                if (channelChangeTimer != nullptr && !channelChangeTimer->isScheduled())
+                    scheduleAfter(SimTime(1, SIMTIME_US), channelChangeTimer);
+            }
+        }
+        else if (signalID == l2ApAssociatedSignal)
+            apAssociationNotifications++;
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, intval_t value, cObject *details) override
+    {
+        if (source == getModuleByPath("^.sta.wlan[0].radio") &&
+                signalID == physicallayer::Ieee80211Radio::radioChannelChangedSignal && value == 6)
+            staTunedToInternalChannelSix = true;
+    }
+
+    virtual void finish() override
+    {
+        auto apMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto staMib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.sta.wlan[0].mib"));
+        const auto& staAddress = staMib->address;
+        ASSERT(apMib->requirePrimaryChannel() == 11);
+        ASSERT(channelChangeTimer == nullptr);
+        ASSERT(apMib->bssAccessPointData.stations.at(staAddress) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(apMib->bssAccessPointData.associationIds.at(staAddress) != 0);
+        ASSERT(apMib->findPeerHtState(staAddress) != nullptr);
+        ASSERT(apMib->findPeerHtState(staAddress)->valid);
+        ASSERT(associationResponseWireChannelChecked);
+        ASSERT(staTunedToInternalChannelSix);
+        ASSERT(apMib->hasPrimaryChannel());
+        ASSERT(apMib->requirePrimaryChannel() == 11);
+        ASSERT(apMib->findPeerHtState(staAddress)->negotiatedCapabilities.operation.primaryChannel == 6);
+        ASSERT(staMib->bssStationData.isAssociated);
+        // IEEE Std 802.11-2024, 9.4.2.54.2/Figure 9-456 and Table 9-224: the n(mixed-2.4Ghz)
+        // profile exposes short GI for the PHY-supported 20 MHz width. The
+        // mode catalog also describes 40 MHz modes, but the current packet PHY
+        // cannot operate a primary/secondary compound channel and must not
+        // advertise that width.
+        ASSERT(staMib->localHtCapabilities.shortGi20);
+        ASSERT(!staMib->localHtCapabilities.shortGi40);
+        ASSERT(apMib->localHtCapabilities.shortGi20);
+        ASSERT(!apMib->localHtCapabilities.shortGi40);
+        ASSERT(staMib->localHtCapabilities.supportedChannelWidths.count(MHz(20)) == 1);
+        ASSERT(staMib->localHtCapabilities.supportedChannelWidths.count(MHz(40)) == 0);
+        // Bridge the MIB-derived capability contract to the actual management
+        // frame serializer: the n(mixed-2.4Ghz) profile must advertise only
+        // PHY-supported short-GI bits in HT Capabilities (IEEE Std 802.11-2024, 9.4.2.54.2,
+        // Figure 9-456 and Table 9-224).
+        auto serializedResponse = makeShared<Ieee80211AssociationResponseFrame>();
+        serializedResponse->setStatusCode(SC_SUCCESSFUL);
+        serializedResponse->setAid(1);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        serializedResponse->setSupportedRates(rates);
+        setHtCapabilities(serializedResponse, staMib->localHtCapabilities);
+        serializedResponse->setChunkLength(B(37)); // fixed fields/rates (9) + HT Capabilities IE (28)
+        Packet serializedPacket("mib-ht-capabilities", serializedResponse);
+        auto serializedBytes = serializedPacket.peekAllAsBytes()->getBytes();
+        ASSERT(serializedBytes.size() == 37);
+        ASSERT(serializedBytes[9] == 45 && serializedBytes[10] == 26);
+        ASSERT((serializedBytes[11] & (1 << 5)) != 0);
+        ASSERT((serializedBytes[11] & (1 << 6)) == 0);
+        ASSERT(staMib->findPeerHtState(apMib->address) != nullptr);
+        ASSERT(staMib->findPeerHtState(apMib->address)->valid);
+        ASSERT(staMib->findPeerHtState(apMib->address)->negotiatedCapabilities.operation.primaryChannel == 6);
+        ASSERT(apAssociationNotifications == 1);
+        EV << "RTS-protected association committed at AP and STA.\n";
+    }
+};
+
+Define_Module(Ieee80211HtAssociationChecker);
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mac.Ieee80211Mac;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+module Ieee80211HcfRtsFailureMac extends Ieee80211Mac
+{
+    parameters:
+        @class(::Ieee80211HcfRtsFailureMac);
+}
+
+simple Ieee80211HtAssociationChecker extends SimpleModule
+{
+    parameters:
+        @class(::Ieee80211HtAssociationChecker);
+}
+
+network Ieee80211HtAssociationTest
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtSta";
+                wlan[*].agent.typename = "Ieee80211AgentSta";
+                wlan[*].mac.typename = "Ieee80211HcfRtsFailureMac";
+        }
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtAp";
+                wlan[*].radio.channelNumber = 6;
+        }
+        test: Ieee80211HtAssociationChecker;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211HtAssociationTest
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50ms
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+**.constraintAreaMinX = 0m
+**.constraintAreaMinY = 0m
+**.constraintAreaMinZ = 0m
+**.constraintAreaMaxX = 100m
+**.constraintAreaMaxY = 100m
+**.constraintAreaMaxZ = 0m
+*.sta.mobility.initialX = 10m
+*.sta.mobility.initialY = 10m
+*.ap.mobility.initialX = 20m
+*.ap.mobility.initialY = 10m
+**.mobility.initialZ = 0m
+
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+*.sta.wlan[0].radio.channelNumber = 6
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.antenna.numAntennas = 1
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+
+**.mgmt.numChannels = 1
+*.ap.wlan[*].mac.qosStation = true
+*.ap.wlan[*].mac.dcf.rtsPolicy.rtsThreshold = 0B
+*.ap.wlan[*].mac.hcf.rtsPolicy.rtsThreshold = 0B
+*.ap.wlan[*].mac.hcf.rateControl.typename = "AarfRateControl"
+*.sta.wlan[*].agent.startingTime = 0s
+*.sta.wlan[*].agent.channelsToScan = "6"
+*.sta.wlan[*].agent.probeDelay = 1ms
+*.sta.wlan[*].agent.minChannelTime = 5ms
+*.sta.wlan[*].agent.maxChannelTime = 5ms
+*.sta.wlan[*].agent.authenticationTimeout = 20ms
+*.sta.wlan[*].agent.associationTimeout = 20ms
+
+%contains: stdout
+Association successful, AP address=
+
+%contains-regex: stdout
+Assoc .*?Ieee80211AssociationRequestFrame.*?htCapabilitiesPresent.*?true.*?htOperationPresent.*?false
+
+%contains-regex: stdout
+AssocResp-OK .*?Ieee80211AssociationResponseFrame.*?htCapabilitiesPresent.*?true.*?htOperationPresent.*?true
+
+%contains: stdout
+Installed peer HT state, peer =
+
+%contains: stdout
+Intentionally blocking the first RTS frame.
+
+%contains: stdout
+RTS-protected association committed at AP and STA.

--- a/tests/module/Ieee80211MgmtApGenericRadio_1.test
+++ b/tests/module/Ieee80211MgmtApGenericRadio_1.test
@@ -1,0 +1,134 @@
+%description:
+A non-HT AP with a GenericRadio generates beacons and probe responses without
+an authoritative IEEE channel. Both retain the legacy unknown channel (-1) and
+omit HT elements. The real beacon timer and management frame dispatch reach the
+production generators; checked frames continue to the real MAC and radio.
+
+%file: TestIeee80211MgmtApGenericRadio.cc
+
+#include <iostream>
+
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtApGenericRadio : public Ieee80211MgmtAp
+{
+  protected:
+    cMessage *probeTimer = nullptr;
+    int beacons = 0;
+    int probeResponses = 0;
+
+    virtual void initialize(int stage) override
+    {
+        Ieee80211MgmtAp::initialize(stage);
+        if (stage == INITSTAGE_LAST) {
+            ASSERT(!mib->isHtOperationSupported());
+            ASSERT(!mib->hasPrimaryChannel());
+            probeTimer = new cMessage("injectProbe");
+            scheduleAt(SimTime(2, SIMTIME_MS), probeTimer);
+        }
+    }
+
+    virtual void handleTimer(cMessage *message) override
+    {
+        if (message != probeTimer) {
+            Ieee80211MgmtAp::handleTimer(message);
+            return;
+        }
+        auto body = makeShared<Ieee80211ProbeRequestFrame>();
+        body->setSSID("");
+        body->setChunkLength(B(2));
+        auto packet = new Packet("ProbeRequest", body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_PROBEREQUEST);
+        header->setTransmitterAddress(MacAddress("02:00:00:00:00:02"));
+        processFrame(packet, header);
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& address, uint64_t transactionId = 0) override
+    {
+        ASSERT(!mib->hasPrimaryChannel());
+        auto discovery = dynamicPtrCast<Ieee80211BeaconFrame>(body);
+        ASSERT(discovery != nullptr);
+        ASSERT(discovery->getChannelNumber() == -1);
+        ASSERT(!discovery->getHtCapabilitiesPresent());
+        ASSERT(!discovery->getHtOperationPresent());
+        if (subtype == ST_BEACON) {
+            ASSERT(address == MacAddress::BROADCAST_ADDRESS);
+            beacons++;
+        }
+        else {
+            ASSERT(subtype == ST_PROBERESPONSE);
+            ASSERT(address == MacAddress("02:00:00:00:00:02"));
+            probeResponses++;
+        }
+        Ieee80211MgmtAp::sendManagementFrame(name, body, subtype, address, transactionId);
+    }
+
+    using cListener::finish;
+
+    virtual void finish() override
+    {
+        ASSERT(beacons > 0);
+        ASSERT(probeResponses == 1);
+        std::cout << "GenericRadio AP generated legacy beacons and a probe response with unknown channel and no HT elements.\n";
+    }
+
+  public:
+    virtual ~TestIeee80211MgmtApGenericRadio() { cancelAndDelete(probeTimer); }
+};
+
+Define_Module(TestIeee80211MgmtApGenericRadio);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.common.medium.RadioMedium;
+
+simple TestIeee80211MgmtApGenericRadio extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApGenericRadio);
+}
+
+network Ieee80211MgmtApGenericRadioTestNetwork
+{
+    submodules:
+        radioMedium: RadioMedium;
+        ap: AccessPoint;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApGenericRadioTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 5ms
+seed-set = 0
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.typename = "TestIeee80211MgmtApGenericRadio"
+*.ap.wlan[0].mgmt.beaconInterval = 1ms
+*.ap.wlan[0].opMode = "g(erp)"
+*.ap.wlan[0].bitrate = 6Mbps
+*.ap.wlan[0].radio.typename = "GenericRadio"
+*.ap.wlan[0].radio.transmitter.bitrate = 6Mbps
+*.ap.wlan[0].radio.transmitter.analogModel.communicationRange = 100m
+*.radioMedium.signalAnalogRepresentation = "unitDisk"
+*.ap.wlan[0].radio.signalAnalogRepresentation = "unitDisk"
+*.ap.mobility.initFromDisplayString = false
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+*.ap.mobility.initialZ = 0m
+
+%contains: stdout
+GenericRadio AP generated legacy beacons and a probe response with unknown channel and no HT elements.

--- a/tests/module/Ieee80211MgmtApHcfQueueDrop_1.test
+++ b/tests/module/Ieee80211MgmtApHcfQueueDrop_1.test
@@ -1,0 +1,298 @@
+%description:
+Verify that a tagged Association or Reassociation Response dropped from an
+HCF EDCA compound pending queue reaches the AP as a terminal outcome. The
+child management queue drop signal is propagated through the compound queue,
+pending state is cleared, and a retransmission completes without disturbing a
+committed association.
+
+%file: TestIeee80211MgmtApHcfQueueDrop.cc
+
+#include <vector>
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/queueing/queue/CompoundPacketQueueBase.h"
+#include "inet/queueing/queue/PacketQueue.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestHcfManagementQueue : public queueing::PacketQueue
+{
+  public:
+    void setPacketCapacityForTest(int capacity) { packetCapacity = capacity; }
+};
+
+Define_Module(TestHcfManagementQueue);
+
+class TestCompoundPendingQueueForHcf : public queueing::CompoundPacketQueueBase
+{
+  public:
+    void setPacketCapacityForTest(int capacity) { packetCapacity = capacity; }
+};
+
+Define_Module(TestCompoundPendingQueueForHcf);
+
+class TestIeee80211MgmtApHcfQueueDrop : public Ieee80211MgmtAp
+{
+  public:
+    std::vector<FrameTransmissionStatus> statuses;
+    std::vector<uint64_t> transactionIds;
+
+    void markAuthenticated(const MacAddress& address)
+    {
+        Enter_Method("markAuthenticated");
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    void submitReassociationRequest(const MacAddress& address, const MacAddress& currentAp)
+    {
+        Enter_Method("submitReassociationRequest");
+        auto packet = new Packet("ReassociationRequest");
+        auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+        body->setSSID("SSID");
+        body->setCurrentAP(currentAp);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleReassociationRequestFrame(packet, header);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const { return staList.at(address).pendingAssociationTransactionId; }
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+    short getCommittedAssociationId(const MacAddress& address) const
+    {
+        auto it = mib->bssAccessPointData.associationIds.find(address);
+        return it == mib->bssAccessPointData.associationIds.end() ? 0 : it->second;
+    }
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const { return mib->bssAccessPointData.stations.at(address); }
+
+  protected:
+    virtual void frameTransmissionFinished(const Packet *responseFrame, FrameTransmissionStatus status) override
+    {
+        statuses.push_back(status);
+        auto transactionTag = responseFrame == nullptr ? nullptr : responseFrame->findTag<Ieee80211MgmtTransactionTag>();
+        transactionIds.push_back(transactionTag == nullptr ? 0 : transactionTag->getTransactionId());
+        Ieee80211MgmtAp::frameTransmissionFinished(responseFrame, status);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApHcfQueueDrop);
+
+class Ieee80211MgmtApHcfQueueDropTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApHcfQueueDropTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtApHcfQueueDrop *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto compoundQueue = check_and_cast<TestCompoundPendingQueueForHcf *>(getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3].pendingQueue"));
+        auto managementQueue = check_and_cast<TestHcfManagementQueue *>(getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3].pendingQueue.managementQueue"));
+        const MacAddress station("02:00:00:00:00:09");
+        const MacAddress reusable("02:00:00:00:00:0a");
+        const MacAddress apAddress("02:00:00:00:00:01");
+
+        ASSERT(compoundQueue->getMaxNumPackets() == -1);
+        ASSERT(managementQueue->getMaxNumPackets() == 0);
+        mgmt->markAuthenticated(station);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && mgmt->statuses.empty(); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 1);
+        ASSERT(mgmt->statuses.back() == FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+        ASSERT(mgmt->transactionIds.back() != 0);
+        auto firstTransactionId = mgmt->transactionIds.back();
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mgmt->getCommittedAssociationId(station) == 0);
+        ASSERT(mgmt->reserveAssociationId(reusable) == 1);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        managementQueue->setPacketCapacityForTest(-1);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && !mgmt->hasPendingAssociation(station); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->hasPendingAssociation(station));
+        auto secondTransactionId = mgmt->getPendingAssociationTransactionId(station);
+        ASSERT(secondTransactionId != 0 && secondTransactionId != firstTransactionId);
+        for (int i = 0; i < 10000 && mgmt->statuses.size() < 2; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 2);
+        ASSERT(mgmt->statuses.back() == FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        ASSERT(mgmt->transactionIds.back() == secondTransactionId);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+        auto committedAid = mgmt->getCommittedAssociationId(station);
+        ASSERT(committedAid == 1);
+
+        managementQueue->setPacketCapacityForTest(-1);
+        compoundQueue->setPacketCapacityForTest(0);
+        mgmt->submitReassociationRequest(station, apAddress);
+        for (int i = 0; i < 100 && mgmt->statuses.size() < 3; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 3);
+        ASSERT(mgmt->statuses.back() == FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(station) == committedAid);
+
+        compoundQueue->setPacketCapacityForTest(-1);
+        mgmt->submitReassociationRequest(station, apAddress);
+        for (int i = 0; i < 100 && !mgmt->hasPendingAssociation(station); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->hasPendingAssociation(station));
+        auto reassociationTransactionId = mgmt->getPendingAssociationTransactionId(station);
+        for (int i = 0; i < 10000 && mgmt->statuses.size() < 4; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 4);
+        ASSERT(mgmt->statuses.back() == FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        ASSERT(mgmt->transactionIds.back() == reassociationTransactionId);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(station) == committedAid);
+
+        std::cout << "HCF compound pending-queue drop cleanup, AID preservation, and reassociation recovery verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApHcfQueueDropTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.linklayer.ieee80211.mac.queue.CompoundPendingQueue;
+import inet.queueing.classifier.PacketClassifier;
+import inet.queueing.queue.CompoundPacketQueueBase;
+import inet.queueing.queue.PacketQueue;
+import inet.queueing.scheduler.PriorityScheduler;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestHcfManagementQueue extends PacketQueue
+{
+    parameters:
+        @class(::inet::ieee80211::TestHcfManagementQueue);
+        packetCapacity = default(0);
+        dropperClass = default("inet::queueing::PacketAtCollectionEndDropper");
+}
+
+module TestCompoundPendingQueueForHcf extends CompoundPacketQueueBase
+{
+    parameters:
+        @class(::inet::ieee80211::TestCompoundPendingQueueForHcf);
+        packetCapacity = default(-1);
+        dropperClass = default("inet::queueing::PacketAtCollectionEndDropper");
+    submodules:
+        classifier: PacketClassifier {
+            parameters:
+                classifierClass = default("inet::ieee80211::MgmtOverDataClassifier");
+        }
+        managementQueue: TestHcfManagementQueue;
+        multicastQueue: PacketQueue;
+        unicastQueue: PacketQueue;
+        prioritizer: PriorityScheduler;
+    connections:
+        in --> classifier.in;
+        classifier.out++ --> managementQueue.in;
+        classifier.out++ --> multicastQueue.in;
+        classifier.out++ --> unicastQueue.in;
+        managementQueue.out --> prioritizer.in++;
+        multicastQueue.out --> prioritizer.in++;
+        unicastQueue.out --> prioritizer.in++;
+        prioritizer.out --> out;
+}
+
+simple TestIeee80211MgmtApHcfQueueDrop extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApHcfQueueDrop);
+}
+
+simple Ieee80211MgmtApHcfQueueDropTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApHcfQueueDropTest);
+}
+
+network Ieee80211MgmtApHcfQueueDropTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApHcfQueueDrop";
+                wlan[*].mac.qosStation = true;
+                wlan[*].mac.hcf.edca.edcaf[*].pendingQueue.typename = "TestCompoundPendingQueueForHcf";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtStaSimplified";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApHcfQueueDropTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApHcfQueueDropTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+
+%contains: stdout
+HCF compound pending-queue drop cleanup, AID preservation, and reassociation recovery verified.

--- a/tests/module/Ieee80211MgmtApHcfRtsTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApHcfRtsTimeout_1.test
@@ -1,0 +1,277 @@
+%description:
+Exercise an AP QoS/HCF management response protected by RTS when the peer
+does not return CTS.  The deterministic two-attempt retry exhaustion must
+reach the typed terminal callback, clear the AP's pending association
+transaction, release its reserved AID, and emit no association notification.
+
+%file: TestIeee80211MgmtApHcfRtsTimeout.cc
+
+#include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/IRecoveryProcedure.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtApHcf : public Ieee80211MgmtAp
+{
+  public:
+    int terminalCallbacks = 0;
+    int associationResponseCallbacks = 0;
+    FrameTransmissionStatus lastStatus = FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED;
+
+    virtual void start() override
+    {
+        // Keep beacon generation out of this focused transaction.  The HCF
+        // exchange below is then the only AP-originated management traffic.
+        Ieee80211MgmtApBase::start();
+    }
+
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    short submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+        return mib->reserveAssociationId(address);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const
+    {
+        return staList.at(address).pendingAssociationTransactionId;
+    }
+
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+
+    bool hasCommittedAssociationId(const MacAddress& address) const
+    {
+        return mib->bssAccessPointData.associationIds.find(address) != mib->bssAccessPointData.associationIds.end();
+    }
+
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const
+    {
+        return mib->bssAccessPointData.stations.at(address);
+    }
+
+  protected:
+    virtual void frameTransmissionFinished(const Packet *responseFrame, FrameTransmissionStatus status) override
+    {
+        terminalCallbacks++;
+        lastStatus = status;
+        if (responseFrame != nullptr) {
+            const auto& header = responseFrame->peekAtFront(b(-1), Chunk::PF_ALLOW_NULLPTR);
+            const auto& mgmtHeader = dynamicPtrCast<const Ieee80211MgmtHeader>(header);
+            if (mgmtHeader != nullptr && (mgmtHeader->getType() == ST_ASSOCIATIONRESPONSE || mgmtHeader->getType() == ST_REASSOCIATIONRESPONSE))
+                associationResponseCallbacks++;
+        }
+        Ieee80211MgmtAp::frameTransmissionFinished(responseFrame, status);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApHcf);
+
+class Ieee80211MgmtApHcfRtsTimeoutTest : public cSimpleModule, public cListener
+{
+    using cListener::finish;
+
+  protected:
+    TestIeee80211MgmtApHcf *mgmt = nullptr;
+    cModule *apHcf = nullptr;
+    cModule *apRecoveryProcedure = nullptr;
+    cModule *apQosEdcaf = nullptr;
+    MacAddress expectedAddress;
+    int associationNotifications = 0;
+    int hcfDrops = 0;
+    int retryLimitNotifications = 0;
+    int rtsAttempts = 0;
+
+  public:
+    Ieee80211MgmtApHcfRtsTimeoutTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtApHcf *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        apHcf = getModuleByPath("^.ap.wlan[0].mac.hcf");
+        apRecoveryProcedure = getModuleByPath("^.ap.wlan[0].mac.hcf.edca.mgmtAndNonQoSRecoveryProcedure");
+        apQosEdcaf = getModuleByPath("^.ap.wlan[0].mac.hcf.edca.edcaf[3]");
+        mgmt->subscribe(l2ApAssociatedSignal, this);
+        apHcf->subscribe(packetDroppedSignal, this);
+        apRecoveryProcedure->subscribe(IRecoveryProcedure::retryLimitReachedSignal, this);
+        apQosEdcaf->subscribe(packetSentToPeerSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (source == mgmt && signalID == l2ApAssociatedSignal) {
+            const auto& notification = check_and_cast<Ieee80211MgmtAp::NotificationInfoSta *>(value);
+            ASSERT(notification->getStaAddress() == expectedAddress);
+            associationNotifications++;
+        }
+        else if (source == apQosEdcaf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_RTS && header->getReceiverAddress() == expectedAddress)
+                rtsAttempts++;
+        }
+        else if (source == apRecoveryProcedure && signalID == IRecoveryProcedure::retryLimitReachedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAddress)
+                retryLimitNotifications++;
+        }
+        else if (source == apHcf && signalID == packetDroppedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAddress) {
+                auto packetDropDetails = check_and_cast<PacketDropDetails *>(details);
+                ASSERT(packetDropDetails->getReason() == RETRY_LIMIT_REACHED);
+                hcfDrops++;
+            }
+        }
+    }
+
+    virtual void activity() override
+    {
+        expectedAddress = MacAddress("02:00:00:00:00:09");
+        mgmt->markAuthenticated(expectedAddress);
+        short associationId = mgmt->submitAssociationRequest(expectedAddress);
+        uint64_t transactionId = mgmt->getPendingAssociationTransactionId(expectedAddress);
+        ASSERT(associationId == 1);
+        ASSERT(transactionId != 0);
+        ASSERT(mgmt->hasPendingAssociation(expectedAddress));
+        ASSERT(mgmt->getStationStatus(expectedAddress) == Ieee80211Mib::AUTHENTICATED);
+
+        // The tester MAC blocks both RTS attempts.  There is intentionally no
+        // ctsTimeout override: the normal HCF timeout and retry path must
+        // deliver the terminal callback.
+        for (int i = 0; i < 100 && mgmt->terminalCallbacks == 0; i++)
+            wait(SimTime(1, SIMTIME_MS));
+
+        ASSERT(rtsAttempts == 2);
+        ASSERT(retryLimitNotifications == 1);
+        ASSERT(hcfDrops == 1);
+        ASSERT(mgmt->terminalCallbacks == 1);
+        ASSERT(mgmt->associationResponseCallbacks == 1);
+        ASSERT(mgmt->lastStatus == FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED);
+        ASSERT(associationNotifications == 0);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAddress));
+        ASSERT(!mgmt->hasCommittedAssociationId(expectedAddress));
+        ASSERT(mgmt->getStationStatus(expectedAddress) == Ieee80211Mib::AUTHENTICATED);
+
+        // A failed transaction releases its reservation so another STA can
+        // reuse the same AID.
+        MacAddress reusable("02:00:00:00:00:0a");
+        ASSERT(mgmt->reserveAssociationId(reusable) == associationId);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        std::cout << "HCF management RTS retry exhaustion and typed AP terminal cleanup verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApHcfRtsTimeoutTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtApHcf extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApHcf);
+}
+
+simple Ieee80211MgmtApHcfRtsTimeoutTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApHcfRtsTimeoutTest);
+}
+
+network Ieee80211MgmtApHcfRtsTimeoutTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApHcf";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mac.typename = "Ieee80211TesterMac";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApHcfRtsTimeoutTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApHcfRtsTimeoutTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+*.sta.mobility.initialX = 1m
+*.sta.mobility.initialY = 0m
+**.wlan[*].opMode = "g(mixed)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+*.ap.wlan[0].mac.qosStation = true
+*.ap.wlan[0].mac.hcf.rtsPolicy.rtsThreshold = 0B
+*.ap.wlan[0].mac.hcf.edca.mgmtAndNonQoSRecoveryProcedure.shortRetryLimit = 2
+*.sta.wlan[0].mac.actions = "BB"
+*.sta.wlan[0].mgmt.typename = "Ieee80211MgmtStaSimplified"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+
+%contains: stdout
+HCF management RTS retry exhaustion and typed AP terminal cleanup verified.

--- a/tests/module/Ieee80211MgmtApLifecycle_1.test
+++ b/tests/module/Ieee80211MgmtApLifecycle_1.test
@@ -1,0 +1,294 @@
+%description:
+Verify that AP lifecycle teardown clears station association records,
+association IDs, reservations, and peer HT state on shutdown, and that
+after restarting the AP, a former station is no longer accepted as associated
+until it authenticates and associates again.
+
+%file: TestIeee80211MgmtApLifecycle.cc
+
+#include <vector>
+
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtAp : public Ieee80211MgmtAp
+{
+  public:
+    std::vector<int> sentSubtypes;
+    std::vector<Ieee80211ReasonCode> sentDeauthReasons;
+
+  protected:
+    virtual void start() override
+    {
+        // Suppress periodic beacon timers so they do not interfere with
+        // microsecond-scale lifecycle state transitions.
+        Ieee80211MgmtApBase::start();
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        sentSubtypes.push_back(subtype);
+        if (subtype == ST_DEAUTHENTICATION) {
+            auto deauth = dynamicPtrCast<const Ieee80211DeauthenticationFrame>(body);
+            if (deauth != nullptr)
+                sentDeauthReasons.push_back(deauth->getReasonCode());
+        }
+    }
+
+  public:
+    void submitAuthenticationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAuthenticationRequest");
+        auto packet = new Packet("AuthenticationRequest");
+        auto body = makeShared<Ieee80211AuthenticationFrame>();
+        body->setSequenceNumber(1);
+        body->setStatusCode(SC_SUCCESSFUL);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_AUTHENTICATION);
+        header->setTransmitterAddress(address);
+        header->setReceiverAddress(mib->address);
+        handleAuthenticationFrame(packet, header);
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID(ssid.c_str());
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+        if (mib->isHtOperationSupported()) {
+            body->setHtCapabilitiesPresent(true);
+            body->setHtCapabilities(makeHtCapabilitiesElement(mib->localHtCapabilities));
+        }
+        body->setChunkLength(B(100));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_ASSOCIATIONREQUEST);
+        header->setTransmitterAddress(address);
+        header->setReceiverAddress(mib->address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    uint64_t getPendingTransactionId(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it == staList.end() ? 0 : it->second.pendingAssociationTransactionId;
+    }
+
+    void finishAssociationResponse(const MacAddress& address)
+    {
+        Enter_Method("finishAssociationResponse");
+        auto response = new Packet("AssociationResponse");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_ASSOCIATIONRESPONSE);
+        header->setReceiverAddress(address);
+        response->insertAtBack(header);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(getPendingTransactionId(address));
+        frameTransmissionFinished(response, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        delete response;
+    }
+
+    bool hasStation(const MacAddress& address) const
+    {
+        return mib->bssAccessPointData.stations.find(address) != mib->bssAccessPointData.stations.end();
+    }
+
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const
+    {
+        auto it = mib->bssAccessPointData.stations.find(address);
+        return it == mib->bssAccessPointData.stations.end() ? Ieee80211Mib::NOT_AUTHENTICATED : it->second;
+    }
+
+    bool hasCommittedAid(const MacAddress& address) const
+    {
+        return mib->bssAccessPointData.associationIds.find(address) != mib->bssAccessPointData.associationIds.end();
+    }
+
+    bool hasPeerHtState(const MacAddress& address) const
+    {
+        return mib->findPeerHtState(address) != nullptr;
+    }
+
+    bool isStaListEmpty() const
+    {
+        return staList.empty();
+    }
+};
+
+Define_Module(TestIeee80211MgmtAp);
+
+class Ieee80211MgmtApLifecycleTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApLifecycleTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto mib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        const MacAddress staAddress("02:00:00:00:00:09");
+
+        // 1. Initial State: station authenticates and associates
+        mgmt->submitAuthenticationRequest(staAddress);
+        ASSERT(mgmt->getStationStatus(staAddress) == Ieee80211Mib::AUTHENTICATED);
+
+        mgmt->submitAssociationRequest(staAddress);
+        mgmt->finishAssociationResponse(staAddress);
+
+        // Verify station is fully associated
+        ASSERT(mgmt->getStationStatus(staAddress) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->hasCommittedAid(staAddress));
+        ASSERT(mgmt->hasPeerHtState(staAddress));
+        std::cout << "Station successfully associated before AP shutdown.\n";
+
+        // 2. AP is shut down at t=10us via ScenarioManager
+        wait(SimTime(15, SIMTIME_US)); // wait until t=15us (AP is down)
+
+        // Verify AP teardown: stations, AIDs, and peer HT states are completely cleared
+        ASSERT(mib->bssAccessPointData.stations.empty());
+        ASSERT(mib->bssAccessPointData.associationIds.empty());
+        ASSERT(mgmt->isStaListEmpty());
+        ASSERT(!mgmt->hasPeerHtState(staAddress));
+        std::cout << "AP lifecycle teardown cleared all station, AID, and peer HT states.\n";
+
+        // 3. AP is restarted at t=20us via ScenarioManager
+        wait(SimTime(10, SIMTIME_US)); // wait until t=25us (AP is restarted and up)
+
+        // Verify former station is NO LONGER accepted as associated
+        ASSERT(!mgmt->hasStation(staAddress) || mgmt->getStationStatus(staAddress) != Ieee80211Mib::ASSOCIATED);
+        ASSERT(!mgmt->hasCommittedAid(staAddress));
+        ASSERT(!mgmt->hasPeerHtState(staAddress));
+
+        // 4. Former station attempts to associate directly WITHOUT authenticating first
+        size_t deauthCountBefore = mgmt->sentDeauthReasons.size();
+        mgmt->submitAssociationRequest(staAddress);
+
+        // AP must reject unauthenticated association request with Deauthentication (RC_NONAUTH_ASS_REQUEST)
+        ASSERT(mgmt->sentDeauthReasons.size() == deauthCountBefore + 1);
+        ASSERT(mgmt->sentDeauthReasons.back() == RC_NONAUTH_ASS_REQUEST);
+        ASSERT(!mgmt->hasStation(staAddress) || mgmt->getStationStatus(staAddress) != Ieee80211Mib::ASSOCIATED);
+        ASSERT(!mgmt->hasCommittedAid(staAddress));
+        ASSERT(!mgmt->hasPeerHtState(staAddress));
+        std::cout << "Former station unauthenticated association request correctly rejected with deauthentication.\n";
+
+        // 5. Former station authenticates again
+        mgmt->submitAuthenticationRequest(staAddress);
+        ASSERT(mgmt->getStationStatus(staAddress) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(!mgmt->hasCommittedAid(staAddress));
+
+        // 6. Former station associates again
+        mgmt->submitAssociationRequest(staAddress);
+        mgmt->finishAssociationResponse(staAddress);
+
+        // Verify station is accepted as associated once again
+        ASSERT(mgmt->getStationStatus(staAddress) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->hasCommittedAid(staAddress));
+        ASSERT(mgmt->hasPeerHtState(staAddress));
+        std::cout << "Former station successfully re-authenticated and re-associated after AP restart.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApLifecycleTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.common.scenario.ScenarioManager;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtAp);
+}
+
+simple Ieee80211MgmtApLifecycleTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApLifecycleTest);
+}
+
+network Ieee80211MgmtApLifecycleTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        scenarioManager: ScenarioManager;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtAp";
+        }
+        test: Ieee80211MgmtApLifecycleTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApLifecycleTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50us
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+**.hasStatus = true
+**.scenarioManager.script = xmldoc("scenario.xml")
+
+*.ap.wlan[0].mgmt.numAuthSteps = 2
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.ap.wlan[0].radio.channelNumber = 6
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%file: scenario.xml
+
+<scenario>
+    <at t="10us">
+        <shutdown module="ap"/>
+    </at>
+    <at t="20us">
+        <startup module="ap"/>
+    </at>
+</scenario>
+
+%contains: stdout
+Station successfully associated before AP shutdown.
+
+%contains: stdout
+AP lifecycle teardown cleared all station, AID, and peer HT states.
+
+%contains: stdout
+Former station unauthenticated association request correctly rejected with deauthentication.
+
+%contains: stdout
+Former station successfully re-authenticated and re-associated after AP restart.

--- a/tests/module/Ieee80211MgmtApMalformedHtCap_1.test
+++ b/tests/module/Ieee80211MgmtApMalformedHtCap_1.test
@@ -1,0 +1,333 @@
+%description:
+Verify that an AP safely validates peer-provided HT Capabilities in
+Association Request and Reassociation Request frames, rejecting malformed
+field-based elements with SC_UNSUP_CAP without terminating the simulation.
+
+%file: TestIeee80211MgmtApMalformedHtCap.cc
+
+#include <vector>
+#include <string>
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class Ieee80211MgmtApMalformedHtCapAp : public Ieee80211MgmtAp
+{
+  public:
+    struct SentFrame {
+        std::string name;
+        int subtype = -1;
+        MacAddress destAddr;
+        uint64_t transactionId = 0;
+        Ieee80211StatusCode statusCode = SC_SUCCESSFUL;
+        short aid = 0;
+    };
+
+    std::vector<SentFrame> sentFrames;
+
+  protected:
+    virtual void start() override
+    {
+        Ieee80211MgmtApBase::start();
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        SentFrame f;
+        f.name = name;
+        f.subtype = subtype;
+        f.destAddr = destAddr;
+        f.transactionId = transactionId;
+        if (auto resp = dynamicPtrCast<const Ieee80211AssociationResponseFrame>(body)) {
+            f.statusCode = static_cast<Ieee80211StatusCode>(resp->getStatusCode());
+            f.aid = resp->getAid();
+        }
+        else if (auto reassResp = dynamicPtrCast<const Ieee80211ReassociationResponseFrame>(body)) {
+            f.statusCode = static_cast<Ieee80211StatusCode>(reassResp->getStatusCode());
+            f.aid = reassResp->getAid();
+        }
+        sentFrames.push_back(f);
+    }
+
+  public:
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitAssociationRequest(const MacAddress& address, bool malformed, short exponent = 4)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setHtCapabilitiesPresent(true);
+        auto elem = makeHtCapabilitiesElement(mib->localHtCapabilities);
+        if (malformed)
+            elem.maxAmpduLengthExponent = exponent;
+        body->setHtCapabilities(elem);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    void submitAssociationRequestWithElement(const MacAddress& address, const Ieee80211HtCapabilitiesElement& elem)
+    {
+        Enter_Method("submitAssociationRequestWithElement");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setHtCapabilitiesPresent(true);
+        body->setHtCapabilities(elem);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    void submitReassociationRequest(const MacAddress& address, bool malformed, short exponent = 4)
+    {
+        Enter_Method("submitReassociationRequest");
+        auto packet = new Packet("ReassociationRequest");
+        auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+        body->setCurrentAP(mib->address);
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setHtCapabilitiesPresent(true);
+        auto elem = makeHtCapabilitiesElement(mib->localHtCapabilities);
+        if (malformed)
+            elem.maxAmpduLengthExponent = exponent;
+        body->setHtCapabilities(elem);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleReassociationRequestFrame(packet, header);
+    }
+
+    uint64_t getPendingTransactionId(const MacAddress& address) const
+    {
+        return staList.at(address).pendingAssociationTransactionId;
+    }
+
+    void finishResponse(const MacAddress& address, Ieee80211FrameType subtype)
+    {
+        Enter_Method("finishResponse");
+        auto response = new Packet(subtype == ST_ASSOCIATIONRESPONSE ? "AssociationResponse" : "ReassociationResponse");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(subtype);
+        header->setReceiverAddress(address);
+        response->insertAtBack(header);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(getPendingTransactionId(address));
+        frameTransmissionFinished(response, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        delete response;
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+};
+
+Define_Module(Ieee80211MgmtApMalformedHtCapAp);
+
+class Ieee80211MgmtApMalformedHtCapTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApMalformedHtCapTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<Ieee80211MgmtApMalformedHtCapAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto mib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        const MacAddress sta1("02:00:00:00:00:09");
+        const MacAddress sta2("02:00:00:00:00:0A");
+
+        mgmt->markAuthenticated(sta1);
+
+        // 1. Malformed AssociationRequest (exponent = 4) refused with SC_UNSUP_CAP without terminating simulation
+        mgmt->submitAssociationRequest(sta1, true, 4);
+        ASSERT(!mgmt->sentFrames.empty());
+        ASSERT(mgmt->sentFrames.back().name == "AssocResp-UnsupportedHtCap");
+        ASSERT(mgmt->sentFrames.back().statusCode == SC_UNSUP_CAP);
+        ASSERT(mgmt->sentFrames.back().aid == 0);
+        ASSERT(mgmt->hasPendingAssociation(sta1));
+        mgmt->finishResponse(sta1, ST_ASSOCIATIONRESPONSE);
+        ASSERT(!mgmt->hasPendingAssociation(sta1));
+        ASSERT(mib->bssAccessPointData.stations.at(sta1) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mib->findPeerHtState(sta1) == nullptr);
+        ASSERT(mib->bssAccessPointData.associationIds.find(sta1) == mib->bssAccessPointData.associationIds.end());
+        std::cout << "Malformed AssociationRequest (exponent 4) refused with SC_UNSUP_CAP.\n";
+
+        // 2. Malformed AssociationRequest (exponent = -1) refused with SC_UNSUP_CAP
+        mgmt->submitAssociationRequest(sta1, true, -1);
+        ASSERT(mgmt->sentFrames.back().name == "AssocResp-UnsupportedHtCap");
+        ASSERT(mgmt->sentFrames.back().statusCode == SC_UNSUP_CAP);
+        ASSERT(mgmt->sentFrames.back().aid == 0);
+        ASSERT(mgmt->hasPendingAssociation(sta1));
+        mgmt->finishResponse(sta1, ST_ASSOCIATIONRESPONSE);
+        ASSERT(!mgmt->hasPendingAssociation(sta1));
+        ASSERT(mib->bssAccessPointData.stations.at(sta1) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mib->findPeerHtState(sta1) == nullptr);
+        std::cout << "Malformed AssociationRequest (exponent -1) refused with SC_UNSUP_CAP.\n";
+
+        // 3. Valid AssociationRequest succeeds
+        mgmt->submitAssociationRequest(sta1, false);
+        ASSERT(mgmt->sentFrames.back().name == "AssocResp-OK");
+        ASSERT(mgmt->sentFrames.back().statusCode == SC_SUCCESSFUL);
+        ASSERT(mgmt->sentFrames.back().aid > 0);
+        mgmt->finishResponse(sta1, ST_ASSOCIATIONRESPONSE);
+        ASSERT(!mgmt->hasPendingAssociation(sta1));
+        ASSERT(mib->bssAccessPointData.stations.at(sta1) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mib->findPeerHtState(sta1) != nullptr);
+        std::cout << "Valid AssociationRequest succeeded with SC_SUCCESSFUL.\n";
+
+        // 4. Malformed ReassociationRequest (exponent = 4) from associated station
+        // IEEE Std 802.11-2024, 11.3.5.5(n): acknowledged refusal clears existing association
+        mgmt->submitReassociationRequest(sta1, true, 4);
+        ASSERT(mgmt->sentFrames.back().name == "ReassocResp-UnsupportedHtCap");
+        ASSERT(mgmt->sentFrames.back().statusCode == SC_UNSUP_CAP);
+        ASSERT(mgmt->sentFrames.back().aid == 0);
+        ASSERT(mgmt->hasPendingAssociation(sta1));
+        mgmt->finishResponse(sta1, ST_REASSOCIATIONRESPONSE);
+        ASSERT(!mgmt->hasPendingAssociation(sta1));
+        ASSERT(mib->bssAccessPointData.stations.at(sta1) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mib->findPeerHtState(sta1) == nullptr);
+        ASSERT(mib->bssAccessPointData.associationIds.find(sta1) == mib->bssAccessPointData.associationIds.end());
+        std::cout << "Malformed ReassociationRequest (exponent 4) refused with SC_UNSUP_CAP and cleared association.\n";
+
+        // 5. Malformed ReassociationRequest (exponent = -1) from authenticated station
+        mgmt->markAuthenticated(sta2);
+        mgmt->submitReassociationRequest(sta2, true, -1);
+        ASSERT(mgmt->sentFrames.back().name == "ReassocResp-UnsupportedHtCap");
+        ASSERT(mgmt->sentFrames.back().statusCode == SC_UNSUP_CAP);
+        ASSERT(mgmt->sentFrames.back().aid == 0);
+        ASSERT(mgmt->hasPendingAssociation(sta2));
+        mgmt->finishResponse(sta2, ST_REASSOCIATIONRESPONSE);
+        ASSERT(!mgmt->hasPendingAssociation(sta2));
+        ASSERT(mib->bssAccessPointData.stations.at(sta2) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mib->findPeerHtState(sta2) == nullptr);
+        std::cout << "Malformed ReassociationRequest (exponent -1) refused with SC_UNSUP_CAP.\n";
+
+        // 6. Malformed AssociationRequest with contradictory Tx MCS set fields refused with SC_UNSUP_CAP
+        auto badTxElem = makeHtCapabilitiesElement(mib->localHtCapabilities);
+        badTxElem.txMcsSetDefined = false;
+        badTxElem.txRxMcsSetNotEqual = true;
+        mgmt->submitAssociationRequestWithElement(sta1, badTxElem);
+        ASSERT(mgmt->sentFrames.back().name == "AssocResp-UnsupportedHtCap");
+        ASSERT(mgmt->sentFrames.back().statusCode == SC_UNSUP_CAP);
+        ASSERT(mgmt->sentFrames.back().aid == 0);
+        ASSERT(mgmt->hasPendingAssociation(sta1));
+        mgmt->finishResponse(sta1, ST_ASSOCIATIONRESPONSE);
+        ASSERT(!mgmt->hasPendingAssociation(sta1));
+        ASSERT(mib->bssAccessPointData.stations.at(sta1) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mib->findPeerHtState(sta1) == nullptr);
+        std::cout << "Malformed AssociationRequest (contradictory Tx MCS) refused with SC_UNSUP_CAP.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApMalformedHtCapTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple Ieee80211MgmtApMalformedHtCapAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApMalformedHtCapAp);
+}
+
+simple Ieee80211MgmtApMalformedHtCapTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApMalformedHtCapTest);
+}
+
+network Ieee80211MgmtApMalformedHtCapNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtApMalformedHtCapAp";
+        }
+        test: Ieee80211MgmtApMalformedHtCapTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApMalformedHtCapNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 1ms
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.ap.wlan[0].radio.channelNumber = 6
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%contains: stdout
+Malformed AssociationRequest (exponent 4) refused with SC_UNSUP_CAP.
+
+%contains: stdout
+Malformed AssociationRequest (exponent -1) refused with SC_UNSUP_CAP.
+
+%contains: stdout
+Valid AssociationRequest succeeded with SC_SUCCESSFUL.
+
+%contains: stdout
+Malformed ReassociationRequest (exponent 4) refused with SC_UNSUP_CAP and cleared association.
+
+%contains: stdout
+Malformed ReassociationRequest (exponent -1) refused with SC_UNSUP_CAP.
+
+%contains: stdout
+Malformed AssociationRequest (contradictory Tx MCS) refused with SC_UNSUP_CAP.

--- a/tests/module/Ieee80211MgmtApQueueDrop_1.test
+++ b/tests/module/Ieee80211MgmtApQueueDrop_1.test
@@ -1,0 +1,209 @@
+%description:
+Verify that a tagged Association Response dropped by the real DCF pending
+queue reaches the AP as a terminal DROPPED_BEFORE_TRANSMISSION outcome. The
+pending association and reserved AID are cleared, and a retransmitted request
+gets a new transaction token.
+
+%file: TestIeee80211MgmtApQueueDrop.cc
+
+#include <vector>
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/queueing/queue/PacketQueue.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestPendingQueue : public queueing::PacketQueue
+{
+  public:
+    void setPacketCapacityForTest(int capacity) { packetCapacity = capacity; }
+};
+
+Define_Module(TestPendingQueue);
+
+class TestIeee80211MgmtApQueueDrop : public Ieee80211MgmtAp
+{
+  public:
+    std::vector<FrameTransmissionStatus> statuses;
+    std::vector<uint64_t> transactionIds;
+
+    void markAuthenticated(const MacAddress& address)
+    {
+        Enter_Method("markAuthenticated");
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const { return staList.at(address).pendingAssociationTransactionId; }
+
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const { return mib->bssAccessPointData.stations.at(address); }
+
+  protected:
+    virtual void frameTransmissionFinished(const Packet *frame, FrameTransmissionStatus status) override
+    {
+        statuses.push_back(status);
+        auto transactionTag = frame == nullptr ? nullptr : frame->findTag<Ieee80211MgmtTransactionTag>();
+        transactionIds.push_back(transactionTag == nullptr ? 0 : transactionTag->getTransactionId());
+        Ieee80211MgmtAp::frameTransmissionFinished(frame, status);
+    }
+};
+
+Define_Module(TestIeee80211MgmtApQueueDrop);
+
+class Ieee80211MgmtApQueueDropTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApQueueDropTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtApQueueDrop *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto queue = check_and_cast<TestPendingQueue *>(getModuleByPath("^.ap.wlan[0].mac.dcf.channelAccess.pendingQueue"));
+        const MacAddress station("02:00:00:00:00:09");
+        const MacAddress reusable("02:00:00:00:00:0a");
+
+        ASSERT(queue->getMaxNumPackets() == 0);
+        mgmt->markAuthenticated(station);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && mgmt->statuses.empty(); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 1);
+        ASSERT(mgmt->statuses.back() == FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION);
+        ASSERT(mgmt->transactionIds.back() != 0);
+        auto firstTransactionId = mgmt->transactionIds.back();
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::AUTHENTICATED);
+
+        // The existing packetDroppedSignal is delivered before deletion, so the reservation
+        // is released synchronously and can be reused by another STA.
+        ASSERT(mgmt->reserveAssociationId(reusable) == 1);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        // A retransmitted request is not mistaken for the dropped transaction.
+        // Open the test queue after the first terminal callback so the second
+        // response can complete through the ordinary DCF/ACK path.
+        queue->setPacketCapacityForTest(-1);
+        mgmt->submitAssociationRequest(station);
+        for (int i = 0; i < 100 && !mgmt->hasPendingAssociation(station); i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->hasPendingAssociation(station));
+        auto secondTransactionId = mgmt->getPendingAssociationTransactionId(station);
+        ASSERT(secondTransactionId != 0);
+        ASSERT(secondTransactionId != firstTransactionId);
+        for (int i = 0; i < 10000 && mgmt->statuses.size() < 2; i++)
+            wait(SimTime(1, SIMTIME_US));
+        ASSERT(mgmt->statuses.size() == 2);
+        ASSERT(mgmt->statuses.back() == FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        ASSERT(mgmt->transactionIds.back() == secondTransactionId);
+        ASSERT(!mgmt->hasPendingAssociation(station));
+        ASSERT(mgmt->getStationStatus(station) == Ieee80211Mib::ASSOCIATED);
+
+        std::cout << "DCF pending-queue overflow terminal cleanup and retransmission recovery verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApQueueDropTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.linklayer.ieee80211.mac.queue.PendingQueue;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestPendingQueue extends PendingQueue
+{
+    parameters:
+        @class(::inet::ieee80211::TestPendingQueue);
+}
+
+simple TestIeee80211MgmtApQueueDrop extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtApQueueDrop);
+}
+
+simple Ieee80211MgmtApQueueDropTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApQueueDropTest);
+}
+
+network Ieee80211MgmtApQueueDropTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtApQueueDrop";
+                wlan[*].mac.dcf.channelAccess.pendingQueue.typename = "TestPendingQueue";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtStaSimplified";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApQueueDropTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApQueueDropTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].mac.dcf.channelAccess.pendingQueue.packetCapacity = 0
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+
+%contains: stdout
+DCF pending-queue overflow terminal cleanup and retransmission recovery verified.

--- a/tests/module/Ieee80211MgmtApTimeout_1.test
+++ b/tests/module/Ieee80211MgmtApTimeout_1.test
@@ -1,0 +1,602 @@
+%description:
+Verify the AP association-response state machine by injecting a delayed
+terminal MAC completion: pending state survives beyond the former AP response
+deadline, commits exactly once, and preserves its association ID while
+duplicate association or reassociation requests are coalesced. Also verify
+failure, deauthentication, disassociation, and same-AP reassociation cleanup.
+Exercise the live DCF path by suppressing two acknowledgments until the retry
+limit drops an Association Response, then verify that a fresh transaction
+recovers through a real response/ACK exchange and reuses the released AID.
+
+%file: TestIeee80211MgmtAp.cc
+
+#include <vector>
+
+#include "inet/common/Simsignals.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/IRecoveryProcedure.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtAp : public Ieee80211MgmtAp
+{
+  public:
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body, int subtype,
+            const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        // Authentication replies are irrelevant to this AP-side transaction
+        // test; suppress them so the tester MAC does not need auth actions.
+        if (subtype == ST_AUTHENTICATION)
+            return;
+        Ieee80211MgmtAp::sendManagementFrame(name, body, subtype, destAddr, transactionId);
+    }
+
+    virtual void start() override
+    {
+        // Keep the AP beacon timer out of this focused exchange.  The STA's
+        // scripted tester must see exactly the two failed response attempts
+        // followed by the response for the recovered transaction.
+        Ieee80211MgmtApBase::start();
+    }
+
+    short startPendingAssociation(const MacAddress& address)
+    {
+        Enter_Method("startPendingAssociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        short aid = mib->reserveAssociationId(address);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    short startPendingReassociation(const MacAddress& address)
+    {
+        Enter_Method("startPendingReassociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        short aid = mib->allocateAssociationId(address);
+        ASSERT(mib->reserveAssociationId(address) == aid);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    short startSuccessfulReassociation(const MacAddress& address, Ieee80211Mib::BssMemberStatus status)
+    {
+        Enter_Method("startSuccessfulReassociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        mib->bssAccessPointData.stations[address] = status;
+        short aid = mib->reserveAssociationId(address);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    short startPendingAssociatedReassociation(const MacAddress& address)
+    {
+        Enter_Method("startPendingAssociatedReassociation");
+        auto& sta = staList[address];
+        sta.address = address;
+        clearPendingAssociation(&sta);
+        short aid = mib->allocateAssociationId(address);
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
+        if (mib->isHtOperationSupported())
+            mib->setPeerHtCapabilities(address, mib->localHtCapabilities, mib->getHtOperation());
+        ASSERT(mib->reserveAssociationId(address) == aid);
+        sta.pendingAssociationSuccessful = true;
+        sta.pendingAssociationTransactionId = createAssociationTransactionId();
+        return aid;
+    }
+
+    void finishAssociationResponse(const MacAddress& address, FrameTransmissionStatus status,
+            bool moreFragments = false, uint64_t transactionId = 0)
+    {
+        if (transactionId == 0)
+            transactionId = staList.at(address).pendingAssociationTransactionId;
+        auto response = new Packet("ReassocResp");
+        auto responseHeader = makeShared<Ieee80211MgmtHeader>();
+        responseHeader->setType(ST_REASSOCIATIONRESPONSE);
+        responseHeader->setReceiverAddress(address);
+        responseHeader->setMoreFragments(moreFragments);
+        response->insertAtBack(responseHeader);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
+        frameTransmissionFinished(response, status);
+        delete response;
+    }
+
+    void deauthenticate(const MacAddress& address)
+    {
+        Enter_Method("deauthenticate");
+        auto packet = new Packet("Deauth");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleDeauthenticationFrame(packet, header);
+    }
+
+    void disassociate(const MacAddress& address)
+    {
+        Enter_Method("disassociate");
+        auto packet = new Packet("Disassoc");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleDisassociationFrame(packet, header);
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+
+    uint64_t getPendingAssociationTransactionId(const MacAddress& address) const { return staList.at(address).pendingAssociationTransactionId; }
+
+    short reserveAssociationId(const MacAddress& address) { return mib->reserveAssociationId(address); }
+    void cancelAssociationIdReservation(const MacAddress& address) { mib->cancelAssociationIdReservation(address); }
+    bool hasCommittedAssociationId(const MacAddress& address) const { return mib->bssAccessPointData.associationIds.find(address) != mib->bssAccessPointData.associationIds.end(); }
+    bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
+    short getCommittedAssociationId(const MacAddress& address) const { return mib->bssAccessPointData.associationIds.at(address); }
+    Ieee80211Mib::BssMemberStatus getStationStatus(const MacAddress& address) const { return mib->bssAccessPointData.stations.at(address); }
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void setAuthenticationSequenceExpected(const MacAddress& address, int sequenceNumber)
+    {
+        staList.at(address).authSeqExpected = sequenceNumber;
+    }
+
+    void submitAuthentication(const MacAddress& address, int sequenceNumber)
+    {
+        Enter_Method("submitAuthentication");
+        auto packet = new Packet("Authentication");
+        auto body = makeShared<Ieee80211AuthenticationFrame>();
+        body->setSequenceNumber(sequenceNumber);
+        body->setStatusCode(SC_SUCCESSFUL);
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleAuthenticationFrame(packet, header);
+    }
+
+    bool hasPendingHtState(const MacAddress& address) const
+    {
+        return staList.at(address).pendingHtStateAvailable;
+    }
+
+    void setPendingHtState(const MacAddress& address)
+    {
+        staList.at(address).pendingHtStateAvailable = true;
+    }
+
+    void submitDuplicateRequest(const MacAddress& address, bool reassociation)
+    {
+        auto packet = new Packet(reassociation ? "DuplicateReassoc" : "DuplicateAssoc");
+        if (reassociation) {
+            auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+            body->setCurrentAP(MacAddress::UNSPECIFIED_ADDRESS);
+            body->setSSID("SSID");
+            Ieee80211SupportedRatesElement rates;
+            rates.numRates = 1;
+            rates.rate[0] = 1;
+            body->setSupportedRates(rates);
+            body->setChunkLength(B(1));
+            packet->insertAtBack(body);
+        }
+        else {
+            auto body = makeShared<Ieee80211AssociationRequestFrame>();
+            body->setSSID("SSID");
+            Ieee80211SupportedRatesElement rates;
+            rates.numRates = 1;
+            rates.rate[0] = 1;
+            body->setSupportedRates(rates);
+            body->setChunkLength(B(1));
+            packet->insertAtBack(body);
+        }
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        if (reassociation)
+            handleReassociationRequestFrame(packet, header);
+        else
+            handleAssociationRequestFrame(packet, header);
+    }
+
+};
+
+Define_Module(TestIeee80211MgmtAp);
+
+class Ieee80211MgmtApTimeoutTest : public cSimpleModule, public cListener
+{
+    using cListener::finish;
+
+  protected:
+    TestIeee80211MgmtAp *mgmt = nullptr;
+    cModule *apDcf = nullptr;
+    cModule *apRecoveryProcedure = nullptr;
+    cModule *staDcf = nullptr;
+    MacAddress expectedAssociatedAddress;
+    MacAddress expectedDisassociatedAddress;
+    Ieee80211Mib::BssMemberStatus expectedDisassociatedStatus = Ieee80211Mib::NOT_AUTHENTICATED;
+    short expectedAssociationId = 0;
+    int associationNotifications = 0;
+    int disassociationNotifications = 0;
+    int retryLimitReachedNotifications = 0;
+    int retryLimitReachedDrops = 0;
+    int staAckTransmissions = 0;
+    std::vector<bool> associationResponseRetries;
+
+  public:
+    Ieee80211MgmtApTimeoutTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void initialize() override
+    {
+        mgmt = check_and_cast<TestIeee80211MgmtAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        apDcf = getModuleByPath("^.ap.wlan[0].mac.dcf");
+        apRecoveryProcedure = getModuleByPath("^.ap.wlan[0].mac.dcf.recoveryProcedure");
+        staDcf = getModuleByPath("^.sta.wlan[0].mac.dcf");
+        mgmt->subscribe(l2ApAssociatedSignal, this);
+        mgmt->subscribe(l2ApDisassociatedSignal, this);
+        apDcf->subscribe(packetSentToPeerSignal, this);
+        apDcf->subscribe(packetDroppedSignal, this);
+        apRecoveryProcedure->subscribe(IRecoveryProcedure::retryLimitReachedSignal, this);
+        staDcf->subscribe(packetSentToPeerSignal, this);
+    }
+
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *value, cObject *details) override
+    {
+        if (source == mgmt) {
+            const auto& notification = check_and_cast<Ieee80211MgmtAp::NotificationInfoSta *>(value);
+            if (signalID == l2ApAssociatedSignal) {
+                ASSERT(notification->getStaAddress() == expectedAssociatedAddress);
+                ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
+                ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
+                ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+                associationNotifications++;
+            }
+            else {
+                ASSERT(signalID == l2ApDisassociatedSignal);
+                ASSERT(notification->getStaAddress() == expectedDisassociatedAddress);
+                ASSERT(!mgmt->hasPendingAssociation(expectedDisassociatedAddress));
+                ASSERT(!mgmt->hasCommittedAssociationId(expectedDisassociatedAddress));
+                ASSERT(!mgmt->hasPeerHtState(expectedDisassociatedAddress));
+                ASSERT(mgmt->getStationStatus(expectedDisassociatedAddress) == expectedDisassociatedStatus);
+                disassociationNotifications++;
+            }
+        }
+        else if (source == apDcf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAssociatedAddress) {
+                associationResponseRetries.push_back(header->getRetry());
+                ASSERT(associationResponseRetries.size() <= 3);
+            }
+        }
+        else if (source == apRecoveryProcedure && signalID == IRecoveryProcedure::retryLimitReachedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAssociatedAddress)
+                retryLimitReachedNotifications++;
+        }
+        else if (source == apDcf && signalID == packetDroppedSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ASSOCIATIONRESPONSE && header->getReceiverAddress() == expectedAssociatedAddress) {
+                auto packetDropDetails = check_and_cast<PacketDropDetails *>(details);
+                ASSERT(packetDropDetails->getReason() == RETRY_LIMIT_REACHED);
+                retryLimitReachedDrops++;
+            }
+        }
+        else if (source == staDcf && signalID == packetSentToPeerSignal) {
+            auto packet = check_and_cast<Packet *>(value);
+            const auto& header = packet->peekAtFront<Ieee80211MacHeader>();
+            if (header->getType() == ST_ACK && header->getReceiverAddress() == MacAddress("02:00:00:00:00:01"))
+                staAckTransmissions++;
+        }
+        else
+            ASSERT(false);
+    }
+
+    virtual void activity() override
+    {
+        // The old AP-local deadline was 100 ms in this test. Keep the
+        // transaction pending beyond it and verify that the reserved AID and
+        // transaction token remain stable until the MAC reports completion.
+        expectedAssociatedAddress = MacAddress("02:00:00:00:00:01");
+        uint64_t delayedTransaction = 0;
+        short delayedAid = mgmt->startPendingAssociation(expectedAssociatedAddress);
+        expectedAssociationId = delayedAid;
+        delayedTransaction = mgmt->getPendingAssociationTransactionId(expectedAssociatedAddress);
+        ASSERT(delayedAid == 1);
+        mgmt->markAuthenticated(expectedAssociatedAddress);
+        mgmt->submitDuplicateRequest(expectedAssociatedAddress, false);
+        mgmt->submitDuplicateRequest(expectedAssociatedAddress, true);
+        ASSERT(mgmt->getPendingAssociationTransactionId(expectedAssociatedAddress) == delayedTransaction);
+        ASSERT(mgmt->reserveAssociationId(expectedAssociatedAddress) == delayedAid);
+
+        MacAddress notReusedWhilePending("02:00:00:00:00:02");
+        ASSERT(mgmt->reserveAssociationId(notReusedWhilePending) == 2);
+        mgmt->cancelAssociationIdReservation(notReusedWhilePending);
+        wait(SimTime(150, SIMTIME_MS));
+        ASSERT(mgmt->hasPendingAssociation(expectedAssociatedAddress));
+        ASSERT(mgmt->getPendingAssociationTransactionId(expectedAssociatedAddress) == delayedTransaction);
+        ASSERT(mgmt->reserveAssociationId(notReusedWhilePending) == 2);
+        mgmt->cancelAssociationIdReservation(notReusedWhilePending);
+
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, true, delayedTransaction);
+        ASSERT(mgmt->hasPendingAssociation(expectedAssociatedAddress));
+        ASSERT(associationNotifications == 0);
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, delayedTransaction);
+        ASSERT(associationNotifications == 1);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+        ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == delayedAid);
+        // A duplicate terminal callback cannot commit or notify a second time.
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, delayedTransaction);
+        ASSERT(associationNotifications == 1);
+
+        expectedAssociatedAddress = MacAddress("02:00:00:00:00:06");
+        expectedAssociationId = mgmt->startSuccessfulReassociation(expectedAssociatedAddress, Ieee80211Mib::AUTHENTICATED);
+        ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(!mgmt->hasCommittedAssociationId(expectedAssociatedAddress));
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        ASSERT(associationNotifications == 2);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+
+        short sameApAid = mgmt->startSuccessfulReassociation(expectedAssociatedAddress, Ieee80211Mib::ASSOCIATED);
+        ASSERT(sameApAid == expectedAssociationId);
+        ASSERT(mgmt->getStationStatus(expectedAssociatedAddress) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(expectedAssociatedAddress) == expectedAssociationId);
+        mgmt->finishAssociationResponse(expectedAssociatedAddress, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        ASSERT(associationNotifications == 2);
+        ASSERT(!mgmt->hasPendingAssociation(expectedAssociatedAddress));
+
+        MacAddress deauthenticated("02:00:00:00:00:07");
+        mgmt->startPendingAssociatedReassociation(deauthenticated);
+        uint64_t staleDeauthenticationTransaction = mgmt->getPendingAssociationTransactionId(deauthenticated);
+        expectedDisassociatedAddress = deauthenticated;
+        expectedDisassociatedStatus = Ieee80211Mib::NOT_AUTHENTICATED;
+        mgmt->deauthenticate(deauthenticated);
+        ASSERT(disassociationNotifications == 1);
+        ASSERT(!mgmt->hasPendingAssociation(deauthenticated));
+        ASSERT(!mgmt->hasCommittedAssociationId(deauthenticated));
+        ASSERT(mgmt->getStationStatus(deauthenticated) == Ieee80211Mib::NOT_AUTHENTICATED);
+        mgmt->finishAssociationResponse(deauthenticated, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, staleDeauthenticationTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(deauthenticated));
+
+        MacAddress disassociated("02:00:00:00:00:08");
+        mgmt->startPendingAssociatedReassociation(disassociated);
+        uint64_t staleDisassociationTransaction = mgmt->getPendingAssociationTransactionId(disassociated);
+        expectedDisassociatedAddress = disassociated;
+        expectedDisassociatedStatus = Ieee80211Mib::AUTHENTICATED;
+        mgmt->disassociate(disassociated);
+        ASSERT(disassociationNotifications == 2);
+        ASSERT(!mgmt->hasPendingAssociation(disassociated));
+        ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
+        ASSERT(mgmt->getStationStatus(disassociated) == Ieee80211Mib::AUTHENTICATED);
+        mgmt->finishAssociationResponse(disassociated, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, staleDisassociationTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(disassociated));
+
+        // A terminal retry result clears a pending transaction and releases
+        // its reservation, while a result for an unknown STA is ignored.
+        MacAddress terminalFailure("02:00:00:00:00:0b");
+        short terminalFailureAid = mgmt->startPendingAssociation(terminalFailure);
+        uint64_t terminalFailureTransaction = mgmt->getPendingAssociationTransactionId(terminalFailure);
+        mgmt->finishAssociationResponse(terminalFailure, FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED, false, terminalFailureTransaction);
+        ASSERT(!mgmt->hasPendingAssociation(terminalFailure));
+        ASSERT(!mgmt->hasCommittedAssociationId(terminalFailure));
+        ASSERT(mgmt->reserveAssociationId(terminalFailure) == terminalFailureAid);
+        mgmt->cancelAssociationIdReservation(terminalFailure);
+        mgmt->finishAssociationResponse(MacAddress("02:00:00:00:00:0c"), FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, 1);
+
+        // Exercise the real AP response path.  With actions "BBA", the tester
+        // MAC consumes the AP's first two responses: the same response is
+        // observed twice, but neither blocked copy reaches the recipient ACK
+        // procedure.  The third action accepts the response for the new
+        // transaction and sends a real ACK.
+        MacAddress failed("02:00:00:00:00:09");
+        expectedAssociatedAddress = failed;
+        mgmt->markAuthenticated(failed);
+        int notificationsBeforeRetry = associationNotifications;
+        mgmt->submitAssociationRequest(failed);
+        uint64_t failedTransaction = mgmt->getPendingAssociationTransactionId(failed);
+        short failedAid = mgmt->reserveAssociationId(failed);
+        ASSERT(failedAid == 3);
+        ASSERT(!mgmt->hasCommittedAssociationId(failed));
+        mgmt->submitAssociationRequest(failed);
+        ASSERT(mgmt->getPendingAssociationTransactionId(failed) == failedTransaction);
+
+        for (int i = 0; i < 100 && (associationResponseRetries.size() < 2 || retryLimitReachedNotifications == 0 || retryLimitReachedDrops == 0 || mgmt->hasPendingAssociation(failed)); i++)
+            wait(SimTime(1, SIMTIME_MS));
+
+        ASSERT(associationResponseRetries.size() == 2);
+        ASSERT(!associationResponseRetries[0]);
+        ASSERT(associationResponseRetries[1]);
+        ASSERT(retryLimitReachedNotifications == 1);
+        ASSERT(retryLimitReachedDrops == 1);
+        ASSERT(!mgmt->hasPendingAssociation(failed));
+        ASSERT(!mgmt->hasCommittedAssociationId(failed));
+        ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::AUTHENTICATED);
+        ASSERT(associationNotifications == notificationsBeforeRetry);
+        MacAddress reusable("02:00:00:00:00:0a");
+        ASSERT(mgmt->reserveAssociationId(reusable) == failedAid);
+        mgmt->cancelAssociationIdReservation(reusable);
+
+        expectedAssociationId = failedAid;
+        mgmt->submitAssociationRequest(failed);
+        uint64_t recoveredTransaction = mgmt->getPendingAssociationTransactionId(failed);
+        ASSERT(recoveredTransaction != failedTransaction);
+        ASSERT(mgmt->reserveAssociationId(failed) == failedAid);
+        ASSERT(!mgmt->hasCommittedAssociationId(failed));
+        for (int i = 0; i < 100 && associationNotifications != notificationsBeforeRetry + 1; i++)
+            wait(SimTime(1, SIMTIME_MS));
+
+        ASSERT(associationResponseRetries.size() == 3);
+        ASSERT(!associationResponseRetries[2]);
+        ASSERT(staAckTransmissions == 1);
+        ASSERT(associationNotifications == notificationsBeforeRetry + 1);
+        ASSERT(!mgmt->hasPendingAssociation(failed));
+        ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->hasCommittedAssociationId(failed));
+        ASSERT(mgmt->getCommittedAssociationId(failed) == failedAid);
+        // A stale completion from the failed transaction must not clear the
+        // recovered transaction's committed association.
+        mgmt->finishAssociationResponse(failed, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, failedTransaction);
+        ASSERT(associationNotifications == notificationsBeforeRetry + 1);
+        ASSERT(!mgmt->hasPendingAssociation(failed));
+        ASSERT(mgmt->getStationStatus(failed) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(failed) == failedAid);
+
+        // Authentication traffic with an invalid sequence number must not
+        // revoke the response transaction that the MAC still owns.
+        MacAddress invalidAuthentication("02:00:00:00:00:0d");
+        short invalidAuthenticationAid = mgmt->startPendingAssociation(invalidAuthentication);
+        uint64_t invalidAuthenticationTransaction = mgmt->getPendingAssociationTransactionId(invalidAuthentication);
+        mgmt->setAuthenticationSequenceExpected(invalidAuthentication, 1);
+        mgmt->markAuthenticated(invalidAuthentication);
+        mgmt->setPendingHtState(invalidAuthentication);
+        mgmt->submitAuthentication(invalidAuthentication, 2);
+        ASSERT(mgmt->hasPendingAssociation(invalidAuthentication));
+        ASSERT(mgmt->getPendingAssociationTransactionId(invalidAuthentication) == invalidAuthenticationTransaction);
+        ASSERT(mgmt->hasPendingHtState(invalidAuthentication));
+        ASSERT(mgmt->reserveAssociationId(invalidAuthentication) == invalidAuthenticationAid);
+        expectedAssociatedAddress = invalidAuthentication;
+        expectedAssociationId = invalidAuthenticationAid;
+        mgmt->finishAssociationResponse(invalidAuthentication, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, invalidAuthenticationTransaction);
+        ASSERT(!mgmt->hasPendingAssociation(invalidAuthentication));
+        ASSERT(mgmt->getStationStatus(invalidAuthentication) == Ieee80211Mib::ASSOCIATED);
+        ASSERT(mgmt->getCommittedAssociationId(invalidAuthentication) == invalidAuthenticationAid);
+
+        // Frame 1 keeps the existing INET restart policy: it supersedes an
+        // in-flight response, and a stale terminal callback is harmless.
+        MacAddress restartedAuthentication("02:00:00:00:00:0e");
+        short restartedAuthenticationAid = mgmt->startPendingAssociation(restartedAuthentication);
+        uint64_t restartedAuthenticationTransaction = mgmt->getPendingAssociationTransactionId(restartedAuthentication);
+        mgmt->setAuthenticationSequenceExpected(restartedAuthentication, 1);
+        mgmt->markAuthenticated(restartedAuthentication);
+        mgmt->submitAuthentication(restartedAuthentication, 1);
+        ASSERT(!mgmt->hasPendingAssociation(restartedAuthentication));
+        ASSERT(mgmt->reserveAssociationId(restartedAuthentication) == restartedAuthenticationAid);
+        mgmt->cancelAssociationIdReservation(restartedAuthentication);
+        mgmt->finishAssociationResponse(restartedAuthentication, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED, false, restartedAuthenticationTransaction);
+        ASSERT(!mgmt->hasCommittedAssociationId(restartedAuthentication));
+
+        std::cout << "AP association response delayed-completion lifecycle verified.\n";
+        std::cout << "AP reassociation notification commit ordering verified.\n";
+        std::cout << "AP retry-limit exhaustion and association recovery verified.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApTimeoutTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.inet.WirelessHost;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtAp);
+}
+
+simple Ieee80211MgmtApTimeoutTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApTimeoutTest);
+}
+
+network Ieee80211MgmtApTimeoutTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtAp";
+        }
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mac.typename = "Ieee80211TesterMac";
+                wlan[*].agent.typename = "";
+        }
+        test: Ieee80211MgmtApTimeoutTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApTimeoutTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 200ms
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+*.sta.mobility.initialX = 1m
+*.sta.mobility.initialY = 0m
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 11Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+*.sta.wlan[0].mac.actions = "BBA"
+*.sta.wlan[0].mgmt.typename = "Ieee80211MgmtStaSimplified"
+*.sta.wlan[0].mgmt.accessPointAddress = "02:00:00:00:00:01"
+*.ap.wlan[0].mac.dcf.recoveryProcedure.shortRetryLimit = 2
+*.ap.wlan[0].mac.dcf.rtsPolicy.rtsThreshold = 4096B
+
+%contains: stdout
+AP association response delayed-completion lifecycle verified.
+
+%contains: stdout
+AP reassociation notification commit ordering verified.
+
+%contains: stdout
+AP retry-limit exhaustion and association recovery verified.

--- a/tests/unit/Ieee80211MgmtApTransaction_1.test
+++ b/tests/unit/Ieee80211MgmtApTransaction_1.test
@@ -1,0 +1,79 @@
+%description:
+Verify deterministic AP association- and reassociation-response result
+classification.  Matching transaction tags complete only on a final ACK,
+retain ACKed non-final fragments, and clear on a terminal retry-limit result;
+stale, missing, and malformed responses are ignored.
+
+%includes:
+#include "inet/common/packet/Packet.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+
+class TestIeee80211MgmtAp : public Ieee80211MgmtAp
+{
+  public:
+    using Ieee80211MgmtAp::AssociationResponseDisposition;
+    using Ieee80211MgmtAp::getAssociationResponseDisposition;
+};
+
+static Packet *makeAssociationResponse(uint64_t transactionId, bool moreFragments = false,
+        bool includeTag = true, Ieee80211FrameType subtype = ST_ASSOCIATIONRESPONSE)
+{
+    auto packet = new Packet("AssociationResponse");
+    auto header = makeShared<Ieee80211MgmtHeader>();
+    header->setType(subtype);
+    header->setReceiverAddress(MacAddress("02:00:00:00:00:01"));
+    header->setMoreFragments(moreFragments);
+    packet->insertAtBack(header);
+    if (includeTag)
+        packet->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(transactionId);
+    return packet;
+}
+
+%activity:
+
+using Disposition = TestIeee80211MgmtAp::AssociationResponseDisposition;
+
+auto finalResponse = makeAssociationResponse(42);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::COMPLETE);
+
+auto nonFinalResponse = makeAssociationResponse(42, true);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::RETAIN);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, FRAME_TRANSMISSION_STATUS_RETRY_LIMIT_REACHED) == Disposition::COMPLETE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nonFinalResponse, 42, FRAME_TRANSMISSION_STATUS_DROPPED_BEFORE_TRANSMISSION) == Disposition::COMPLETE);
+
+auto reassociationResponse = makeAssociationResponse(42, false, true, ST_REASSOCIATIONRESPONSE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(reassociationResponse, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::COMPLETE);
+
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 41, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(finalResponse, 0, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::IGNORE);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(nullptr, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::IGNORE);
+
+auto zeroTokenResponse = makeAssociationResponse(0);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(zeroTokenResponse, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::IGNORE);
+auto untaggedResponse = makeAssociationResponse(42, false, false);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(untaggedResponse, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::IGNORE);
+
+auto aggregate = new Packet("A-MPDU-like");
+aggregate->insertAtBack(makeShared<Ieee80211MpduSubframeHeader>());
+aggregate->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(42);
+ASSERT(TestIeee80211MgmtAp::getAssociationResponseDisposition(aggregate, 42, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED) == Disposition::IGNORE);
+
+delete aggregate;
+delete untaggedResponse;
+delete zeroTokenResponse;
+delete reassociationResponse;
+delete nonFinalResponse;
+delete finalResponse;
+
+EV << "AP management transmission-result classification verified.\n";
+
+%contains: stdout
+AP management transmission-result classification verified.

--- a/tests/unit/Ieee80211MibAssociationId_1.test
+++ b/tests/unit/Ieee80211MibAssociationId_1.test
@@ -1,0 +1,46 @@
+%description:
+Verify deterministic IEEE 802.11 association ID reservation, commit,
+cancellation, reuse, and lifecycle clearing.
+
+%includes:
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%activity:
+
+Ieee80211Mib mib;
+MacAddress first("02:00:00:00:00:01");
+MacAddress second("02:00:00:00:00:02");
+MacAddress third("02:00:00:00:00:03");
+MacAddress fourth("02:00:00:00:00:04");
+
+ASSERT(mib.reserveAssociationId(first) == 1);
+ASSERT(mib.reserveAssociationId(second) == 2);
+ASSERT(mib.reserveAssociationId(first) == 1);
+
+mib.cancelAssociationIdReservation(first);
+ASSERT(mib.reserveAssociationId(third) == 1);
+
+ASSERT(mib.commitAssociationId(second) == 2);
+ASSERT(mib.bssAccessPointData.associationIds.at(second) == 2);
+mib.cancelAssociationIdReservation(second);
+ASSERT(mib.bssAccessPointData.associationIds.at(second) == 2);
+
+ASSERT(mib.commitAssociationId(third) == 1);
+mib.releaseAssociationId(second);
+ASSERT(mib.bssAccessPointData.associationIds.count(second) == 0);
+ASSERT(mib.allocateAssociationId(fourth) == 2);
+
+mib.reserveAssociationId(first);
+mib.bssAccessPointData.stations[first] = Ieee80211Mib::ASSOCIATED;
+mib.clearAssociationIds();
+ASSERT(mib.bssAccessPointData.stations.empty());
+ASSERT(mib.bssAccessPointData.associationIds.empty());
+ASSERT(mib.reserveAssociationId(second) == 1);
+
+EV << "Association ID ownership checks passed.\n";
+
+%contains: stdout
+Association ID ownership checks passed.


### PR DESCRIPTION
# Complete AP association transactions from MAC outcomes

Enqueuing an association response does not establish successful delivery. Publish terminal MAC outcomes and use transaction identity to commit or release AP AIDs and negotiated state. Cover queue drops, retry exhaustion, malformed requests, configured MAC subscription, AP shutdown, and GenericRadio non-HT compatibility; charge internal collisions to the losing EDCAF. Synchronize accumulated baseline drift in the JSON fingerprint store with accepted CSV values.

## Stack and reading order

PR 3/4. Head: `pr/ht-03-ap-transactions`. Target: `master` (PR 1/4 [#1167](https://github.com/inet-framework/inet/pull/1167) and PR 2/4 [#1172](https://github.com/inet-framework/inet/pull/1172) merged). Range: `814e6a7438eb..095c457c10`. Read the following commits in order:

- `5c630b95f3` — ieee80211: preserve receiver header trailing spacing
- `b61cacb44c` — ieee80211: order MAC PHY includes by name
- `3c00448c1b` — ieee80211: explain incompatible HT transmitter and receiver types
- `e1bdc650d8` — ieee80211: use management headers for HCF retry accounting
- `42dd47f450` — ieee80211: publish terminal management frame outcomes
- `9f70afa7bd` — ieee80211: reserve association IDs before committing membership
- `726153fa00` — ieee80211: advertise AP HT discovery state from the MIB
- `c886bccbc0` — ieee80211: commit AP associations after response completion
- `9d0104c0a5` — ieee80211: charge collision retries to the owning EDCAF
- `095c457c10` — tests: synchronize stale JSON fingerprints with CSV baselines

## Architectural surface

Synchronous `frameTransmissionOutcome` signal (declared on DCF and HCF) and details (`FrameTransmissionDetails`), result filters/statistics, DCF/HCF completion reporting via upward signal propagation to MAC subscribers, AP pending transactions, MIB AID allocation, and GenericRadio non-HT fallback (retaining legacy unknown channel when no channel is published and reading HT operation only when HT is supported). No sealed packet-core paths changed.

## Baselines

C10 (`095c457c10`) synchronizes 72 obsolete run-0 tplx entries in `tests/fingerprint/store.json` with the accepted CSV baselines already present at `master` (`814e6a7438eb`). This addresses accumulated baseline-store synchronization drift from previous merges; no single source commit in this series caused the movement, and the source tree remains completely unmodified by this update.

Note on `check-commits.sh`: The mechanical checker flags C10 under `PR-SPLIT-BASELINE` solely because a baseline-only commit follows source commit C09 in the series; the commit body details the accumulated drift justification per `PR-SPLIT-BASELINE` and `TR-BASELINE-PROVENANCE`.

## Verification

Passing final debug build and passing filtered `opp_repl` test suite:
- `make MODE=debug -j$(nproc)`: PASS, exit 0.
- Unit and module tests: 2 unit tests (`Ieee80211MibAssociationId_1.test`, `Ieee80211MgmtApTransaction_1.test`) and 12 module tests (frame transmission statistics, AP queue drops, HCF queue drops, RTS timeouts, malformed HT capability rejection, timeouts, lifecycle stop/start, HT associations, antenna/rate control, internal collisions, GenericRadio AP discovery, and unavailable channel) PASS with exit 0.
- Architecture rules for `linklayer/ieee80211` and `physicallayer/wireless/ieee80211` PASS, exit 0.
- Fingerprints: All 72 synchronized fingerprint test cases pass with exit 0 under `opp_repl` in debug mode (run 0, tplx); aggregate selector of 311 tasks yielded 227 PASS, 0 FAIL, 0 ERROR, and 84 unrecorded baseline SKIPs.
- Working tree clean, exact tree match against preserved topic tree (`git diff --exit-code adf266f48f HEAD --`: exit 0; tree `00f9d50599`).
