### PR TITLE
ieee80211: keep HT operation coherent across discovery, beacons, and channel changes

### DIFF
--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.cc
@@ -135,9 +135,12 @@ void Ieee80211MgmtAp::frameTransmissionFinished(const Packet *responseFrame, Fra
             mib->bssAccessPointData.stations[address] = Ieee80211Mib::ASSOCIATED;
             if (sta->second.pendingHtStateAvailable) {
                 // IEEE Std 802.11-2024, 11.3.5.3: association state becomes effective only after the successful response exchange.
-                if (sta->second.pendingHtCapabilitiesValid) {
-                    ASSERT(sta->second.pendingHtOperationValid);
-                    mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, sta->second.pendingHtOperation);
+                if (sta->second.pendingHtCapabilitiesValid && mib->isHtOperationSupported()) {
+                    const auto& currentOperation = mib->getHtOperation();
+                    if (supportsBasicHtMcsSet(sta->second.pendingHtCapabilities, currentOperation))
+                        mib->setPeerHtCapabilities(address, sta->second.pendingHtCapabilities, currentOperation);
+                    else
+                        mib->removePeerHtCapabilities(address);
                 }
                 else
                     mib->removePeerHtCapabilities(address);

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtApBase.cc
@@ -43,6 +43,7 @@ void Ieee80211MgmtApBase::initialize(int stage)
     else if (stage == INITSTAGE_LINK_LAYER)
         mib->bssData.bssid = mib->address;
     else if (stage == INITSTAGE_LAST && mib->isHtOperationSupported()) {
+        mib->setPrimaryChannel(mib->requirePrimaryChannel(), getHtOperationBand());
         const auto& operation = mib->getHtOperation();
         if (operation.operatingChannelWidth == MHz(40) &&
                 !getHtOperationBand()->isHt40OperationSupported(operation.primaryChannel, operation.secondaryChannelOffset))
@@ -57,7 +58,10 @@ void Ieee80211MgmtApBase::receiveSignal(cComponent *source, simsignal_t signalID
 
     if (source == radio && signalID == ieee80211RadioChannelChangedSignal) {
         EV << "Updating AP primary channel to " << value << ".\n";
-        mib->setPrimaryChannel(value);
+        if (mib->isHtOperationSupported())
+            mib->setPrimaryChannel(value, getHtOperationBand());
+        else
+            mib->setPrimaryChannel(value);
     }
 }
 

--- a/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
+++ b/src/inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.cc
@@ -1235,7 +1235,30 @@ bool Ieee80211MgmtSta::storeAPInfo(Packet *packet, const Ptr<const Ieee80211Mgmt
     ap->isAuthenticated = candidate.isAuthenticated;
     ap->authSeqExpected = candidate.authSeqExpected;
     ap->authTimeoutMsg = candidate.authTimeoutMsg;
-    if (signalPowerInd != nullptr && currentAp)
+    bool currentAssociatedAp = mib != nullptr && mib->bssStationData.isAssociated && address == assocAP.address;
+    bool isBeacon = header->getType() == ST_BEACON ||
+            (header->getType() != ST_PROBERESPONSE && dynamicPtrCast<const Ieee80211ProbeResponseFrame>(body) == nullptr);
+    if (currentAssociatedAp && isBeacon) {
+        (ApInfo&)assocAP = *ap;
+        mib->bssData.ssid = ap->ssid;
+        if (mib->isHtOperationSupported() && candidate.htCapabilitiesPresent && candidate.htOperationPresent) {
+            auto negotiated = negotiateHtCapabilities(mib->localHtCapabilities, candidate.htCapabilities, candidate.htOperation);
+            if (supportsBasicHtMcsSet(mib->localHtCapabilities, candidate.htOperation) &&
+                    negotiated.localTxPeerRx.valid && negotiated.localRxPeerTx.valid) {
+                EV_INFO << "Refreshing authoritative HT state for associated AP address=" << address << "\n";
+                mib->setPeerHtCapabilities(address, candidate.htCapabilities, candidate.htOperation);
+            }
+            else {
+                EV_WARN << "Beacon from associated AP has unusable HT advertisement: removing peer HT state for AP address=" << address << "\n";
+                mib->removePeerHtCapabilities(address);
+            }
+        }
+        else {
+            EV_INFO << "Beacon from associated AP has no usable HT advertisement or STA is legacy: removing peer HT state for AP address=" << address << "\n";
+            mib->removePeerHtCapabilities(address);
+        }
+    }
+    else if (signalPowerInd != nullptr && currentAp)
         assocAP.rxPower = candidate.rxPower;
     return true;
 }

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Band.h"
 #include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
 
 namespace inet {
@@ -20,10 +21,12 @@ Define_Module(Ieee80211Mib);
 void Ieee80211Mib::initialize(int stage)
 {
     if (stage == INITSTAGE_LOCAL) {
+        configuredSecondaryChannelOffset = par("htSecondaryChannelOffset");
         WATCH(address);
         WATCH(mode);
         WATCH(qos);
         WATCH(localHtCapabilitiesValid);
+        WATCH(configuredSecondaryChannelOffset);
         WATCH(primaryChannelAvailable);
         WATCH(bssData.bssid);
         WATCH(bssStationData.stationType);
@@ -50,10 +53,57 @@ int Ieee80211Mib::requirePrimaryChannel() const
 
 void Ieee80211Mib::setPrimaryChannel(int primaryChannel)
 {
+    setPrimaryChannel(primaryChannel, nullptr);
+}
+
+void Ieee80211Mib::setPrimaryChannel(int primaryChannel, const physicallayer::IIeee80211Band *band)
+{
     if (primaryChannel < 0 || primaryChannel > 255)
         throw cRuntimeError("IEEE 802.11 primary channel must be in the range 0..255, not %d", primaryChannel);
+
+    if (band != nullptr) {
+        try {
+            band->getStandardChannelNumber(primaryChannel);
+        }
+        catch (const cRuntimeError&) {
+            throw cRuntimeError("Invalid primary channel %d for band '%s'", primaryChannel, band->getName());
+        }
+
+        if (localHtCapabilitiesValid) {
+            if (configuredSecondaryChannelOffset != 0) {
+                if (band->isHt40OperationSupported(primaryChannel, configuredSecondaryChannelOffset)) {
+                    htOperation.secondaryChannelOffset = configuredSecondaryChannelOffset;
+                    htOperation.operatingChannelWidth = MHz(40);
+                }
+                else {
+                    // IEEE Std 802.11-2024, 11.15.2 and 11.15.3.1: fallback to 20 MHz BSS operation
+                    EV_WARN << "Configured 40 MHz HT operation (offset " << configuredSecondaryChannelOffset
+                            << ") is unsupported on primary channel " << primaryChannel
+                            << " in band '" << band->getName() << "'; falling back to 20 MHz BSS operation.\n";
+                    htOperation.secondaryChannelOffset = 0;
+                    htOperation.operatingChannelWidth = MHz(20);
+                }
+            }
+            else {
+                htOperation.secondaryChannelOffset = 0;
+                htOperation.operatingChannelWidth = MHz(20);
+            }
+        }
+    }
+
     htOperation.primaryChannel = primaryChannel;
     primaryChannelAvailable = true;
+
+    if (localHtCapabilitiesValid) {
+        for (auto& entry : peerHtStates) {
+            if (entry.second.valid) {
+                entry.second.negotiatedCapabilities = negotiateHtCapabilities(localHtCapabilities,
+                        entry.second.advertisedCapabilities, htOperation);
+                if (++entry.second.generation == 0)
+                    entry.second.generation = 1;
+            }
+        }
+    }
 }
 
 const Ieee80211HtOperation& Ieee80211Mib::getHtOperation() const
@@ -120,9 +170,10 @@ void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeS
     if (localHtCapabilities.maxAmpduLengthExponent < 0 || localHtCapabilities.maxAmpduLengthExponent > 3)
         throw cRuntimeError("htMaxAmpduLengthExponent must be between 0 and 3");
 
-    htOperation.secondaryChannelOffset = par("htSecondaryChannelOffset");
-    if (htOperation.secondaryChannelOffset != 0 && htOperation.secondaryChannelOffset != 1 && htOperation.secondaryChannelOffset != 3)
+    configuredSecondaryChannelOffset = par("htSecondaryChannelOffset");
+    if (configuredSecondaryChannelOffset != 0 && configuredSecondaryChannelOffset != 1 && configuredSecondaryChannelOffset != 3)
         throw cRuntimeError("htSecondaryChannelOffset must be 0, 1, or 3");
+    htOperation.secondaryChannelOffset = configuredSecondaryChannelOffset;
     bool use40Mhz = htOperation.secondaryChannelOffset != 0;
     if (use40Mhz && localHtCapabilities.supportedChannelWidths.count(MHz(40)) == 0)
         throw cRuntimeError("40 MHz HT operation requires a configured PHY that can operate a 40 MHz channel width");
@@ -131,10 +182,14 @@ void Ieee80211Mib::updateLocalHtCapabilities(const physicallayer::Ieee80211ModeS
     if (protectionMode < 0 || protectionMode > 3)
         throw cRuntimeError("htProtectionMode must be between 0 and 3");
     htOperation.protectionMode = static_cast<Ieee80211HtProtectionMode>(protectionMode);
-    for (auto& entry : peerHtStates)
-        if (entry.second.valid)
+    for (auto& entry : peerHtStates) {
+        if (entry.second.valid) {
             entry.second.negotiatedCapabilities = negotiateHtCapabilities(localHtCapabilities,
-                    entry.second.advertisedCapabilities, entry.second.negotiatedCapabilities.operation);
+                    entry.second.advertisedCapabilities, htOperation);
+            if (++entry.second.generation == 0)
+                entry.second.generation = 1;
+        }
+    }
 }
 
 const Ieee80211Mib::PeerHtState *Ieee80211Mib::findPeerHtState(const MacAddress& address) const

--- a/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
+++ b/src/inet/linklayer/ieee80211/mib/Ieee80211Mib.h
@@ -16,6 +16,7 @@ namespace inet {
 
 namespace physicallayer {
 class Ieee80211ModeSet;
+class IIeee80211Band;
 }
 
 namespace ieee80211 {
@@ -81,6 +82,7 @@ class INET_API Ieee80211Mib : public SimpleModule
 
   private:
     Ieee80211HtOperation htOperation;
+    int configuredSecondaryChannelOffset = 0;
     bool primaryChannelAvailable = false;
     std::map<MacAddress, short> associationIdReservations;
     std::map<MacAddress, PeerHtState> peerHtStates;
@@ -104,6 +106,7 @@ class INET_API Ieee80211Mib : public SimpleModule
     bool hasPrimaryChannel() const { return primaryChannelAvailable; }
     int requirePrimaryChannel() const;
     void setPrimaryChannel(int primaryChannel);
+    void setPrimaryChannel(int primaryChannel, const physicallayer::IIeee80211Band *band);
     const Ieee80211HtOperation& getHtOperation() const;
     const PeerHtState *findPeerHtState(const MacAddress& address) const;
     void setPeerHtCapabilities(const MacAddress& address, const Ieee80211HtCapabilities& capabilities, const Ieee80211HtOperation& operation);

--- a/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.cc
+++ b/src/inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.cc
@@ -108,6 +108,9 @@ void Ieee80211Radio::setBand(const IIeee80211Band *band)
     ieee80211Receiver->setBand(band);
     EV << "Changing radio band to " << band << endl;
     receptionTimer = nullptr;
+    const auto *channel = ieee80211Transmitter->getChannel();
+    if (channel != nullptr)
+        emit(radioChannelChangedSignal, channel->getChannelNumber());
     emit(listeningChangedSignal, 0);
 }
 

--- a/tests/module/Ieee80211HtAssociation_1.test
+++ b/tests/module/Ieee80211HtAssociation_1.test
@@ -128,7 +128,7 @@ class Ieee80211HtAssociationChecker : public SimpleModule, public cListener
         ASSERT(staTunedToInternalChannelSix);
         ASSERT(apMib->hasPrimaryChannel());
         ASSERT(apMib->requirePrimaryChannel() == 11);
-        ASSERT(apMib->findPeerHtState(staAddress)->negotiatedCapabilities.operation.primaryChannel == 6);
+        ASSERT(apMib->findPeerHtState(staAddress)->negotiatedCapabilities.operation.primaryChannel == 11);
         ASSERT(staMib->bssStationData.isAssociated);
         // IEEE Std 802.11-2024, 9.4.2.54.2/Figure 9-456 and Table 9-224: the n(mixed-2.4Ghz)
         // profile exposes short GI for the PHY-supported 20 MHz width. The

--- a/tests/module/Ieee80211MgmtApChannelChange_1.test
+++ b/tests/module/Ieee80211MgmtApChannelChange_1.test
@@ -1,0 +1,459 @@
+%description:
+Verify that runtime radioChannelChanged notifications revalidate channel and
+band changes against the active IIeee80211Band, dynamically fall back to 20 MHz
+BSS operation when a configured secondary channel offset is unsupported, restore
+40 MHz operation when returning to a capable channel, reject invalid channels
+with cRuntimeError before committing, defer HT-only validation until local HT
+operation is known, and keep advertised HT Operation and existing negotiated
+peer state consistent throughout.
+
+%file: TestIeee80211MgmtApChannelChange.cc
+
+#include <vector>
+
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/Ieee80211PeerModeSelection.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Band.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211HtMode.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211ModeSet.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Receiver.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Transmitter.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestHt40Transmitter : public physicallayer::Ieee80211Transmitter
+{
+  public:
+    virtual bool isHtChannelWidthSupported(Hz channelWidth) const override
+    {
+        return (channelWidth == MHz(20) || channelWidth == MHz(40)) &&
+               modeSet != nullptr && modeSet->getHtSupportedChannelWidths().count(channelWidth) != 0;
+    }
+};
+
+Define_Module(TestHt40Transmitter);
+
+class TestHt40Receiver : public physicallayer::Ieee80211Receiver
+{
+  public:
+    virtual bool isHtChannelWidthSupported(Hz channelWidth) const override
+    {
+        return (channelWidth == MHz(20) || channelWidth == MHz(40)) &&
+               modeSet != nullptr && modeSet->getHtSupportedChannelWidths().count(channelWidth) != 0;
+    }
+};
+
+Define_Module(TestHt40Receiver);
+
+class TestIeee80211MgmtAp : public Ieee80211MgmtAp
+{
+  public:
+    std::vector<Ptr<Ieee80211BeaconFrame>> sentBeacons;
+
+    using Ieee80211MgmtApBase::getHtOperationBand;
+
+  protected:
+    virtual void start() override
+    {
+        // Suppress automatic periodic beacons so test controls frame generation.
+        Ieee80211MgmtApBase::start();
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        if (subtype == ST_BEACON) {
+            auto beacon = dynamicPtrCast<const Ieee80211BeaconFrame>(body);
+            if (beacon != nullptr)
+                sentBeacons.push_back(constPtrCast<Ieee80211BeaconFrame>(beacon));
+        }
+    }
+
+  public:
+    void emitBeaconNow()
+    {
+        Enter_Method("emitBeaconNow");
+        sendBeacon();
+    }
+
+    void submitAuthenticationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAuthenticationRequest");
+        auto packet = new Packet("AuthenticationRequest");
+        auto body = makeShared<Ieee80211AuthenticationFrame>();
+        body->setSequenceNumber(1);
+        body->setStatusCode(SC_SUCCESSFUL);
+        body->setChunkLength(B(6));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_AUTHENTICATION);
+        header->setTransmitterAddress(address);
+        header->setReceiverAddress(mib->address);
+        handleAuthenticationFrame(packet, header);
+    }
+
+    void submitAssociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitAssociationRequest");
+        auto packet = new Packet("AssociationRequest");
+        auto body = makeShared<Ieee80211AssociationRequestFrame>();
+        body->setSSID(ssid.c_str());
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+        if (mib->isHtOperationSupported()) {
+            body->setHtCapabilitiesPresent(true);
+            auto staCaps = mib->localHtCapabilities;
+            staCaps.supportedChannelWidths.insert(MHz(20));
+            staCaps.supportedChannelWidths.insert(MHz(40));
+            body->setHtCapabilities(makeHtCapabilitiesElement(staCaps));
+        }
+        body->setChunkLength(B(100));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_ASSOCIATIONREQUEST);
+        header->setTransmitterAddress(address);
+        header->setReceiverAddress(mib->address);
+        handleAssociationRequestFrame(packet, header);
+    }
+
+    uint64_t getPendingTransactionId(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it == staList.end() ? 0 : it->second.pendingAssociationTransactionId;
+    }
+
+    void finishAssociationResponse(const MacAddress& address)
+    {
+        Enter_Method("finishAssociationResponse");
+        auto response = new Packet("AssociationResponse");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_ASSOCIATIONRESPONSE);
+        header->setReceiverAddress(address);
+        response->insertAtBack(header);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(getPendingTransactionId(address));
+        frameTransmissionFinished(response, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        delete response;
+    }
+};
+
+Define_Module(TestIeee80211MgmtAp);
+
+static const physicallayer::IIeee80211Mode *findHtMode(const physicallayer::Ieee80211ModeSet *modeSet, int mcsIndex, Hz bandwidth)
+{
+    for (int i = 0; i < modeSet->getNumModes(); i++) {
+        const auto *mode = modeSet->getMode(i);
+        if (mode->getHtMcsIndex() == mcsIndex && mode->getDataMode()->getBandwidth() == bandwidth &&
+                !mode->isHtShortGuardInterval())
+            return mode;
+    }
+    return nullptr;
+}
+
+class Ieee80211MgmtApChannelChangeTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApChannelChangeTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto mib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto radio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.ap.wlan[0].radio"));
+        const auto *modeSet = physicallayer::Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+        const MacAddress staAddress("02:00:00:00:00:09");
+
+        // 1. Initial State: AP initialized on channel 0 (std channel 1) with HT40 SCA (+1)
+        ASSERT(mib->hasPrimaryChannel());
+        ASSERT(mib->requirePrimaryChannel() == 0);
+        ASSERT(mib->getHtOperation().primaryChannel == 0);
+        ASSERT(mib->getHtOperation().secondaryChannelOffset == 1);
+        ASSERT(mib->getHtOperation().operatingChannelWidth == MHz(40));
+        std::cout << "AP initialized with 40 MHz HT operation on channel 0.\n";
+
+        // 2. Station authenticates and associates
+        mgmt->submitAuthenticationRequest(staAddress);
+        mgmt->submitAssociationRequest(staAddress);
+        mgmt->finishAssociationResponse(staAddress);
+
+        const auto *peerState = mib->findPeerHtState(staAddress);
+        ASSERT(peerState != nullptr);
+        ASSERT(peerState->valid);
+        ASSERT(peerState->negotiatedCapabilities.operation.primaryChannel == 0);
+        ASSERT(peerState->negotiatedCapabilities.operation.secondaryChannelOffset == 1);
+        ASSERT(peerState->negotiatedCapabilities.operation.operatingChannelWidth == MHz(40));
+
+        // Verify beacon advertised HT Operation matches 40 MHz SCA operation
+        mgmt->emitBeaconNow();
+        ASSERT(!mgmt->sentBeacons.empty());
+        auto beaconElem = mgmt->sentBeacons.back()->getHtOperation();
+        ASSERT(mgmt->sentBeacons.back()->getHtOperationPresent());
+        ASSERT(beaconElem.primaryChannel == 1); // standard channel 1 on wire
+        ASSERT(beaconElem.secondaryChannelOffset == 1); // SCA
+        ASSERT(beaconElem.staChannelWidth40Mhz);
+
+        // Verify rate selection selects 40 MHz mode for peer
+        const auto *mcs7_40 = findHtMode(modeSet, 7, MHz(40));
+        ASSERT(mcs7_40 != nullptr);
+        const auto *selectedMode = selectPeerCompatibleMode(modeSet, peerState, mcs7_40, staAddress);
+        ASSERT(selectedMode == mcs7_40);
+        std::cout << "Station associated and negotiated 40 MHz HT operation.\n";
+
+        // 3. Dynamic runtime channel change to channel index 10 (std channel 11)
+        // In 2.4 GHz band, channel 11 + offset 1 would require channel 15, which is outside the band.
+        radio->setChannelNumber(10);
+
+        // Verify MIB downgraded to 20 MHz BSS operation while keeping configured offset policy
+        ASSERT(mib->requirePrimaryChannel() == 10);
+        ASSERT(mib->getHtOperation().primaryChannel == 10);
+        ASSERT(mib->getHtOperation().secondaryChannelOffset == 0);
+        ASSERT(mib->getHtOperation().operatingChannelWidth == MHz(20));
+
+        // Verify existing negotiated peer state is consistently updated
+        peerState = mib->findPeerHtState(staAddress);
+        ASSERT(peerState != nullptr);
+        ASSERT(peerState->valid);
+        ASSERT(peerState->negotiatedCapabilities.operation.primaryChannel == 10);
+        ASSERT(peerState->negotiatedCapabilities.operation.secondaryChannelOffset == 0);
+        ASSERT(peerState->negotiatedCapabilities.operation.operatingChannelWidth == MHz(20));
+
+        // Verify beacon advertised HT Operation reflects 20 MHz BSS operation
+        mgmt->emitBeaconNow();
+        beaconElem = mgmt->sentBeacons.back()->getHtOperation();
+        ASSERT(beaconElem.primaryChannel == 11); // standard channel 11 on wire
+        ASSERT(beaconElem.secondaryChannelOffset == 0); // SCN
+        ASSERT(!beaconElem.staChannelWidth40Mhz);
+
+        // Verify rate selection for existing peer restricts to 20 MHz
+        selectedMode = selectPeerCompatibleMode(modeSet, peerState, mcs7_40, staAddress);
+        ASSERT(selectedMode != nullptr);
+        ASSERT(selectedMode != mcs7_40);
+        ASSERT(selectedMode->getDataMode()->getBandwidth() == MHz(20));
+        std::cout << "Dynamic channel change to 11 downgraded to 20 MHz and updated peer state.\n";
+
+        // 4. Dynamic runtime channel change back to channel index 0 (std channel 1)
+        radio->setChannelNumber(0);
+
+        // Verify 40 MHz HT operation is restored
+        ASSERT(mib->requirePrimaryChannel() == 0);
+        ASSERT(mib->getHtOperation().primaryChannel == 0);
+        ASSERT(mib->getHtOperation().secondaryChannelOffset == 1);
+        ASSERT(mib->getHtOperation().operatingChannelWidth == MHz(40));
+
+        // Verify existing peer state is restored to 40 MHz
+        peerState = mib->findPeerHtState(staAddress);
+        ASSERT(peerState != nullptr);
+        ASSERT(peerState->valid);
+        ASSERT(peerState->negotiatedCapabilities.operation.primaryChannel == 0);
+        ASSERT(peerState->negotiatedCapabilities.operation.secondaryChannelOffset == 1);
+        ASSERT(peerState->negotiatedCapabilities.operation.operatingChannelWidth == MHz(40));
+
+        // Verify beacon advertised HT Operation restored to 40 MHz
+        mgmt->emitBeaconNow();
+        beaconElem = mgmt->sentBeacons.back()->getHtOperation();
+        ASSERT(beaconElem.primaryChannel == 1);
+        ASSERT(beaconElem.secondaryChannelOffset == 1);
+        ASSERT(beaconElem.staChannelWidth40Mhz);
+
+        // Verify rate selection permits 40 MHz again
+        selectedMode = selectPeerCompatibleMode(modeSet, peerState, mcs7_40, staAddress);
+        ASSERT(selectedMode == mcs7_40);
+        std::cout << "Dynamic channel change back to 0 restored 40 MHz HT operation.\n";
+
+        // 5. Invalid primary channel rejected before committing
+        // Both signal-driven notifications and direct MIB calls must validate against active band.
+        bool threwSignalInvalidChannel = false;
+        try {
+            radio->emit(physicallayer::Ieee80211Radio::radioChannelChangedSignal, 99);
+        }
+        catch (const cRuntimeError& e) {
+            threwSignalInvalidChannel = true;
+        }
+        ASSERT(threwSignalInvalidChannel);
+
+        bool threwMibInvalidChannel = false;
+        try {
+            mib->setPrimaryChannel(99, mgmt->getHtOperationBand());
+        }
+        catch (const cRuntimeError& e) {
+            threwMibInvalidChannel = true;
+        }
+        ASSERT(threwMibInvalidChannel);
+
+        // Prior state remains untouched
+        ASSERT(mib->requirePrimaryChannel() == 0);
+        ASSERT(mib->getHtOperation().primaryChannel == 0);
+        ASSERT(mib->getHtOperation().secondaryChannelOffset == 1);
+        ASSERT(mib->getHtOperation().operatingChannelWidth == MHz(40));
+        std::cout << "Invalid channel change rejected before commit.\n";
+
+        // 6. Dynamic band change
+        static const physicallayer::Ieee80211EnumeratedBand testBand5GHz("Test 5 GHz",
+                { GHz(5.180), GHz(5.200), GHz(5.220) },
+                { 36, 40, 44 });
+        radio->setBand(&testBand5GHz);
+        ASSERT(mgmt->getHtOperationBand() == &testBand5GHz);
+        ASSERT(mib->hasPrimaryChannel());
+        ASSERT(mib->requirePrimaryChannel() == 0);
+        ASSERT(mib->getHtOperation().primaryChannel == 0);
+        ASSERT(mib->getHtOperation().secondaryChannelOffset == 1);
+        ASSERT(mib->getHtOperation().operatingChannelWidth == MHz(40));
+
+        // Existing peer HT state should be re-negotiated against the new band
+        peerState = mib->findPeerHtState(staAddress);
+        ASSERT(peerState != nullptr);
+        ASSERT(peerState->valid);
+        ASSERT(peerState->negotiatedCapabilities.operation.primaryChannel == 0);
+        ASSERT(peerState->negotiatedCapabilities.operation.secondaryChannelOffset == 1);
+        ASSERT(peerState->negotiatedCapabilities.operation.operatingChannelWidth == MHz(40));
+
+        // Advertised beacon reflects new band standard channel number (36)
+        mgmt->emitBeaconNow();
+        beaconElem = mgmt->sentBeacons.back()->getHtOperation();
+        ASSERT(beaconElem.primaryChannel == 36); // standard channel 36 on wire
+        ASSERT(beaconElem.secondaryChannelOffset == 1);
+        ASSERT(beaconElem.staChannelWidth40Mhz);
+
+        // Also verify that band change to a band without standard channel numbers throws
+        bool threwInvalidBand = false;
+        try {
+            mib->setPrimaryChannel(0, &physicallayer::Ieee80211CompliantBands::band5GHz);
+        }
+        catch (const cRuntimeError& e) {
+            threwInvalidBand = true;
+        }
+        ASSERT(threwInvalidBand);
+        ASSERT(mib->requirePrimaryChannel() == 0);
+        ASSERT(mib->getHtOperation().primaryChannel == 0);
+        ASSERT(mib->getHtOperation().secondaryChannelOffset == 1);
+
+        std::cout << "Dynamic band change revalidated against new active band.\n";
+
+        // 7. Band notifications may arrive during initialization before the MAC
+        // publishes whether HT operation is supported. A legacy/non-HT AP must
+        // retain the radio's channel without applying HT-only band validation.
+        mib->updateLocalHtCapabilities(nullptr, {}, 0);
+        ASSERT(!mib->isHtOperationSupported());
+        bool threwNonHtBandChange = false;
+        try {
+            radio->setBand(&physicallayer::Ieee80211CompliantBands::band5GHz);
+        }
+        catch (const cRuntimeError&) {
+            threwNonHtBandChange = true;
+        }
+        ASSERT(!threwNonHtBandChange);
+        ASSERT(mib->hasPrimaryChannel());
+        ASSERT(mib->requirePrimaryChannel() == 0);
+        std::cout << "Non-HT band notification deferred HT-only validation.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApChannelChangeTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211Receiver;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211Transmitter;
+
+module TestHt40Transmitter extends Ieee80211Transmitter
+{
+    parameters:
+        @class(::inet::ieee80211::TestHt40Transmitter);
+}
+
+module TestHt40Receiver extends Ieee80211Receiver
+{
+    parameters:
+        @class(::inet::ieee80211::TestHt40Receiver);
+}
+
+simple TestIeee80211MgmtAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtAp);
+}
+
+simple Ieee80211MgmtApChannelChangeTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApChannelChangeTest);
+}
+
+network Ieee80211MgmtApChannelChangeTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtAp";
+        }
+        test: Ieee80211MgmtApChannelChangeTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApChannelChangeTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 50us
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+**.hasStatus = true
+
+*.ap.wlan[0].mgmt.numAuthSteps = 2
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.ap.wlan[0].radio.channelNumber = 0
+*.ap.wlan[0].mib.htSecondaryChannelOffset = 1
+*.ap.wlan[0].radio.transmitter.typename = "TestHt40Transmitter"
+*.ap.wlan[0].radio.receiver.typename = "TestHt40Receiver"
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%contains: stdout
+AP initialized with 40 MHz HT operation on channel 0.
+
+%contains: stdout
+Station associated and negotiated 40 MHz HT operation.
+
+%contains: stdout
+Dynamic channel change to 11 downgraded to 20 MHz and updated peer state.
+
+%contains: stdout
+Dynamic channel change back to 0 restored 40 MHz HT operation.
+
+%contains: stdout
+Invalid channel change rejected before commit.
+
+%contains: stdout
+Dynamic band change revalidated against new active band.
+
+%contains: stdout
+Non-HT band notification deferred HT-only validation.

--- a/tests/module/Ieee80211MgmtApReassociationSnapshot_1.test
+++ b/tests/module/Ieee80211MgmtApReassociationSnapshot_1.test
@@ -1,0 +1,190 @@
+%description:
+Verify that an AP reassociation response reconciles the committed peer
+HT Operation with runtime channel changes at completion while preserving
+the advertised response element.
+
+%file: TestIeee80211MgmtApReassociationSnapshot.cc
+
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtAp.h"
+#include "inet/linklayer/ieee80211/mac/contract/FrameTransmissionDetails_m.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtTransactionTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Radio.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class Ieee80211MgmtApReassociationSnapshotAp : public Ieee80211MgmtAp
+{
+  protected:
+    int advertisedPrimaryChannel = -1;
+
+    virtual void start() override
+    {
+        // The response is injected directly below; keep beacon traffic out
+        // of this focused transaction.
+        Ieee80211MgmtApBase::start();
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& destAddr, uint64_t transactionId = 0) override
+    {
+        if (subtype == ST_REASSOCIATIONRESPONSE) {
+            ASSERT(body->getHtOperationPresent());
+            advertisedPrimaryChannel = body->getHtOperation().primaryChannel;
+        }
+    }
+
+  public:
+    void markAuthenticated(const MacAddress& address)
+    {
+        auto& sta = staList[address];
+        sta.address = address;
+        mib->bssAccessPointData.stations[address] = Ieee80211Mib::AUTHENTICATED;
+    }
+
+    void submitReassociationRequest(const MacAddress& address)
+    {
+        Enter_Method("submitReassociationRequest");
+        auto packet = new Packet("ReassociationRequest");
+        auto body = makeShared<Ieee80211ReassociationRequestFrame>();
+        body->setCurrentAP(mib->address);
+        body->setSSID("SSID");
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 1;
+        body->setSupportedRates(rates);
+        body->setHtCapabilitiesPresent(true);
+        body->setHtCapabilities(makeHtCapabilitiesElement(mib->localHtCapabilities));
+        body->setChunkLength(B(1));
+        packet->insertAtBack(body);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        handleReassociationRequestFrame(packet, header);
+    }
+
+    int getAdvertisedPrimaryChannel() const { return advertisedPrimaryChannel; }
+
+    uint64_t getPendingTransactionId(const MacAddress& address) const
+    {
+        return staList.at(address).pendingAssociationTransactionId;
+    }
+
+    void finishReassociationResponse(const MacAddress& address)
+    {
+        Enter_Method("finishReassociationResponse");
+        auto response = new Packet("ReassociationResponse");
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_REASSOCIATIONRESPONSE);
+        header->setReceiverAddress(address);
+        response->insertAtBack(header);
+        response->addTag<Ieee80211MgmtTransactionTag>()->setTransactionId(getPendingTransactionId(address));
+        frameTransmissionFinished(response, FRAME_TRANSMISSION_STATUS_ACKNOWLEDGED);
+        delete response;
+    }
+
+    bool hasPendingAssociation(const MacAddress& address) const
+    {
+        auto it = staList.find(address);
+        return it != staList.end() && it->second.pendingAssociationTransactionId != 0;
+    }
+};
+
+Define_Module(Ieee80211MgmtApReassociationSnapshotAp);
+
+class Ieee80211MgmtApReassociationSnapshotTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtApReassociationSnapshotTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<Ieee80211MgmtApReassociationSnapshotAp *>(getModuleByPath("^.ap.wlan[0].mgmt"));
+        auto mib = check_and_cast<Ieee80211Mib *>(getModuleByPath("^.ap.wlan[0].mib"));
+        auto radio = check_and_cast<physicallayer::Ieee80211Radio *>(getModuleByPath("^.ap.wlan[0].radio"));
+        const MacAddress staAddress("02:00:00:00:00:09");
+
+        mgmt->markAuthenticated(staAddress);
+        mgmt->submitReassociationRequest(staAddress);
+        ASSERT(mgmt->getAdvertisedPrimaryChannel() == 7);
+        ASSERT(mib->requirePrimaryChannel() == 6);
+
+        radio->setChannelNumber(11);
+        ASSERT(mib->requirePrimaryChannel() == 11);
+        mgmt->finishReassociationResponse(staAddress);
+
+        ASSERT(!mgmt->hasPendingAssociation(staAddress));
+        ASSERT(mib->bssAccessPointData.stations.at(staAddress) == Ieee80211Mib::ASSOCIATED);
+        const auto *peerState = mib->findPeerHtState(staAddress);
+        ASSERT(peerState != nullptr);
+        ASSERT(peerState->negotiatedCapabilities.operation.primaryChannel == 11);
+        std::cout << "AP reassociation reconciles committed HT Operation with current channel after channel change.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtApReassociationSnapshotTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtAp;
+import inet.node.wireless.AccessPoint;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple Ieee80211MgmtApReassociationSnapshotAp extends Ieee80211MgmtAp
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApReassociationSnapshotAp);
+}
+
+simple Ieee80211MgmtApReassociationSnapshotTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtApReassociationSnapshotTest);
+}
+
+network Ieee80211MgmtApReassociationSnapshotNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        ap: AccessPoint {
+            parameters:
+                wlan[*].mgmt.typename = "Ieee80211MgmtApReassociationSnapshotAp";
+        }
+        test: Ieee80211MgmtApReassociationSnapshotTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtApReassociationSnapshotNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 1ms
+cmdenv-express-mode = false
+record-vector-results = false
+record-scalar-results = false
+
+*.ap.wlan[0].mgmt.beaconInterval = 10s
+*.ap.wlan[0].address = "02:00:00:00:00:01"
+*.ap.wlan[0].radio.channelNumber = 6
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 65Mbps
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+*.ap.mobility.initialX = 0m
+*.ap.mobility.initialY = 0m
+
+%contains: stdout
+AP reassociation reconciles committed HT Operation with current channel after channel change.

--- a/tests/module/Ieee80211MgmtStaBeaconUpdate_1.test
+++ b/tests/module/Ieee80211MgmtStaBeaconUpdate_1.test
@@ -1,0 +1,504 @@
+%description:
+Verify that an accepted Beacon from the currently associated AP refreshes
+the authoritative associated-AP snapshot and MIB peer HT state, that unicast
+rate selection dynamically follows changed channel-width, guard-interval, and
+MCS constraints, and that legacy or unusable updates preserve the association
+while falling back to legacy operational modes.
+
+%file: TestIeee80211MgmtStaBeaconUpdate.cc
+
+#include <string>
+#include <vector>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/QosRateSelection.h"
+#include "inet/linklayer/ieee80211/mac/rateselection/RateSelection.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211HtMgmtElements.h"
+#include "inet/linklayer/ieee80211/mgmt/Ieee80211MgmtSta.h"
+#include "inet/linklayer/ieee80211/mib/Ieee80211Mib.h"
+#include "inet/physicallayer/wireless/common/contract/packetlevel/SignalTag_m.h"
+#include "inet/physicallayer/wireless/ieee80211/mode/Ieee80211Channel.h"
+#include "inet/physicallayer/wireless/ieee80211/packetlevel/Ieee80211Tag_m.h"
+
+namespace inet {
+namespace ieee80211 {
+
+class TestIeee80211MgmtStaBeaconUpdate : public Ieee80211MgmtSta
+{
+  public:
+    int changedChannel = -1;
+    std::vector<int> changedChannels;
+    int associationConfirms = 0;
+
+    virtual void changeChannel(int channel) override
+    {
+        changedChannel = channel;
+        changedChannels.push_back(channel);
+    }
+
+    virtual void sendManagementFrame(const char *name, const Ptr<Ieee80211MgmtFrame>& body,
+            int subtype, const MacAddress& address) override
+    {
+    }
+
+    virtual void sendAssociationConfirm(ApInfo *ap, Ieee80211PrimResultCode resultCode) override
+    {
+        associationConfirms++;
+    }
+
+    void setPrimaryChannelForTest(int channel)
+    {
+        Enter_Method("setPrimaryChannelForTest");
+        mib->setPrimaryChannel(channel);
+    }
+
+    void enable40MhzLocalCapabilities()
+    {
+        Enter_Method("enable40MhzLocalCapabilities");
+        mib->localHtCapabilities.supportedChannelWidths.insert(MHz(40));
+        mib->localHtCapabilities.shortGi20 = true;
+        mib->localHtCapabilities.shortGi40 = true;
+    }
+
+    const ApInfo *getCachedAp(const MacAddress& address) const
+    {
+        return const_cast<TestIeee80211MgmtStaBeaconUpdate *>(this)->lookupAP(address);
+    }
+
+    bool isAssociatedForTest() const { return mib->bssStationData.isAssociated; }
+    const AssociatedApInfo& getAssocApForTest() const { return assocAP; }
+    bool hasPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address) != nullptr; }
+    const Ieee80211Mib::PeerHtState *getPeerHtState(const MacAddress& address) const { return mib->findPeerHtState(address); }
+    bool hasBeaconTimeoutForTest() const { return assocAP.beaconTimeoutMsg != nullptr; }
+    simtime_t getBeaconTimeoutArrivalForTest() const { return assocAP.beaconTimeoutMsg->getArrivalTime(); }
+    simtime_t getBeaconIntervalForTest() const { return assocAP.beaconInterval; }
+
+    void prepareResponse(const MacAddress& address, bool reassociation)
+    {
+        Enter_Method("prepareResponse");
+        auto ap = lookupAP(address);
+        if (ap == nullptr) {
+            apList.push_back(ApInfo());
+            ap = &apList.back();
+            ap->address = address;
+            ap->channel = mib->getHtOperation().primaryChannel;
+            ap->ssid = "test-bss";
+            ap->beaconInterval = SimTime(100, SIMTIME_MS);
+        }
+        ap->isAuthenticated = true;
+        assocTimeoutMsg = new cMessage("assocTimeout", 2);
+        assocTimeoutMsg->setContextPointer(ap);
+        reassociationInProgress = reassociation;
+    }
+
+    void deliverResponse(const MacAddress& address, bool reassociation, Ieee80211StatusCode statusCode,
+            int responseOperatingChannelWidth = 40, int responseSecondaryChannelOffset = 1,
+            bool shortGi20 = true, bool shortGi40 = true)
+    {
+        Enter_Method("deliverResponse");
+        Ptr<Ieee80211AssociationResponseFrame> body;
+        if (reassociation)
+            body = makeShared<Ieee80211ReassociationResponseFrame>();
+        else
+            body = makeShared<Ieee80211AssociationResponseFrame>();
+        body->setStatusCode(statusCode);
+        body->setAid(1);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+
+        auto capabilities = mib->localHtCapabilities;
+        auto operation = mib->getHtOperation();
+        operation.operatingChannelWidth = MHz(responseOperatingChannelWidth);
+        operation.secondaryChannelOffset = responseSecondaryChannelOffset;
+        capabilities.supportedChannelWidths.insert(MHz(20));
+        if (responseOperatingChannelWidth == 40)
+            capabilities.supportedChannelWidths.insert(MHz(40));
+        capabilities.shortGi20 = shortGi20;
+        capabilities.shortGi40 = shortGi40;
+        for (int i = 0; i < 8; i++) {
+            capabilities.rxMcsSupported[i] = true;
+            operation.basicMcsSupported[i] = true;
+        }
+        capabilities.txMcsNss.maxMcsPerNss[0] = 7;
+        setHtCapabilities(body, capabilities);
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        setHtOperation(body, band, operation);
+
+        body->setChunkLength(B(9) + getHtMgmtElementsLength(body));
+        auto packet = new Packet("AssociationResponse");
+        packet->insertAtBack(body);
+        int channelNumber = mib->getHtOperation().primaryChannel;
+        physicallayer::Ieee80211Channel channel(band, channelNumber);
+        packet->addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setTransmitterAddress(address);
+        processAssociationResponse(packet, header, reassociation);
+    }
+
+    void deliverBeaconFrame(const MacAddress& address,
+            bool htPresent,
+            int operatingChannelWidth = 20,
+            int secondaryChannelOffset = 0,
+            bool shortGi20 = true,
+            bool shortGi40 = false,
+            const std::vector<int>& supportedMcs = {0, 1, 2, 3, 4, 5, 6, 7},
+            const std::vector<int>& basicMcs = {0, 1, 2, 3, 4, 5, 6, 7},
+            simtime_t beaconInterval = SimTime(100, SIMTIME_MS),
+            bool malformedOperation = false)
+    {
+        Enter_Method("deliverBeaconFrame");
+        auto body = makeShared<Ieee80211BeaconFrame>();
+        body->setSSID("test-bss");
+        int primaryChannel = mib->getHtOperation().primaryChannel;
+        body->setChannelNumber(primaryChannel);
+        body->setBeaconInterval(beaconInterval);
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+
+        if (htPresent) {
+            Ieee80211HtCapabilities capabilities;
+            capabilities.supportedChannelWidths.insert(MHz(20));
+            if (operatingChannelWidth == 40)
+                capabilities.supportedChannelWidths.insert(MHz(40));
+            capabilities.shortGi20 = shortGi20;
+            capabilities.shortGi40 = shortGi40;
+            int maxMcs = -1;
+            for (int mcs : supportedMcs) {
+                if (mcs >= 0 && mcs < 77) {
+                    capabilities.rxMcsSupported[mcs] = true;
+                    if (mcs < 8 && mcs > maxMcs)
+                        maxMcs = mcs;
+                }
+            }
+            capabilities.txMcsNss.maxMcsPerNss[0] = maxMcs;
+            setHtCapabilities(body, capabilities);
+
+            Ieee80211HtOperation operation;
+            const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+            operation.primaryChannel = primaryChannel;
+            operation.operatingChannelWidth = MHz(operatingChannelWidth);
+            operation.secondaryChannelOffset = secondaryChannelOffset;
+            for (int mcs : basicMcs) {
+                if (mcs >= 0 && mcs < 77)
+                    operation.basicMcsSupported[mcs] = true;
+            }
+            setHtOperation(body, band, operation);
+
+            if (malformedOperation) {
+                auto opElement = body->getHtOperation();
+                opElement.secondaryChannelOffset = 2; // invalid offset
+                body->setHtOperation(opElement);
+            }
+        }
+        body->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(body));
+        auto packet = new Packet("Beacon");
+        packet->insertAtBack(body);
+        packet->addTag<SignalPowerInd>()->setPower(mW(1));
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        physicallayer::Ieee80211Channel channel(band, primaryChannel);
+        packet->addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_BEACON);
+        header->setTransmitterAddress(address);
+        handleBeaconFrame(packet, header);
+    }
+
+    void deliverProbeResponseFrame(const MacAddress& address,
+            bool htPresent,
+            int operatingChannelWidth = 20,
+            int secondaryChannelOffset = 0,
+            bool shortGi20 = true,
+            bool shortGi40 = false)
+    {
+        Enter_Method("deliverProbeResponseFrame");
+        auto body = makeShared<Ieee80211ProbeResponseFrame>();
+        body->setSSID("test-bss");
+        int primaryChannel = mib->getHtOperation().primaryChannel;
+        body->setChannelNumber(primaryChannel);
+        body->setBeaconInterval(SimTime(100, SIMTIME_MS));
+        Ieee80211SupportedRatesElement rates;
+        rates.numRates = 1;
+        rates.rate[0] = 6;
+        body->setSupportedRates(rates);
+
+        if (htPresent) {
+            Ieee80211HtCapabilities capabilities;
+            capabilities.supportedChannelWidths.insert(MHz(20));
+            if (operatingChannelWidth == 40)
+                capabilities.supportedChannelWidths.insert(MHz(40));
+            capabilities.shortGi20 = shortGi20;
+            capabilities.shortGi40 = shortGi40;
+            for (int i = 0; i < 8; i++)
+                capabilities.rxMcsSupported[i] = true;
+            capabilities.txMcsNss.maxMcsPerNss[0] = 7;
+            setHtCapabilities(body, capabilities);
+
+            Ieee80211HtOperation operation;
+            const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+            operation.primaryChannel = primaryChannel;
+            operation.operatingChannelWidth = MHz(operatingChannelWidth);
+            operation.secondaryChannelOffset = secondaryChannelOffset;
+            for (int i = 0; i < 8; i++)
+                operation.basicMcsSupported[i] = true;
+            setHtOperation(body, band, operation);
+        }
+        body->setChunkLength(B(8 + 2 + 2 + (2 + 10)) + B(3) + getHtMgmtElementsLength(body));
+        auto packet = new Packet("ProbeResponse");
+        packet->insertAtBack(body);
+        packet->addTag<SignalPowerInd>()->setPower(mW(1));
+        const auto *band = &physicallayer::Ieee80211CompliantBands::band2_4GHz;
+        physicallayer::Ieee80211Channel channel(band, primaryChannel);
+        packet->addTag<physicallayer::Ieee80211ChannelInd>()->setChannel(&channel);
+        auto header = makeShared<Ieee80211MgmtHeader>();
+        header->setType(ST_PROBERESPONSE);
+        header->setTransmitterAddress(address);
+        handleProbeResponseFrame(packet, header);
+    }
+};
+
+Define_Module(TestIeee80211MgmtStaBeaconUpdate);
+
+class Ieee80211MgmtStaBeaconUpdateTest : public cSimpleModule
+{
+  public:
+    Ieee80211MgmtStaBeaconUpdateTest() : cSimpleModule(65536) {}
+
+  protected:
+    virtual void activity() override
+    {
+        auto mgmt = check_and_cast<TestIeee80211MgmtStaBeaconUpdate *>(getModuleByPath("^.sta.wlan[0].mgmt"));
+        auto dcfRateSelection = check_and_cast<RateSelection *>(getModuleByPath("^.sta.wlan[0].mac.dcf.rateSelection"));
+        auto qosRateSelection = check_and_cast<QosRateSelection *>(getModuleByPath("^.sta.wlan[0].mac.hcf.rateSelection"));
+        const auto *modeSet = physicallayer::Ieee80211ModeSet::getModeSet("n(mixed-2.4Ghz)");
+
+        const MacAddress apAddress("02:00:00:00:00:01");
+        auto dataHeader = makeShared<Ieee80211DataHeader>();
+        dataHeader->setReceiverAddress(apAddress);
+        Packet ratePacket("rate-selection");
+
+        auto checkUnicastMode = [&](Hz expectedBandwidth, bool expectedSgi, int expectedMcs) {
+            const auto *dcfMode = dcfRateSelection->computeMode(&ratePacket, dataHeader);
+            const auto *qosMode = qosRateSelection->computeMode(&ratePacket, dataHeader, nullptr);
+            ASSERT(dcfMode == qosMode);
+            if (expectedMcs >= 0) {
+                ASSERT(dcfMode->getHtMcsIndex() == expectedMcs);
+                ASSERT(dcfMode->getDataMode()->getBandwidth() == expectedBandwidth);
+                ASSERT(dcfMode->isHtShortGuardInterval() == expectedSgi);
+            }
+            else {
+                ASSERT(dcfMode->getHtMcsIndex() < 0);
+                ASSERT(dcfMode == modeSet->getFastestLegacyOperationalMode());
+            }
+        };
+
+        mgmt->setPrimaryChannelForTest(6);
+        mgmt->enable40MhzLocalCapabilities();
+
+        // 1. Initial Beacon discovery (40 MHz, Short GI 20 & 40, MCS 0..7)
+        mgmt->deliverBeaconFrame(apAddress, true, 40, 1, true, true);
+        ASSERT(mgmt->getCachedAp(apAddress) != nullptr);
+        ASSERT(mgmt->getCachedAp(apAddress)->htOperationPresent);
+        ASSERT(mgmt->getCachedAp(apAddress)->htOperation.operatingChannelWidth == MHz(40));
+
+        // 2. Initial Association (40 MHz, Short GI 20 & 40)
+        mgmt->prepareResponse(apAddress, false);
+        mgmt->deliverResponse(apAddress, false, SC_SUCCESSFUL, 40, 1, true, true);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasPeerHtState(apAddress));
+        ASSERT(mgmt->getAssocApForTest().htOperation.operatingChannelWidth == MHz(40));
+        ASSERT(mgmt->getAssocApForTest().htCapabilities.shortGi20);
+        ASSERT(mgmt->getAssocApForTest().htCapabilities.shortGi40);
+        ASSERT(mgmt->hasBeaconTimeoutForTest());
+
+        // Verify rate selection selects 40 MHz Short GI MCS 7 (150 Mbps)
+        checkUnicastMode(MHz(40), true, 7);
+
+        // 3. Subsequent Beacon from associated AP switches HT Operation to 20 MHz
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverBeaconFrame(apAddress, true, 20, 0, true, true);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasPeerHtState(apAddress));
+        ASSERT(mgmt->getAssocApForTest().htOperation.operatingChannelWidth == MHz(20));
+        ASSERT(mgmt->getAssocApForTest().htOperation.secondaryChannelOffset == 0);
+        ASSERT(mgmt->getPeerHtState(apAddress)->negotiatedCapabilities.operation.operatingChannelWidth == MHz(20));
+        // Rate selection must demote to 20 MHz Short GI MCS 7; cannot retain obsolete 40 MHz constraint
+        checkUnicastMode(MHz(20), true, 7);
+
+        // 4. Subsequent Beacon disables Short Guard Interval (20 MHz, Long GI)
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverBeaconFrame(apAddress, true, 20, 0, false, false);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasPeerHtState(apAddress));
+        ASSERT(!mgmt->getAssocApForTest().htCapabilities.shortGi20);
+        ASSERT(!mgmt->getPeerHtState(apAddress)->negotiatedCapabilities.localTxPeerRx.receiverShortGi20);
+        // Rate selection must demote to 20 MHz Long GI MCS 7; cannot retain obsolete Short GI constraint
+        checkUnicastMode(MHz(20), false, 7);
+
+        // 5. Subsequent Beacon restricts supported MCS to MCS 0 only
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverBeaconFrame(apAddress, true, 20, 0, false, false, {0}, {0});
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasPeerHtState(apAddress));
+        ASSERT(mgmt->getAssocApForTest().htCapabilities.rxMcsSupported[0]);
+        ASSERT(!mgmt->getAssocApForTest().htCapabilities.rxMcsSupported[7]);
+        ASSERT(mgmt->getPeerHtState(apAddress)->negotiatedCapabilities.localTxPeerRx.supportedMcs[0]);
+        ASSERT(!mgmt->getPeerHtState(apAddress)->negotiatedCapabilities.localTxPeerRx.supportedMcs[7]);
+        // Rate selection must demote to MCS 0; cannot retain obsolete MCS 7 constraint
+        checkUnicastMode(MHz(20), false, 0);
+
+        // 6. Subsequent Beacon switches to Legacy advertisement (no HT elements)
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverBeaconFrame(apAddress, false);
+        // Association is PRESERVED, beacon timeout timer still active
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasBeaconTimeoutForTest());
+        ASSERT(!mgmt->getAssocApForTest().htCapabilitiesPresent);
+        ASSERT(!mgmt->getAssocApForTest().htOperationPresent);
+        // MIB peer HT state is REMOVED
+        ASSERT(!mgmt->hasPeerHtState(apAddress));
+        // Rate selection falls back to fastest legacy operational mode
+        checkUnicastMode(MHz(20), false, -1);
+
+        // 7. Subsequent Beacon advertises unusable HT (unsupported Basic MCS 32 only)
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverBeaconFrame(apAddress, true, 20, 0, true, false, {0, 1, 2, 3, 4, 5, 6, 7}, {32});
+        // Association is PRESERVED
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasBeaconTimeoutForTest());
+        ASSERT(mgmt->getAssocApForTest().htOperationPresent);
+        ASSERT(mgmt->getAssocApForTest().htOperation.basicMcsSupported[32]);
+        // MIB peer HT state remains absent because Basic MCS is unsupported
+        ASSERT(!mgmt->hasPeerHtState(apAddress));
+        // Rate selection remains on legacy mode
+        checkUnicastMode(MHz(20), false, -1);
+
+        // 8. Subsequent Beacon restores full 40 MHz Short GI HT advertisement + updates beacon interval
+        wait(SimTime(1, SIMTIME_US));
+        simtime_t newBeaconInterval = SimTime(200, SIMTIME_MS);
+        mgmt->deliverBeaconFrame(apAddress, true, 40, 1, true, true,
+                {0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}, newBeaconInterval);
+        ASSERT(mgmt->isAssociatedForTest());
+        ASSERT(mgmt->hasPeerHtState(apAddress));
+        ASSERT(mgmt->getAssocApForTest().htOperation.operatingChannelWidth == MHz(40));
+        ASSERT(mgmt->getAssocApForTest().htCapabilities.shortGi20);
+        ASSERT(mgmt->getAssocApForTest().htCapabilities.shortGi40);
+        ASSERT(mgmt->getAssocApForTest().beaconInterval == newBeaconInterval);
+        // Beacon timeout timer rescheduled with new beacon interval
+        ASSERT(mgmt->getBeaconTimeoutArrivalForTest() == simTime() + 3.5 * newBeaconInterval);
+        // Rate selection restores 40 MHz Short GI MCS 7 (150 Mbps)
+        checkUnicastMode(MHz(40), true, 7);
+
+        // 9. Subsequent malformed Beacon (invalid secondaryChannelOffset = 2) is rejected
+        wait(SimTime(1, SIMTIME_US));
+        simtime_t deadlineBeforeMalformed = mgmt->getBeaconTimeoutArrivalForTest();
+        mgmt->deliverBeaconFrame(apAddress, true, 40, 1, true, true,
+                {0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}, newBeaconInterval, true);
+        // Beacon deadline must NOT be extended for rejected beacon
+        ASSERT(mgmt->getBeaconTimeoutArrivalForTest() == deadlineBeforeMalformed);
+        // Authoritative state must NOT be corrupted
+        ASSERT(mgmt->getAssocApForTest().htOperation.operatingChannelWidth == MHz(40));
+        ASSERT(mgmt->hasPeerHtState(apAddress));
+        checkUnicastMode(MHz(40), true, 7);
+
+        // 10. Probe Response from associated AP does NOT update authoritative HT snapshot or MIB state
+        wait(SimTime(1, SIMTIME_US));
+        mgmt->deliverProbeResponseFrame(apAddress, true, 20, 0, false, false);
+        // Cached AP list has the probe response, but assocAP and MIB peer HT state retain 40 MHz SGI
+        ASSERT(mgmt->getCachedAp(apAddress)->htOperation.operatingChannelWidth == MHz(20));
+        ASSERT(mgmt->getAssocApForTest().htOperation.operatingChannelWidth == MHz(40));
+        ASSERT(mgmt->getPeerHtState(apAddress)->negotiatedCapabilities.operation.operatingChannelWidth == MHz(40));
+        checkUnicastMode(MHz(40), true, 7);
+
+        std::cout << "Subsequent Beacon updates authoritative associated-AP snapshot and MIB peer HT state.\n";
+        std::cout << "Unicast rate selection follows dynamic channel-width, guard-interval, and MCS updates.\n";
+        std::cout << "Legacy and unusable HT updates preserve association while falling back to legacy modes.\n";
+    }
+};
+
+Define_Module(Ieee80211MgmtStaBeaconUpdateTest);
+
+} // namespace ieee80211
+} // namespace inet
+
+%file: test.ned
+
+//
+// Copyright (C) 2026 INET Framework contributors
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+
+import inet.common.SimpleModule;
+import inet.linklayer.ieee80211.mgmt.Ieee80211MgmtSta;
+import inet.node.inet.WirelessHost;
+import inet.physicallayer.wireless.ieee80211.packetlevel.Ieee80211ScalarRadioMedium;
+
+simple TestIeee80211MgmtStaBeaconUpdate extends Ieee80211MgmtSta
+{
+    parameters:
+        @class(::inet::ieee80211::TestIeee80211MgmtStaBeaconUpdate);
+}
+
+simple Ieee80211MgmtStaBeaconUpdateTest extends SimpleModule
+{
+    parameters:
+        @class(::inet::ieee80211::Ieee80211MgmtStaBeaconUpdateTest);
+}
+
+network Ieee80211MgmtStaBeaconUpdateTestNetwork
+{
+    submodules:
+        radioMedium: Ieee80211ScalarRadioMedium;
+        sta: WirelessHost {
+            parameters:
+                wlan[*].mgmt.typename = "TestIeee80211MgmtStaBeaconUpdate";
+                wlan[*].agent.typename = "Ieee80211AgentSta";
+        }
+        test: Ieee80211MgmtStaBeaconUpdateTest;
+}
+
+%inifile: omnetpp.ini
+
+[General]
+network = Ieee80211MgmtStaBeaconUpdateTestNetwork
+ned-path = .;../../../../src;../../lib
+sim-time-limit = 10ms
+seed-set = 0
+cmdenv-express-mode = true
+record-vector-results = false
+record-scalar-results = false
+
+*.sta.wlan[0].address = "02:00:00:00:00:09"
+*.sta.wlan[0].agent.startingTime = 100s
+**.wlan[*].opMode = "n(mixed-2.4Ghz)"
+**.wlan[*].bitrate = 150Mbps
+*.sta.wlan[0].mac.*.rateSelection.dataFrameBitrate = 150Mbps
+*.sta.wlan[0].mac.*.rateSelection.dataFrameBandwidth = 40MHz
+*.sta.wlan[0].mac.*.rateSelection.dataFrameNumSpatialStreams = 1
+*.sta.wlan[0].mac.qosStation = true
+**.wlan[*].radio.bandName = "2.4 GHz"
+**.wlan[*].radio.centerFrequency = 2.4GHz
+**.wlan[*].radio.transmitter.power = 100mW
+**.wlan[*].radio.receiver.sensitivity = -85dBm
+**.wlan[*].radio.receiver.snirThreshold = 4dB
+**.mobility.initFromDisplayString = false
+**.mobility.constraintAreaMinX = 0m
+**.mobility.constraintAreaMinY = 0m
+**.mobility.constraintAreaMinZ = 0m
+**.mobility.constraintAreaMaxX = 100m
+**.mobility.constraintAreaMaxY = 100m
+**.mobility.constraintAreaMaxZ = 0m
+
+%contains: stdout
+Subsequent Beacon updates authoritative associated-AP snapshot and MIB peer HT state.
+
+%contains: stdout
+Unicast rate selection follows dynamic channel-width, guard-interval, and MCS updates.
+
+%contains: stdout
+Legacy and unusable HT updates preserve association while falling back to legacy modes.


### PR DESCRIPTION
## What

Keep the negotiated IEEE 802.11 HT operation coherent across runtime state changes: an associated STA refreshes its HT state from accepted Beacons, and both sides reconcile the operation across runtime channel and band changes.

## Why

Two related gaps left the negotiated HT state stale or inconsistent across runtime changes:

1. An associated STA never refreshed its HT width, guard-interval, and MCS constraints from accepted Beacons, so post-association changes in the BSS operation were ignored — and a Probe Response could overwrite the authoritative associated-AP snapshot.
2. A runtime band or channel change could invalidate an HT40 pair while negotiated peer state stayed on the old operation, and a band change that retained the same internal channel index skipped revalidation entirely. Furthermore, when a pending association response completes after a runtime operation change, committed peer state could become desynchronized from the current BSS operation.

## Stack and reading order

PR 4/4. Head: `pr/ht-04-runtime-state`. Target: `master` (PR 1/4 [#1167](https://github.com/inet-framework/inet/pull/1167), PR 2/4 [#1172](https://github.com/inet-framework/inet/pull/1172), and PR 3/4 [#1173](https://github.com/inet-framework/inet/pull/1173) merged). Range: `53acf0a633..79a767a3b9`. Read the following commits in order:

1. `8fc2eaa285` — `ieee80211: refresh associated HT state from accepted beacons`
   STA side: refresh the authoritative associated-AP snapshot and peer constraints from accepted Beacons; Probe Responses must not overwrite that state.
2. `79a767a3b9` — `ieee80211: reconcile HT operation across runtime channel changes`
   Revalidate the operation on band/channel change (even when the internal channel index is unchanged), fall back or restore width, update peer constraints, and reconcile committed peer state when a pending association response completes while preserving the element already advertised on the wire.

## Architectural surface

- Contracts: `Ieee80211Mib` gains a `setPrimaryChannel` overload that takes the band (`void setPrimaryChannel(int primaryChannel, const physicallayer::IIeee80211Band *band);`); callers are `Ieee80211MgmtApBase` and `Ieee80211Radio`.
- Associated STA state: `Ieee80211MgmtSta` updates `assocAP` and peer HT capabilities on accepted Beacons from the associated AP.
- Radio signaling: `Ieee80211Radio` emits `radioChannelChangedSignal` on band change when a channel is configured, ensuring channel revalidation across band transitions.
- AP association completion: `Ieee80211MgmtAp` reconciles committed peer HT state with current MIB operation upon response completion.
- Packet content: unchanged.
- Configuration surface: unchanged (no NED or ini changes).
- Feature descriptors: unchanged.
- No new `AV-*` / `NV-*` deviations; no sealed paths are touched.

## Baselines

No fingerprint or statistical baseline changes.

## Verification

Passing debug build and passing focused module test suite:

```sh
make MODE=debug -j$(nproc)
inet_run_module_tests -m debug -f '(Ieee80211HtAssociation_1|Ieee80211MgmtApChannelChange_1|Ieee80211MgmtApReassociationSnapshot_1|Ieee80211MgmtStaBeaconUpdate_1)\.test'
```

Result: 4 PASS with exit 0:
- `Ieee80211MgmtStaBeaconUpdate_1.test` (added by C1): verifies width, short GI, MCS set refresh, and legacy fallback from accepted Beacons while ignoring Probe Responses.
- `Ieee80211MgmtApChannelChange_1.test` (added by C2): verifies 40 MHz fallback to 20 MHz on channel change, width restoration on return to supported channel, and peer constraint refresh.
- `Ieee80211MgmtApReassociationSnapshot_1.test` (added by C2): verifies committed peer state reconciliation when association completes after a channel change.
- `Ieee80211HtAssociation_1.test` (adjusted in C2): verifies committed peer negotiated operation tracks updated primary channel.

Commit gate (`doc/project/enforcement/check-commits.sh origin/master..HEAD`) and source seals guard (`doc/project/enforcement/check-source-seals.sh --base origin/master`) both PASS, exit 0. Working tree clean.
