### PR TITLE
ipv6: keep an address alive while its prefix is still advertised

### DIFF
--- a/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
+++ b/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
@@ -2489,6 +2489,7 @@ void Ipv6NeighbourDiscovery::processRaPrefixInfoForAddrAutoConf(const Ipv6NdPref
 
     // changed structure of code below, 12.9.07 - CB
     bool isPrefixAssignedToInterface = false;
+    int assignedAddrIndex = -1;
     bool returnedHome = false; // 4.9.07 - CB
 
     for (int i = 0; i < ie->getProtocolData<Ipv6InterfaceData>()->getNumAddresses(); i++) {
@@ -2516,9 +2517,47 @@ void Ipv6NeighbourDiscovery::processRaPrefixInfoForAddrAutoConf(const Ipv6NdPref
                 returnedHome = true;
             else {
                 isPrefixAssignedToInterface = true;
+                assignedAddrIndex = i;
                 EV_INFO << "The received Prefix is already assigned to the interface" << endl; // Zarrar Yousaf 19.07.07
                 break;
             }
+        }
+    }
+
+    /*e) If the advertised prefix is equal to the prefix of an address
+         configured by stateless autoconfiguration in the list, the preferred
+         lifetime of the address is reset to the Preferred Lifetime in the
+         received advertisement.  The specific action to perform for the valid
+         lifetime of the address depends on the Valid Lifetime in the received
+         advertisement and the remaining time to the valid lifetime expiration
+         of the previously autoconfigured address.*/
+    if (isPrefixAssignedToInterface) {
+        auto *ipv6Data = ie->getProtocolDataForUpdate<Ipv6InterfaceData>();
+        simtime_t expiryTime = ipv6Data->getAddressExpiryTime(assignedAddrIndex);
+        // An address with an infinite valid lifetime was not autoconfigured from a
+        // Prefix Information option, so step (e) does not speak about it.
+        if (expiryTime != SIMTIME_ZERO) {
+            // RFC 4862 Section 5.5.3 (e) writes the remaining valid lifetime of the
+            // address as RemainingLifetime, and caps how far an unauthenticated
+            // advertisement may shorten it. Without that cap a single forged
+            // advertisement carrying short valid lifetimes could expire every
+            // address of a node; a legitimate advertisement, which the router
+            // repeats, always passes the first case and takes effect immediately.
+            const simtime_t twoHours = 7200;
+            simtime_t remainingLifetime = expiryTime - simTime();
+            simtime_t newValidLifetime;
+
+            if (validLifetime > twoHours || validLifetime > remainingLifetime)
+                newValidLifetime = validLifetime; // (e)(1)
+            else if (remainingLifetime <= twoHours)
+                newValidLifetime = remainingLifetime; // (e)(2), the advertisement is not authenticated
+            else
+                newValidLifetime = twoHours; // (e)(3)
+
+            EV_INFO << "Prefix already assigned to the interface, refreshing lifetimes: valid "
+                    << newValidLifetime << ", preferred " << preferredLifetime << endl;
+            ipv6Data->updateMatchingAddressExpiryTimes(prefix, prefixLength,
+                    simTime() + newValidLifetime, simTime() + preferredLifetime);
         }
     }
     /*d) If the prefix advertised does not match the prefix of an address already

--- a/src/inet/networklayer/ipv6/Ipv6InterfaceData.cc
+++ b/src/inet/networklayer/ipv6/Ipv6InterfaceData.cc
@@ -362,6 +362,12 @@ Ipv6InterfaceData::AddressType Ipv6InterfaceData::getAddressType(int i) const
     return addresses[i].addrType;
 }
 
+simtime_t Ipv6InterfaceData::getAddressExpiryTime(int i) const
+{
+    ASSERT(i >= 0 && i < (int)addresses.size());
+    return addresses[i].expiryTime;
+}
+
 Ipv6InterfaceData::AddressType Ipv6InterfaceData::getAddressType(const Ipv6Address& addr) const
 {
     return getAddressType(findAddress(addr));

--- a/src/inet/networklayer/ipv6/Ipv6InterfaceData.h
+++ b/src/inet/networklayer/ipv6/Ipv6InterfaceData.h
@@ -491,6 +491,12 @@ class INET_API Ipv6InterfaceData : public InterfaceProtocolData
     AddressType getAddressType(int i) const;
 
     /**
+     * Returns the time at which the valid lifetime of the ith address of the
+     * interface expires, or zero if that lifetime is infinite.
+     */
+    simtime_t getAddressExpiryTime(int i) const;
+
+    /**
      * Returns the address type (HoA, CoA) of the provided address of the interface.
      */
     AddressType getAddressType(const Ipv6Address& addr) const;

--- a/tests/module/Ipv6_prefix_lifetime_refresh.test
+++ b/tests/module/Ipv6_prefix_lifetime_refresh.test
@@ -1,0 +1,78 @@
+%description:
+Tests that a repeated Prefix Information option refreshes the lifetimes of the
+address the host already holds from that prefix (RFC 4862 Section 5.5.3 step e).
+
+The router advertises a prefix whose valid lifetime (20 s) and preferred
+lifetime (10 s) are much shorter than the 60 s run, and re-advertises it every
+4 s to 6 s. The host forms one address from the prefix and must then keep it
+alive from the repeated advertisements, instead of forming a second address or
+letting the first one lapse at the lifetime the first advertisement carried.
+
+%#--------------------------------------------------------------------------------------------------------------
+%file: test.ned
+import inet.networklayer.configurator.ipv6.Ipv6NetworkConfigurator;
+import inet.node.ipv6.Router6;
+import inet.node.ipv6.StandardHost6;
+import ned.DatarateChannel;
+
+network PrefixLifetimeRefreshNetwork
+{
+    types:
+        channel ethline extends DatarateChannel
+        {
+            delay = 0.1us;
+            datarate = 100Mbps;
+        }
+    submodules:
+        configurator: Ipv6NetworkConfigurator;
+        router: Router6;
+        host: StandardHost6;
+    connections:
+        host.ethg++ <--> ethline <--> router.ethg++;
+}
+%#--------------------------------------------------------------------------------------------------------------
+%file: config.xml
+<config>
+    <interface among="host router" prefix="aaaa:1::/64" advValidLifetime="20" advPreferredLifetime="10"/>
+</config>
+%#--------------------------------------------------------------------------------------------------------------
+%inifile: omnetpp.ini
+[General]
+record-vector-results = false
+ned-path = ../../../../src
+network = PrefixLifetimeRefreshNetwork
+sim-time-limit = 60s
+cmdenv-express-mode = false
+cmdenv-log-prefix = "%C: "
+
+**.ipv6.configurator.networkConfiguratorModule = "configurator"
+*.configurator.assignAddressesToHosts = false
+*.configurator.config = xmldoc("config.xml")
+
+# Advertise far more often than the advertised lifetimes, so that the address
+# would lapse many times over if the advertisements did not refresh it.
+**.neighbourDiscovery.minIntervalBetweenRAs = 4s
+**.neighbourDiscovery.maxIntervalBetweenRAs = 6s
+
+# Ethernet NIC configuration
+**.eth[*].queue.typename = "EthernetQosQueue"
+**.eth[*].queue.dataQueue.typename = "DropTailQueue"
+**.eth[*].queue.dataQueue.packetCapacity = 10
+
+%#--------------------------------------------------------------------------------------------------------------
+%subst: /omnetpp:://
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+PrefixLifetimeRefreshNetwork.host.ipv6.neighbourDiscovery: DAD completed for address aaaa:1::
+%#--------------------------------------------------------------------------------------------------------------
+%contains: stdout
+PrefixLifetimeRefreshNetwork.host.ipv6.neighbourDiscovery: Prefix already assigned to the interface, refreshing lifetimes: valid 20, preferred 10
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: grep -c "Assigning new address to: eth0" test.out > test_newaddr.out || true
+%contains: test_newaddr.out
+1
+%#--------------------------------------------------------------------------------------------------------------
+%postrun-command: grep "undisposed object:" test.out > test_undisposed.out || true
+%not-contains: test_undisposed.out
+undisposed object: (
+%#--------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A host stored the valid and preferred lifetimes it was given when it first
formed an address from an advertised prefix, and nothing ever updated them. The
router repeating the prefix -- which is how a host is meant to keep the address
it holds -- left them untouched, so the address stayed on the schedule the first
advertisement had set, however long the router kept advertising.

Closes #1180

Two commits: the first adds a getter to a shared component, the second is the
fix that needs it. Read them in that order.

## The problem

RFC 4862 Section 5.5.3 step (e) has a host that receives a Prefix Information
option for a prefix it already holds an address from reset that address's
preferred lifetime and, under three sub-cases, its valid lifetime.

`processRaPrefixInfoForAddrAutoConf()` had no branch for that case at all. It
formed an address when the prefix was new to the interface, took the MIPv6
handover path when the interface held addresses from another prefix, and did
nothing when the same router repeated the same prefix.
`Ipv6InterfaceData::updateMatchingAddressExpiryTimes()`, which does the storing,
had no caller anywhere in the tree.

The other half of Section 5.5.3 is already implemented: commit 21aca8cee7 made a
Prefix Information option with a zero valid lifetime invalidate the address
autoconfigured from that prefix. Step (e) is the missing half.

## The fix

The branch is added with all three sub-cases. The valid lifetime follows the
advertisement when it is longer than two hours or longer than what is left; it
is left alone when two hours or less remain, because the advertisement is not
authenticated; otherwise it is cut to two hours. Those rules are what stops a
forged advertisement carrying short valid lifetimes from expiring every address
of a node, while a legitimate advertisement, which a router repeats, always
takes the first case and applies at once. The preferred lifetime follows the
advertisement in every case, as the step says.

An address with an infinite valid lifetime was not autoconfigured from a Prefix
Information option, so step (e) does not speak about it and the branch leaves it
alone.

## Why the first commit is separate

`Ipv6InterfaceData` stored a per-address valid lifetime expiry and let a caller
set it, through `assignAddress()` and `updateMatchingAddressExpiryTimes()`, but
offered no way to read it back, and step (e) has to decide the new valid lifetime
from the lifetime that is left. `getAddressExpiryTime(int i)` is a change to a
shared component with its own audience, so it is its own commit and comes first
(PR-SPLIT-UPSTREAM). It adds no caller of its own, so it changes no behaviour and
moves no baseline.

## Verification

```
cd tests/fingerprint && ./fingerprinttest -s -F tyf
cd tests/module      && inet_run_module_tests   -m release -f 'IPv6|MIPv6|Ipv6'
cd tests/protocol/ipv6 && inet_run_protocol_tests -m release
bash doc/project/enforcement/check-commits.sh origin/master..HEAD
```

Unmodified master gives 1774 rows with 3 failures and 62 errors, and so does
this branch. The 62 errors are disabled optional features -- `VoIPStream`,
`TcpLwip`, `VoipStreamSender` -- and have nothing to do with IPv6. The 3 failures
are `examples/ipv6/mipv6` `Handover` and `RouteOptimizationTwoCNs` and
`examples/ipv6/mipv6roaming` `Roaming`, all `~tNlb` rows of
`mipv6-refactoring.csv`. Their recorded values are stale on master already, so
they keep them here; re-recording them would absorb that staleness rather than
fix it.

No fingerprint moves, and none is expected: no shipped example advertises a
lifetime short enough to be reached within its run, so no advertisement in the
suite lands on a prefix the receiving host already holds an address from with a
lifetime worth refreshing. The whole 1774-row suite was still run, on both
commits, to show that.

Module tests: 43 tests, 41 pass. `MIPv6_tcp_handover` and `IPv6_packet_too_big`
fail identically on unmodified master. The 43rd is the new
`Ipv6_prefix_lifetime_refresh`, which fails on master and passes here.

Protocol tests, `tests/protocol/ipv6`: 29 tests, 21 pass and 8 expected failures
-- the same result as unmodified master.

`check-commits.sh` passes. `check-architecture.sh` and `check-naming.sh` report
only candidates already present on master, in `src/inet/applications/sctpapp`,
`src/inet/applications/rtpapp` and `images/misc`.

## Architectural surface

`Ipv6InterfaceData` gains one const getter, `getAddressExpiryTime(int i)`. No
packet content, configuration surface, feature descriptor or contract changes,
and no sealed path is touched. The new module test is named
`Ipv6_prefix_lifetime_refresh.test` rather than `IPv6_...`, so it does not widen
the open `NV-16` row; no new `AV-*` or `NV-*` row is needed.

## Not addressed here

`Ipv6InterfaceData::getPreferredAddress()` (`Ipv6InterfaceData.h:559`) and
`getGlobalAddress()` (`Ipv6InterfaceData.cc:777`) return an address without
checking whether its lifetimes have run out; both carry a `FIXME` saying so. And
nothing removes an address when its valid lifetime expires -- it survives until
the next unrelated change to the interface's address list runs
`choosePreferredAddress()`. Until both are repaired, a stale lifetime has no
effect a running simulation can see, which is why this defect needs a module test
to demonstrate it and moves no fingerprint.

Two further Neighbour Discovery conformance defects are fixed separately, in
#1178 (the initial Router Advertisement clamp) and #1179 (the Duplicate Address
Detection delay).
