### PR TITLE
ipv6: delay the first Duplicate Address Detection probe

### DIFF
--- a/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
+++ b/src/inet/networklayer/icmpv6/Ipv6NeighbourDiscovery.cc
@@ -836,19 +836,22 @@ void Ipv6NeighbourDiscovery::initiateDad(const Ipv6Address& tentativeAddr, Netwo
        the IP source is set to the unspecified address and the IP
        destination is set to the solicited-node multicast address of the
        target address.*/
-    Ipv6Address destAddr = tentativeAddr.formSolicitedNodeMulticastAddress();
-    // Send a NS
-    createAndSendNsPacket(tentativeAddr, destAddr,
-            Ipv6Address::UNSPECIFIED_ADDRESS, ie);
-    dadEntry->numNSSent++;
-
     cMessage *msg = new cMessage("dadTimeout", MK_DAD_TIMEOUT);
     msg->setContextPointer(dadEntry);
     dadEntry->timeoutMsg = msg;
 
-    // added uniform(0, IPv6_MAX_RTR_SOLICITATION_DELAY) to account for joining the solicited-node multicast
-    // group which is delay up to one 1 second (RFC 4862, 5.4.2)
-    scheduleAfter(ie->getProtocolData<Ipv6InterfaceData>()->getRetransTimer() + uniform(0, IPv6_MAX_RTR_SOLICITATION_DELAY), msg);
+    /*RFC 4862: Section 5.4.2
+       Before sending a Neighbor Solicitation, an interface MUST join the
+       all-nodes multicast address and the solicited-node multicast address
+       of the tentative address.*/
+    /*If the Neighbor Solicitation is going to be the first message sent
+       from an interface after interface (re)initialization, the node SHOULD
+       delay joining the solicited-node multicast address by a random delay
+       between 0 and MAX_RTR_SOLICITATION_DELAY as specified in [RFC4861].*/
+    // The join has to precede the solicitation, so delaying the join delays the
+    // solicitation with it. processDadTimeout() sends this first solicitation and
+    // every later one, each separated by RetransTimer.
+    scheduleAfter(uniform(0, IPv6_MAX_RTR_SOLICITATION_DELAY), msg);
 
     emit(startDadSignal, 1);
 }

--- a/tests/fingerprint/examples.csv
+++ b/tests/fingerprint/examples.csv
@@ -31,14 +31,14 @@
 /examples/bgpv4/BgpUpdate/,          -f omnetpp.ini -c General -r 0,                30s,             9552-83f7/tplx;3a06-a4f0/~tNl;62be-5688/~tND;0573-e0b4/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpAndOspf/,         -f omnetpp.ini -c General -r 0,                1000s,           1e22-36e3/tplx;2b66-00b2/~tNl;430e-7064/~tND;de89-afd7/tyf, PASS, ospf EthernetMac Ipv4
 /examples/bgpv4/BgpAndOspfSimple/,   -f omnetpp.ini -c General -r 0,                1000s,           dc15-38aa/tplx;dacd-0cbd/~tNl;46d3-bcb3/~tND;8a59-2347/tyf, PASS, ospf EthernetMac Ipv4
-/examples/bgpv4/BgpIpv6Basic/,       -f omnetpp.ini -c General -r 0,                30s,             4094-e79b/tplx;a631-2b6d/~tNl;7b45-6ce9/~tND;b856-841a/tyf, PASS, EthernetMac Ipv6
-/examples/bgpv4/BgpAndOspfv3/,       -f omnetpp.ini -c General -r 0,                100s,            279e-7c39/tplx;c850-91d5/~tNl;4a67-0d99/~tND, PASS, ospf EthernetMac Ipv6
+/examples/bgpv4/BgpIpv6Basic/,       -f omnetpp.ini -c General -r 0,                30s,             54f7-bd6d/tplx;a255-8bd4/~tNl;7e9d-f559/~tND;b856-841a/tyf, PASS, EthernetMac Ipv6
+/examples/bgpv4/BgpAndOspfv3/,       -f omnetpp.ini -c General -r 0,                100s,            3ecb-8be7/tplx;962e-acef/~tNl;2c1e-2db8/~tND, PASS, ospf EthernetMac Ipv6
 /examples/bgpv4/BgpDiamondFailover/, -f omnetpp.ini -c General -r 0,                160s,            819b-726f/tplx;759b-8711/~tNl;f690-850d/~tND;fc56-f343/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
-/examples/bgpv4/BgpDiamondFailover6/,-f omnetpp.ini -c General -r 0,                160s,            a666-6758/tplx;d51e-c4d6/~tNl;2735-bd52/~tND;5c49-0569/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
+/examples/bgpv4/BgpDiamondFailover6/,-f omnetpp.ini -c General -r 0,                160s,            5fca-d255/tplx;419a-cee4/~tNl;4a8d-2ae9/~tND;5c49-0569/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
 /examples/bgpv4/BgpWithdrawal/,      -f omnetpp.ini -c General -r 0,                100s,            5c56-7cbf/tplx;8250-4312/~tNl;4fe4-ce94/~tND;4b70-109c/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
 /examples/bgpv4/BgpWithdrawal/,      -f omnetpp.ini -c Restart -r 0,                160s,            ca6f-1994/tplx;93e2-ddd6/~tNl;e095-19d7/~tND;6886-9c54/tyf, PASS, ospf EthernetMac Ipv4 lifecycle
-/examples/bgpv4/BgpWithdrawal6/,     -f omnetpp.ini -c General -r 0,                100s,            ab2e-3ef8/tplx;9719-7216/~tNl;3f7c-49a9/~tND;e5cd-25cd/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
-/examples/bgpv4/BgpWithdrawal6/,     -f omnetpp.ini -c Restart -r 0,                160s,            1049-f3fa/tplx;9430-9652/~tNl;16c8-e8fa/~tND;92cc-81f6/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
+/examples/bgpv4/BgpWithdrawal6/,     -f omnetpp.ini -c General -r 0,                100s,            524f-e919/tplx;e75a-3b00/~tNl;47f0-f512/~tND;e5cd-25cd/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
+/examples/bgpv4/BgpWithdrawal6/,     -f omnetpp.ini -c Restart -r 0,                160s,            3175-c313/tplx;a66e-f4db/~tNl;74e4-0f90/~tND;92cc-81f6/tyf, PASS, ospf EthernetMac Ipv6 lifecycle
 
 /examples/clock/,                    -f omnetpp.ini -c General -r 0,                10ms,            35c3-8325/tplx;0000-0000/~tNl;0000-0000/~tND;a4b7-bff5/tyf, PASS,
 
@@ -165,7 +165,7 @@
 
 # /examples/inet/hierarchical99/,      -f .qtenv.ini -c General -r 0
 /examples/inet/hierarchical99/,      -f networklayer.ini -c IPv4 -r 0,              10000s,          a94d-edae/tplx;1f32-e325/~tNl;b138-ee8b/~tND;66c9-cd73/tyf, PASS, EthernetMac Ipv4
-/examples/inet/hierarchical99/,      -f networklayer.ini -c IPv6 -r 0,              10000s,          0001-0108/tplx;3960-479e/~tNl;add1-e848/~tND;2c03-abef/tyf, PASS, EthernetMac
+/examples/inet/hierarchical99/,      -f networklayer.ini -c IPv6 -r 0,              10000s,          1675-2b68/tplx;5f66-74d8/~tNl;2248-9fa3/~tND;2c03-abef/tyf, PASS, EthernetMac
 /examples/inet/hierarchical99/,      -f networklayer.ini -c Generic -r 0,           10000s,          6ae4-6e75/tplx;2209-80ac/~tNl;93bf-6657/tyf, PASS, EthernetMac
 /examples/inet/hierarchical99/,      -f networklayer.ini -c Flooding -r 0,          10000s,          7ba7-5b91/tplx;b0f0-411e/~tNl;2b94-8906/tyf, PASS, EthernetMac
 /examples/inet/hierarchical99/,      -f networklayer.ini -c ProbabilisticBroadcast -r 0,              10000s,          5a54-9779/tplx;1165-a70b/~tNl;760b-abfc/tyf, PASS, EthernetMac
@@ -179,9 +179,9 @@
 /examples/inet/ipsec/,               -f omnetpp.ini -c TCPTraffic -r 0,             200s,            a2ab-cc8e/tplx;d76c-cb91/~tNl, PASS, IPSec
 /examples/inet/ipsec/,               -f omnetpp.ini -c UDPTraffic -r 0,             200s,            bfe2-5b42/tplx;3d88-94d1/~tNl, PASS, IPSec
 /examples/inet/ipsec/,               -f omnetpp.ini -c Multicast -r 0,              200s,            e53d-f92e/tplx;6ac3-ef6b/~tNl, PASS, IPSec
-/examples/inet/ipsec/,               -f ipv6.ini -c UDPTraffic6 -r 0,              200s,            bac2-fae6/tplx;d5ee-ccc0/~tNl, PASS, IPSec
-/examples/inet/ipsec/,               -f ipv6.ini -c TCPTraffic6 -r 0,              200s,            50b3-6ddd/tplx;c410-879b/~tNl, PASS, IPSec
-/examples/inet/ipsec/,               -f ipv6.ini -c Multicast6 -r 0,               200s,            e6f7-0820/tplx;1222-ffd8/~tNl, PASS, IPSec
+/examples/inet/ipsec/,               -f ipv6.ini -c UDPTraffic6 -r 0,              200s,            6c0d-e70c/tplx;fd91-6e76/~tNl, PASS, IPSec
+/examples/inet/ipsec/,               -f ipv6.ini -c TCPTraffic6 -r 0,              200s,            fe5e-9d9d/tplx;396d-b0e1/~tNl, PASS, IPSec
+/examples/inet/ipsec/,               -f ipv6.ini -c Multicast6 -r 0,               200s,            8c4d-0ef0/tplx;ac85-88d8/~tNl, PASS, IPSec
 
 /examples/inet/ipv4hook/,            -f omnetpp.ini -c General -r 0,                100s,            1afb-5eeb/tplx;3df8-bb36/~tNl;2891-5a4e/~tND;48e1-2966/tyf, PASS, EthernetMac Ipv4
 
@@ -319,9 +319,9 @@
 /examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Fragment_ipv4 -r 0,      10s,             f8fb-0997/tplx;3f90-c480/~tNl;0b85-3891/~tND;a03d-f93b/tyf, PASS, Ipv4
 /examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Port_Unav_ipv4 -r 0,     10s,             744f-ba84/tplx;e23b-dc11/~tNl;d637-dffb/~tND;bfe9-7735/tyf, PASS, Ipv4
 /examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Host_Unav_ipv4 -r 0,     10s,             acca-28f8/tplx;0000-0000/~tNl;0000-0000/~tND;d93d-fffd/tyf, PASS, Ipv4
-/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_OK_ipv6 -r 0,            10s,             d73a-ba68/tplx;3ffa-4292/~tNl;3f49-6ccd/~tND;4cbc-d8eb/tyf, PASS,
-/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Port_Unav_ipv6 -r 0,     10s,             fefe-0afc/tplx;402a-1aac/~tNl;c236-0e73/~tND;7c98-eece/tyf, PASS,
-/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Host_Unav_ipv6 -r 0,     10s,             289c-06ea/tplx;b123-55f0/~tNl;a861-f74f/~tND;11de-e77a/tyf, PASS,
+/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_OK_ipv6 -r 0,            10s,             717e-909f/tplx;c3fa-0078/~tNl;aafa-4948/~tND;4cbc-d8eb/tyf, PASS,
+/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Port_Unav_ipv6 -r 0,     10s,             bad4-fd5a/tplx;bc2a-5846/~tNl;e7b3-9bc0/~tND;7c98-eece/tyf, PASS,
+/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Host_Unav_ipv6 -r 0,     10s,             6cb6-f14c/tplx;f3c9-a9f0/~tNl;314d-dbe2/~tND;11de-e77a/tyf, PASS,
 /examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_OK_gn -r 0,              10s,             4460-ccf4/tplx;0000-0000/~tNl;0000-0000/~tND;1720-6af0/tyf, PASS,
 /examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Port_Unav_gn -r 0,       10s,             4460-ccf4/tplx;0000-0000/~tNl;0000-0000/~tND;1720-6af0/tyf, PASS,
 /examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Host_Unav_gn -r 0,       10s,             4460-ccf4/tplx;0000-0000/~tNl;0000-0000/~tND;1720-6af0/tyf, PASS,
@@ -336,28 +336,28 @@
 
 # /examples/ipv6/nclients/,            -f omnetpp.ini -c TCP_APP -r 0    # abstract-config
 # /examples/ipv6/nclients/,            -f omnetpp.ini -c SCTP_APP -r 0   # abstract-config
-/examples/ipv6/nclients/,            -f omnetpp.ini -c ETH -r 0,                    1000s,           5ceb-d724/tplx;f68f-bd29/~tNl;dc62-23bc/tyf, PASS, EthernetMac
+/examples/ipv6/nclients/,            -f omnetpp.ini -c ETH -r 0,                    1000s,           92f9-2427/tplx;9612-4e01/~tNl;dc62-23bc/tyf, PASS, EthernetMac
 
-/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP -r 0,                    1000s,           e456-89b4/tplx;495e-637d/~tNl;70e4-0b40/tyf, PASS,
-/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP_SCTP -r 0,               100s,            8e6b-b19c/tplx;72ba-2d33/~tNl;6414-b270/~tND;acbf-ec68/tyf, PASS,
+/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP -r 0,                    1000s,           b42f-eb50/tplx;ddb5-9d03/~tNl;70e4-0b40/tyf, PASS,
+/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP_SCTP -r 0,               100s,            eaec-d0a7/tplx;2f0a-8fd5/~tNl;0e37-1753/~tND;acbf-ec68/tyf, PASS,
 
 /examples/manetrouting/dsdv/,        -f omnetpp.ini -c IPv4 -r 0,                   10s,             2d1b-0515/tplx;1ba1-8398/~tNl;bed0-9954/~tND;4aa9-4bbb/tyf, PASS,  wireless adhoc Ipv4
-/examples/manetrouting/dsdv/,        -f omnetpp.ini -c MultiIPv4 -r 0,              10s,             a35f-3c51/tplx;9f80-f16d/~tNl;92cb-62b4/~tND;c4d3-2514/tyf, PASS,  wireless adhoc Ipv4
+/examples/manetrouting/dsdv/,        -f omnetpp.ini -c MultiIPv4 -r 0,              10s,             c9a5-41d1/tplx;b85d-0f44/~tNl;c3f8-86b4/~tND;c4d3-2514/tyf, PASS,  wireless adhoc Ipv4
 /examples/manetrouting/dsdv/,        -f omnetpp.ini -c DynamicIPv4 -r 0,            22s,             b5fe-a1b2/tplx;3e2c-1eee/~tNl;0af5-5bc7/~tND;70dc-efb6/tyf, PASS,  wireless adhoc Ipv4
 
 # /examples/manetrouting/dymo/,        -f omnetpp.ini -c _IPv4 -r 0      # abstract-config
 /examples/manetrouting/dymo/,        -f omnetpp.ini -c IPv4 -r 0,                   10s,             1a85-cb5d/tplx;dfe8-11b9/~tNl;2b10-4dcb/tyf, PASS,  wireless adhoc Ipv4
 # /examples/manetrouting/dymo/,        -f omnetpp.ini -c _IPv6 -r 0      # abstract-config
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c IPv6 -r 0,                   10s,             d3ef-c8cf/tplx;fd53-3e15/~tNl;8301-9264/tyf, PASS,  wireless adhoc
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c IPv6 -r 0,                   10s,             ed4c-72ae/tplx;6ec6-4c82/~tNl;8301-9264/tyf, PASS,  wireless adhoc
 # /examples/manetrouting/dymo/,        -f omnetpp.ini -c _Generic -r 0   # abstract-config
 /examples/manetrouting/dymo/,        -f omnetpp.ini -c Generic -r 0,                10s,             5f8a-7174/tplx;9713-e7fe/~tNl;5716-c166/tyf, PASS,  wireless adhoc
 # /examples/manetrouting/dymo/,        -f omnetpp.ini -c _Multi -r 0     # abstract-config
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiIPv4 -r 0,              10s,             b346-3570/tplx;7bce-e34f/~tNl;4782-99e5/tyf, PASS,  wireless adhoc Ipv4
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiIPv6 -r 0,              10s,             d3ef-c8cf/tplx;fd53-3e15/~tNl;3ba7-352e/tyf, PASS,  wireless adhoc
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiGeneric -r 0,           10s,             0354-6dd4/tplx;735c-957d/~tNl;31f0-2788/tyf, PASS,  wireless adhoc
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiIPv4 -r 0,              10s,             144a-acba/tplx;9a83-184c/~tNl;4782-99e5/tyf, PASS,  wireless adhoc Ipv4
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiIPv6 -r 0,              10s,             ed4c-72ae/tplx;6ec6-4c82/~tNl;3ba7-352e/tyf, PASS,  wireless adhoc
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiGeneric -r 0,           10s,             dec3-1ea0/tplx;85a3-5ff5/~tNl;31f0-2788/tyf, PASS,  wireless adhoc
 # /examples/manetrouting/dymo/,        -f omnetpp.ini -c _Dynamic -r 0   # abstract-config
 /examples/manetrouting/dymo/,        -f omnetpp.ini -c DynamicIPv4 -r 0,            22s,             2f57-3280/tplx;8f96-3d9c/~tNl;c33f-4f8c/tyf, PASS,  wireless adhoc Ipv4
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c DynamicIPv6 -r 0,            22s,             1e32-4f69/tplx;c684-e25f/~tNl;3469-a611/tyf, PASS,  wireless adhoc
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c DynamicIPv6 -r 0,            22s,             67b8-29ca/tplx;91f5-b323/~tNl;3469-a611/tyf, PASS,  wireless adhoc
 /examples/manetrouting/dymo/,        -f omnetpp.ini -c DynamicGeneric -r 0,         22s,             b68e-dfe3/tplx;9c68-c2d4/~tNl;8c4d-6bc7/tyf, PASS,  wireless adhoc
 
 # /examples/manetrouting/gpsr/,        -f omnetpp.ini -c Random -r 0,    # abstract-config
@@ -365,25 +365,25 @@
 # /examples/manetrouting/gpsr/,        -f omnetpp.ini -c _IPv6 -r 0,     # abstract-config
 # /examples/manetrouting/gpsr/,        -f omnetpp.ini -c _Generic -r 0,  # abstract-config
 /examples/manetrouting/gpsr/,        -f omnetpp.ini -c IPv4 -r 0,                   20s,             1128-a3bc/tplx;9f6c-df77/~tNl;5d32-0ae4/tyf, PASS,  wireless adhoc Ipv4
-/examples/manetrouting/gpsr/,        -f omnetpp.ini -c IPv6 -r 0,                   20s,             5a83-8612/tplx;2240-53c0/~tNl;f19e-13d3/tyf, PASS,  wireless adhoc
+/examples/manetrouting/gpsr/,        -f omnetpp.ini -c IPv6 -r 0,                   20s,             c555-09c6/tplx;8dc6-8c9e/~tNl;f19e-13d3/tyf, PASS,  wireless adhoc
 /examples/manetrouting/gpsr/,        -f omnetpp.ini -c Generic -r 0,                20s,             6b9d-8586/tplx;c58b-970e/~tNl;17f5-8ad3/tyf, PASS,  wireless adhoc
 # /examples/manetrouting/gpsr/,        -f omnetpp.ini -c _Multi -r 0,    # abstract-config
-/examples/manetrouting/gpsr/,        -f omnetpp.ini -c MultiIPv4 -r 0,              20s,             d4a1-5cf9/tplx;c727-b58f/~tNl;bf7d-a45f/tyf, PASS,  wireless adhoc Ipv4
-/examples/manetrouting/gpsr/,        -f omnetpp.ini -c MultiIPv6 -r 0,              20s,             5a83-8612/tplx;2240-53c0/~tNl;273d-a6b5/tyf, PASS,  wireless adhoc
-/examples/manetrouting/gpsr/,        -f omnetpp.ini -c MultiGeneric -r 0,           20s,             5c6b-556c/tplx;e56d-c248/~tNl;c35c-205b/tyf, PASS,  wireless adhoc
+/examples/manetrouting/gpsr/,        -f omnetpp.ini -c MultiIPv4 -r 0,              20s,             5457-25b2/tplx;6a05-561c/~tNl;bf7d-a45f/tyf, PASS,  wireless adhoc Ipv4
+/examples/manetrouting/gpsr/,        -f omnetpp.ini -c MultiIPv6 -r 0,              20s,             c555-09c6/tplx;8dc6-8c9e/~tNl;273d-a6b5/tyf, PASS,  wireless adhoc
+/examples/manetrouting/gpsr/,        -f omnetpp.ini -c MultiGeneric -r 0,           20s,             65eb-50a0/tplx;cf47-02cf/~tNl;c35c-205b/tyf, PASS,  wireless adhoc
 /examples/manetrouting/gpsr/,        -f omnetpp.ini -c Manual -r 0,                 20s,             41d0-4325/tplx;b911-bca9/~tNl;8a0e-d569/tyf, PASS,  wireless adhoc Ipv4
 # /examples/manetrouting/gpsr/,        -f omnetpp.ini -c _Dynamic -r 0,  # abstract-config
 /examples/manetrouting/gpsr/,        -f omnetpp.ini -c DynamicIPv4 -r 0,            20s,             ce31-f8ed/tplx;8a3b-235d/~tNl;3ecd-bfef/tyf, PASS,  wireless adhoc Ipv4
-/examples/manetrouting/gpsr/,        -f omnetpp.ini -c DynamicIPv6 -r 0,            20s,             6299-3bf9/tplx;3617-890d/~tNl;2653-aa28/tyf, PASS,  wireless adhoc
+/examples/manetrouting/gpsr/,        -f omnetpp.ini -c DynamicIPv6 -r 0,            20s,             d603-3ad0/tplx;49cd-c8da/~tNl;2653-aa28/tyf, PASS,  wireless adhoc
 /examples/manetrouting/gpsr/,        -f omnetpp.ini -c DynamicGeneric -r 0,         20s,             732c-c576/tplx;03c2-f3ec/~tNl;fb81-3dac/tyf, PASS,  wireless adhoc
 
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c MultiRadio -r 0,             20s,             ec17-5cc2/tplx;55f5-0894/~tNl, PASS,  wireless adhoc Ipv4
 /examples/manetrouting/multiradio/,  -f omnetpp.ini -c SingleRadio -r 0,            20s,             85a0-51b8/tplx;c07a-44e1/~tNl;3aa0-49ed/tyf, PASS,  wireless adhoc Ipv4
 
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             17ac-0898/tplx;8bbc-d083/~tNl;fdb7-4ab1/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             19e2-a165/tplx;d96c-5e41/~tNl;ee03-5334/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
-/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             123e-b941/tplx;4e91-d6bb/~tNl;8642-5854/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
-/examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             8bf1-01f5/tplx;c5d4-bce4/~tNl;0f9a-c178/~tND;0277-d784/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c Handover -r 0,                70s,             57c7-8b2d/tplx;cfe6-6ec3/~tNl;5613-f022/~tND;44ef-1a45/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6/,               -f omnetpp.ini -c RouteOptimizationTwoCNs -r 0,  60s,             28c8-d513/tplx;3dc9-d9de/~tNl;d770-d40d/~tND;ed3e-17fa/tyf, PASS, wireless EthernetMac
+/examples/ipv6/mipv6roaming/,        -f omnetpp.ini -c Roaming -r 0,                 70s,             8758-593b/tplx;0c71-36b5/~tNl;4077-996a/~tND;afae-2b3c/tyf, PASS, wireless EthernetMac
+/examples/ipv6/pmipv6/,              -f omnetpp.ini -c General -r 0,                 60s,             a43d-ac92/tplx;de7e-35a3/~tNl;9aed-07f6/~tND;0277-d784/tyf, PASS, wireless EthernetMac
 
 /examples/mobility/,                 -f omnetpp.ini -c AnsimMobility -r 0,          10000s,          72f8-5c0b/tplx;0000-0000/~tNl;0000-0000/~tND;7dd1-18eb/tyf, PASS,
 /examples/mobility,                  -f omnetpp.ini -c AttachedMobility,            10s,             566c-6355/tplx;0000-0000/~tNl;0000-0000/~tND;fa92-f68c/tyf, PASS,
@@ -453,10 +453,10 @@
 /examples/ospfv2/simpletest/,        -f omnetpp.ini -c ShutdownAndRestart -r 0,     500s,            fbe5-93ad/tplx;bc6e-6aa5/~tNl;1700-f363/~tND;7e87-b79f/tyf, PASS, EthernetMac Ipv4
 /examples/ospfv2/simpletest/,        -f omnetpp.ini -c CrashAndReboot -r 0,         500s,            73cc-e6f7/tplx;bc6e-6aa5/~tNl;1700-f363/~tND;8ea5-1a49/tyf, PASS, EthernetMac Ipv4
 
-/examples/ospfv3/multiple_areas_FINAL/, -f omnetpp.ini -c General -r 0,             500s,            5a6c-7b26/tplx;1cb8-4b4c/~tNl;c96e-af34/tyf;2d23-dc61/~tND, PASS, EthernetMac
-/examples/ospfv3/multiple_areas_FINAL/, -f omnetpp.ini -c LinkDown -r 0,            500s,            0a8e-1d2c/tplx;026a-465c/~tNl;058d-fbf3/tyf;5859-a357/~tND, PASS, EthernetMac
-/examples/ospfv3/multiple_areas_FINAL/, -f omnetpp.ini -c LinkDownLinkUp -r 0,      500s,            ca28-5d2b/tplx;e812-c9a5/~tNl;7d65-aa4c/tyf;8767-9c3b/~tND, PASS, EthernetMac
-/examples/ospfv3/small/,             -f omnetpp.ini -c General -r 0,                200s,            a507-2349/tplx;78bf-31e2/~tNl;441a-9244/tyf;4b8b-fb7a/~tND, PASS, EthernetMac
+/examples/ospfv3/multiple_areas_FINAL/, -f omnetpp.ini -c General -r 0,             500s,            60e2-599b/tplx;8a56-bf38/~tNl;c96e-af34/tyf;77be-157f/~tND, PASS, EthernetMac
+/examples/ospfv3/multiple_areas_FINAL/, -f omnetpp.ini -c LinkDown -r 0,            500s,            a906-b262/tplx;d031-fd8d/~tNl;058d-fbf3/tyf;1fcf-0425/~tND, PASS, EthernetMac
+/examples/ospfv3/multiple_areas_FINAL/, -f omnetpp.ini -c LinkDownLinkUp -r 0,      500s,            e1fb-f5c9/tplx;1c66-5f4b/~tNl;7d65-aa4c/tyf;ddfa-5525/~tND, PASS, EthernetMac
+/examples/ospfv3/small/,             -f omnetpp.ini -c General -r 0,                200s,            50f3-d619/tplx;ab6a-8069/~tNl;441a-9244/tyf;2606-fa92/~tND, PASS, EthernetMac
 /examples/ospfv3/v3_2_routers/,      -f omnetpp.ini -c General -r 0,                400s,            b94b-8c51/tplx;536c-1525/~tNl;993e-1af3/tyf;bb52-b309/~tND, PASS, EthernetMac
 /examples/ospfv3/v3_2_routers/,      -f omnetpp.ini -c LinkDownAndUp -r 0,          400s,            24d9-8a90/tplx;d598-192b/~tNl;c4df-4e3f/tyf;b19b-722d/~tND, PASS, EthernetMac
 /examples/ospfv3/v3_3_areas/,        -f omnetpp.ini -c General -r 0,               3000s,            7cc4-6f54/tplx;18bf-6f31/~tNl;ddbf-753a/tyf;89ed-849f/~tND, PASS, EthernetMac
@@ -528,8 +528,8 @@
 /examples/rip/mixednetwork/,         -f omnetpp.ini -c disconnect -r 0,             100s,            cff2-9525/tplx;ba53-ebda/~tNl;24fe-02a7/~tND;65b9-9e8c/tyf, PASS, EthernetMac Ipv4
 /examples/rip/mixednetwork/,         -f omnetpp.ini -c shutdown-restart -r 0,       100s,            3f15-0c9c/tplx;0916-8bd0/~tNl;bdd5-b370/~tND;3d73-91e0/tyf, PASS, EthernetMac Ipv4
 /examples/rip/simpletest/,           -f omnetpp.ini -c IPv4 -r 0,                   100s,            e4b8-5591/tplx;eede-9ed7/~tNl;9364-b90a/~tND;bac1-99b5/tyf, PASS, EthernetMac Ipv4
-/examples/rip/simpletest/,           -f omnetpp.ini -c IPv6 -r 0,                   100s,            86c3-66f0/tplx;ce03-6f52/~tNl;883f-6d71/tyf, PASS, EthernetMac
-/examples/rip/simpletest/,           -f omnetpp.ini -c MultiIPv4 -r 0,              100s,            640c-b305/tplx;2dde-f981/~tNl;595e-ecc4/~tND;3d31-178a/tyf, PASS, EthernetMac Ipv4
+/examples/rip/simpletest/,           -f omnetpp.ini -c IPv6 -r 0,                   100s,            ddce-602c/tplx;acb6-346f/~tNl;883f-6d71/tyf, PASS, EthernetMac
+/examples/rip/simpletest/,           -f omnetpp.ini -c MultiIPv4 -r 0,              100s,            ef6d-13de/tplx;10bc-4cda/~tNl;f273-6b9a/~tND;3d31-178a/tyf, PASS, EthernetMac Ipv4
 
 /examples/rtp/multicast1/,           -f omnetpp.ini -c General -r 0,                500s,           3b10-2c5c/tplx;b015-6f81/~tNl;5260-d4c2/~tND;d294-df5c/tyf, PASS, igmp Ipv4
 /examples/rtp/unicast/,              -f omnetpp.ini -c General -r 0,                1500s,           0055-d76b/tplx;7c48-14c9/~tNl;f185-90f2/~tND;c576-873e/tyf, PASS, Ipv4

--- a/tests/fingerprint/mipv6-refactoring.csv
+++ b/tests/fingerprint/mipv6-refactoring.csv
@@ -18,19 +18,19 @@
 # causes parsimPack() to abort — use ~tNl (no parsim serialization) instead; tyf excluded as unreliable
 /examples/ipv6/mld/,            -f omnetpp.ini -c MldDemo -r 0,              30s,             f1b1-b523/~tNl, PASS, EthernetMac MLD
 /examples/ipv6/mld/,            -f omnetpp.ini -c MldV2Ssm -r 0,            30s,             a22a-81c9/~tNl, PASS, EthernetMac MLD
-/examples/ipv6/nclients/,            -f omnetpp.ini -c ETH -r 0,                    1000s,           50c9-9bb3/~tNlb, PASS, EthernetMac
-/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP -r 0,                    1000s,           0e0c-b800/~tNlb, PASS,
-/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP_SCTP -r 0,               100s,            06b9-ff17/~tNlb, PASS,
+/examples/ipv6/nclients/,            -f omnetpp.ini -c ETH -r 0,                    1000s,           ae8a-8c69/~tNlb, PASS, EthernetMac
+/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP -r 0,                    1000s,           f95b-bf3b/~tNlb, PASS,
+/examples/ipv6/nclients/,            -f omnetpp.ini -c PPP_SCTP -r 0,               100s,            ab1e-9aa0/~tNlb, PASS,
 
 # IPv6 networking examples
-/examples/inet/hierarchical99/,      -f networklayer.ini -c IPv6 -r 0,              10000s,          f206-a0e2/~tNlb, PASS, EthernetMac
-/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_OK_ipv6 -r 0,            10s,             8feb-3936/~tNlb, PASS,
-/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Port_Unav_ipv6 -r 0,     10s,             9661-c1f5/~tNlb, PASS,
-/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Host_Unav_ipv6 -r 0,     10s,             6360-9ed1/~tNlb, PASS,
+/examples/inet/hierarchical99/,      -f networklayer.ini -c IPv6 -r 0,              10000s,          6574-3289/~tNlb, PASS, EthernetMac
+/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_OK_ipv6 -r 0,            10s,             cbbd-f1df/~tNlb, PASS,
+/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Port_Unav_ipv6 -r 0,     10s,             07b3-4cca/~tNlb, PASS,
+/examples/inet/udpclientserver/,     -f omnetpp.ini -c udp_Host_Unav_ipv6 -r 0,     10s,             273f-5638/~tNlb, PASS,
 
 # DYMO with IPv6
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c IPv6 -r 0,                   10s,             bbf0-c890/~tNlb, PASS,  wireless adhoc
-/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiIPv6 -r 0,              10s,             bbf0-c890/~tNlb, PASS,  wireless adhoc
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c IPv6 -r 0,                   10s,             3f4a-17a7/~tNlb, PASS,  wireless adhoc
+/examples/manetrouting/dymo/,        -f omnetpp.ini -c MultiIPv6 -r 0,              10s,             3f4a-17a7/~tNlb, PASS,  wireless adhoc
 
 # EIGRP with IPv6
 /examples/eigrp/testing_scenario6/,    -f omnetpp.ini -c EIGRP-IPv6_exp1_bandwidth-change -r 0,              3min,         c645-565e/~tNlb,  PASS,  eigrp EthernetMac


### PR DESCRIPTION
A node sent the first Neighbor Solicitation of Duplicate Address Detection in
the same event in which it formed the tentative address, and added the random
delay to the timeout instead. RFC 4862 Section 5.4.2 puts the delay before the
probe, not after it.

Closes #1179

**Please read *The open question* below before merging.** This branch leaves two
Mobile IPv6 protocol tests failing, and how to resolve that is a question for
their author.

## The problem

RFC 4862 Section 5.4.2 requires an interface to join the solicited-node
multicast address of the tentative address *before* it sends a Neighbor
Solicitation for it, and asks the node to delay that join by a random time of up
to MAX_RTR_SOLICITATION_DELAY, one second:

> Before sending a Neighbor Solicitation, an interface MUST join the all-nodes
> multicast address and the solicited-node multicast address of the tentative
> address.

> If the Neighbor Solicitation is going to be the first message sent from an
> interface after interface (re)initialization, the node SHOULD delay joining
> the solicited-node multicast address by a random delay between 0 and
> MAX_RTR_SOLICITATION_DELAY as specified in [RFC4861]. This serves to alleviate
> congestion when many nodes start up on the link at the same time, such as
> after a power failure, and may help to avoid race conditions when more than
> one node is trying to solicit for the same address at the same time.

The join has to precede the solicitation, so delaying the join delays the
solicitation with it. `initiateDad()` kept the random draw but added it to the
timeout: the probe went out immediately and the node then listened for between
one and two seconds, instead of waiting up to one second and then listening for
`RetransTimer`. Its comment names the right section and the right reason; only
the code disagrees.

Two things are wrong, and neither makes detection less safe -- a node that
probes early and listens longer covers the same window. They are conformance and
timing defects.

1. There is no delay before the first probe at all. Nodes brought up at the same
   instant probe at the same instant, which is the congestion and the race the
   delay exists to avoid, and a capture taken from INET does not look like one
   from a real host during boot.
2. The probes are unevenly spaced. The first two are `RetransTimer` plus the
   draw apart while every later pair is `RetransTimer` apart, against the same
   section's "each separated by RetransTimer milliseconds".

In `examples/ipv6/nclients`, config `ETH`, on master:

| Event | Time |
| --- | --- |
| `cli[0]` forms its tentative link-local address | 0.922007 s |
| `cli[0]` transmits its first Neighbor Solicitation | 0.922007 s -- the same event |
| `cli[0]` completes Duplicate Address Detection | 2.866676 s |

The check ran for 1.944669 s rather than the 1 s of `RetransTimer`.

## The fix

Schedule the timer with the random delay alone and leave the sending to
`processDadTimeout()`, which already sends a solicitation and rearms the timer
whenever fewer than `DupAddrDetectTransmits` have gone out. That also repairs the
probe spacing.

Only the probe moves. The random draw is the same one, so the check still ends
where it did: `cli[0]` starts at 0.922007 s and completes at 2.866676 s exactly
as before, but the probe is now at 1.866676 s, and completion is `RetransTimer`
after the probe rather than `RetransTimer` plus a random delay after the address
was formed. The node is listening throughout, because the tentative address is on
the interface before the delay starts -- which is what the same section asks for
when it requires an interface to "receive and process datagrams sent to the
all-nodes multicast address or solicited-node multicast address of the tentative
address during the delay period".

## The open question

Moving every node's first probe by up to one second re-phases a wireless Mobile
IPv6 handover: after re-associating, the mobile node catches a later Router
Advertisement, and its care-of address is formed about 5.4 s later than on
master. Home registration moves from 66.707 s to 72.043 s.

That breaks both Mobile IPv6 tests in `tests/protocol/ipv6`, which were tuned to
master's timeline:

- `Mipv6Registration.test` passes again after moving the three tuned numbers by
  the same amount the handover moved: the step-0 deadline 72 s to 78 s, the
  correspondent node's ping start 71 s to 77 s, and `sim-time-limit` 85 s to 91 s.
- `Mipv6Interface.test` still fails after that, and the reason is not a tuning
  number. With the new phase the Care-of Test reply arrives at 77.002006 s,
  1.9 ms *before* the tester finishes matching its step 2 at 77.003946 s, so it
  falls outside step 3's window. The care-of round trip goes direct while the
  home round trip goes through the home agent, so the reply can come back before
  the Home Test Init is even sent; the test's split of the exchange into an
  ordered step 2 and step 3 assumes the other order.

Neither test is touched by this branch. Retuning them, merging their steps 2 and
3 into one unordered group, or holding this fix are all reasonable, and the
choice belongs with the tests' author.

## Verification

```
cd tests/fingerprint && ./fingerprinttest -s -F tyf
cd tests/module      && inet_run_module_tests   -m release -f 'IPv6|MIPv6|Ipv6'
cd tests/protocol/ipv6 && inet_run_protocol_tests -m release
bash doc/project/enforcement/check-commits.sh origin/master..HEAD
```

The fingerprint suite is run whole -- all 1774 rows of every `.csv`, not an
IPv6-filtered subset -- because this change moves rows whose configuration names
do not contain the string `ipv6`: `examples/ospfv3`, `examples/bgpv4`,
`examples/manetrouting/dymo`, `gpsr` and `dsdv`, `examples/rip/simpletest` and
`examples/inet/hierarchical99`.

Unmodified master gives 1774 rows with 3 failures and 62 errors, and so does
this branch. The 62 errors are disabled optional features -- `VoIPStream`,
`TcpLwip`, `VoipStreamSender` -- and have nothing to do with IPv6. The 3 failures
are `examples/ipv6/mipv6` `Handover` and `RouteOptimizationTwoCNs` and
`examples/ipv6/mipv6roaming` `Roaming`, all `~tNlb` rows of
`mipv6-refactoring.csv`. Their recorded values are stale on master already, so
they keep them here; re-recording them would absorb that staleness rather than
fix it.

Baselines re-recorded: 45 rows, 36 in `examples.csv` and 9 in
`mipv6-refactoring.csv`, covering every example with IPv6 nodes -- every node in
an IPv6 network sends these solicitations at startup. 't' moves because the
probes and their replies happen at new times; 'p' and 'N' with the modules and
nodes those events run in; 'l', 'b' and 'D' because the solicitations enter the
hash at different points; 'x' with the event sequence. Graphical ('tyf')
fingerprints were excluded from every run and are unchanged.

### Landing order against #1181

#1181, the pull request for #1178, re-records 20 of the same fingerprint rows as this branch -- 16 in
`examples.csv` and 4 in `mipv6-refactoring.csv`, in `examples/ipv6/nclients`,
`examples/bgpv4` over IPv6, `examples/inet/hierarchical99` `IPv6`,
`examples/manetrouting/gpsr` and `examples/rip/simpletest`. Both branches record
those values against plain master, because each has to stand on its own, so the
two conflict textually in `tests/fingerprint/examples.csv` and
`tests/fingerprint/mipv6-refactoring.csv`, and **whichever lands second needs
those 20 rows re-recorded on top of the first**. Ping me and I will do it for
whichever order you prefer.

The source changes do not conflict: they touch disjoint parts of
`Ipv6NeighbourDiscovery.cc`.

Module tests: 42 tests, 40 pass. `MIPv6_tcp_handover` and `IPv6_packet_too_big`
fail identically on unmodified master.

Protocol tests, `tests/protocol/ipv6`: 29 tests, 19 pass and 8 expected failures.
`Mipv6Registration` and `Mipv6Interface` are unexpected failures, for the reason
set out under *The open question*. Master gives 21 pass and the same 8 expected
failures.

`tests/fingerprint/store.json`, the separate expectation store `opp_repl` reads,
is deliberately left alone. It is already out of step with the `.csv` baselines
for these rows on master: for `examples/ipv6/nclients` `ETH` at the same
directory, ini file, configuration, run and time limit it holds `tplx`
`c5d4-8871` where `examples.csv` holds `5ceb-d724`, and for
`examples/inet/udpclientserver` `udp_OK_ipv6` it holds `8fe6-9756` where
`examples.csv` holds `d73a-ba68`. That drift predates this branch and, as
3a9cc276bb records, no single source commit causes it; it belongs in a
baseline-only commit of its own.

`check-commits.sh` passes. `check-architecture.sh` and `check-naming.sh` report
only candidates already present on master, in `src/inet/applications/sctpapp`,
`src/inet/applications/rtpapp` and `images/misc`.

## Architectural surface

No contract, packet content, configuration surface or feature descriptor
changes, and no sealed path is touched. No new `AV-*` or `NV-*` row is needed.

## Not addressed here

`startAddressProbe()` on the `topic/gy/mipv6-ha-dad` branch repeats the same
scheduling that this branch fixes, and will need the same change when that branch
is rebased.

Two further Neighbour Discovery conformance defects are fixed separately, in
#1178 (the initial Router Advertisement clamp) and #1180 (address lifetimes on a
repeated prefix).
