### PR TITLE
ieee80211: preserve all 12 bits of the A-MPDU delimiter length

### DIFF
--- a/src/inet/linklayer/ieee80211/mac/Ieee80211MacHeaderSerializer.cc
+++ b/src/inet/linklayer/ieee80211/mac/Ieee80211MacHeaderSerializer.cc
@@ -137,8 +137,11 @@ const Ptr<Chunk> Ieee80211MpduSubframeHeaderSerializer::deserializeFields(Memory
 {
     auto mpduSubframe = makeShared<Ieee80211MpduSubframeHeader>();
     stream.readUint4();
-    mpduSubframe->setLength(stream.readUint4() >> 8);
-    mpduSubframe->setLength(stream.readUint8());
+    // IEEE Std 802.11-2024, 9.7.1, Table 9-659 and Figure 9-1330:
+    // in an HT PPDU, MPDU Length Low is 12 bits and MPDU Length High is reserved.
+    int length = stream.readUint4() << 8;
+    length |= stream.readUint8();
+    mpduSubframe->setLength(length);
     stream.readByte();
     stream.readByte();
     return mpduSubframe;

--- a/tests/unit/Ieee80211MpduSubframeHeaderSerializer_1.test
+++ b/tests/unit/Ieee80211MpduSubframeHeaderSerializer_1.test
@@ -1,0 +1,42 @@
+%description:
+The MPDU subframe header decoder preserves all 12 length bits emitted by the encoder.
+Check decoded fields through the registered serializer using fresh byte-backed packets,
+so cached serialized bytes cannot hide an incorrect decoded length.
+
+%includes:
+#include <vector>
+
+#include "inet/common/packet/Packet.h"
+#include "inet/common/packet/chunk/BytesChunk.h"
+#include "inet/linklayer/ieee80211/mac/Ieee80211Frame_m.h"
+
+using namespace inet;
+using namespace inet::ieee80211;
+
+%global:
+static void checkDecodedLength(const std::vector<uint8_t>& bytes, int expectedLength)
+{
+    Packet input("input", makeShared<BytesChunk>(bytes));
+    auto header = input.popAtFront<Ieee80211MpduSubframeHeader>(B(4));
+    ASSERT(header->getLength() == expectedLength);
+    ASSERT(header->getChunkLength() == B(4));
+    ASSERT(input.getDataLength() == B(0));
+}
+
+%activity:
+for (int length : {0, 255, 256, 0xABC, 4095}) {
+    auto header = makeShared<Ieee80211MpduSubframeHeader>();
+    header->setLength(length);
+    Packet output("output", header);
+    auto bytes = output.peekAllAsBytes()->getBytes();
+    ASSERT(bytes.size() == 4);
+    checkDecodedLength(bytes, length);
+}
+
+// Fixed input in the existing encoder's format, independent of the round trip.
+checkDecodedLength({0x0A, 0xBC, 0x00, 0x4E}, 0xABC);
+
+EV << "MPDU subframe lengths preserved across the 8-bit boundary.\n";
+
+%contains: stdout
+MPDU subframe lengths preserved across the 8-bit boundary.


### PR DESCRIPTION
## What

Preserve all 12 bits of the A-MPDU delimiter length when deserializing `Ieee80211MpduSubframeHeader` in `Ieee80211MpduSubframeHeaderSerializer`.

## Why

In `Ieee80211MpduSubframeHeaderSerializer::deserializeFields()`, the decoder previously discarded the high length nibble and overwrote the length with only the low byte:
```cpp
stream.readUint4();
mpduSubframe->setLength(stream.readUint4() >> 8);
mpduSubframe->setLength(stream.readUint8());
```
Because `readUint4() >> 8` evaluates to 0 and the subsequent `setLength(stream.readUint8())` unconditionally overwrote the length with only the low 8 bits, any delimiter length >= 256 had its upper 4 bits discarded (e.g., decoding `0xABC` as `0x0BC`).

Restoring:
```cpp
int length = stream.readUint4() << 8;
length |= stream.readUint8();
mpduSubframe->setLength(length);
```
restores symmetry with `serializeFields()`, which emits the 12-bit length across the high nibble and low byte per IEEE Std 802.11 A-MPDU delimiter specifications.

## Reading Order

This PR consists of a single self-contained commit:
1. `97fdb7ba2e` — `ieee80211: preserve all 12 bits of the A-MPDU delimiter length`
   - **Single decision & rationale:** Fixes 12-bit length deserialization in `Ieee80211MpduSubframeHeaderSerializer::deserializeFields` and adds unit test `Ieee80211MpduSubframeHeaderSerializer_1.test` verifying round-trip serialization/deserialization across byte boundaries (0, 255, 256, 0xABC, 4095) and fixed-byte decoding.
   - **Component surface:**
     - `src/inet/linklayer/ieee80211/mac/Ieee80211MacHeaderSerializer.cc`
     - `tests/unit/Ieee80211MpduSubframeHeaderSerializer_1.test`

## Architectural Surface

- **Modules touched:**
  - `src/inet/linklayer/ieee80211/mac/Ieee80211MacHeaderSerializer.cc`
  - `tests/unit/Ieee80211MpduSubframeHeaderSerializer_1.test`
- **Contracts and protocols:** IEEE 802.11 MAC A-MPDU subframe header chunk serializer (`Ieee80211MpduSubframeHeaderSerializer`).
- **Packet representation:** Preserves existing `Ieee80211MpduSubframeHeader` chunk definition; fixes deserialization of byte-backed packets into chunk fields.
- **Configuration surface:** None.
- **Feature descriptors:** None.
- **Seals and audit exceptions:** All modified source files under `src/inet/` are unsealed (`doc/project/enforcement/check-source-seals.sh` PASS). No architectural deviations (`AV-*`) or naming deviations (`NV-*`) introduced.

## Baselines

All fingerprint tests passed. No fingerprint or statistical baseline updates required.

## Verification Evidence

1. **Compilation:**
   - `make MODE=debug -j$(nproc)`: Clean build (`libINET_dbg.so`).
   - `make MODE=release -j$(nproc)`: Clean build (`libINET.so`).
2. **Mechanical gates:**
   - `doc/project/enforcement/check-commits.sh upstream/master..HEAD`: PASS (1 commit, linear, valid subject/facts format, clean splits).
   - `doc/project/enforcement/check-source-seals.sh --base upstream/master`: PASS (all touched files unsealed).
   - `doc/project/enforcement/check-naming.sh --base upstream/master`: PASS (0 mechanical candidates in changed files).
   - `doc/project/enforcement/check-architecture.sh src/inet/linklayer/ieee80211`: PASS (clean architecture).
3. **Direct unit tests:**
   - `inet_run_unit_tests -m debug -f 'Ieee80211MpduSubframeHeaderSerializer.*'`: PASS (`Ieee80211MpduSubframeHeaderSerializer_1.test` passed in 0.594s).
4. **Fingerprint tests:**
   - All tests passed.