### PR TITLE
Fix SharingRegionTagSet::removeTagsWherePresent<T>() wiping tags of every type

### DIFF
--- a/src/inet/common/packet/tag/SharingRegionTagSet.cc
+++ b/src/inet/common/packet/tag/SharingRegionTagSet.cc
@@ -331,5 +331,62 @@ void SharingRegionTagSet::prepareTagsVectorForUpdate()
     }
 }
 
+void SharingRegionTagSet::clearTags(const std::type_info& typeInfo, b offset, b length)
+{
+    if (regionTags != nullptr) {
+        bool changed = false;
+        b clearStartOffset = offset;
+        b clearEndOffset = offset + length;
+        for (size_t i = 0; i < regionTags->size(); i++) {
+            auto& regionTag = (*regionTags)[i];
+            auto tagObject = regionTag.getTag().get();
+            if (typeInfo != typeid(*tagObject))
+                // wrong type, leave it alone
+                continue;
+            else if (clearEndOffset <= regionTag.getStartOffset() || regionTag.getEndOffset() <= clearStartOffset)
+                // no intersection
+                continue;
+            else if (clearStartOffset <= regionTag.getStartOffset() && regionTag.getEndOffset() <= clearEndOffset) {
+                // clear totally covers region
+                prepareTagsVectorForUpdate();
+                regionTags->erase(regionTags->begin() + i--);
+                changed = true;
+            }
+            else if (regionTag.getStartOffset() < clearStartOffset && clearEndOffset < regionTag.getEndOffset()) {
+                // clear splits region into two parts
+                prepareTagsVectorForUpdate();
+                auto& regionTag = (*regionTags)[i];
+                auto startOffset = regionTag.getStartOffset();
+                regionTag.setLength(regionTag.getEndOffset() - clearEndOffset);
+                regionTag.setOffset(clearEndOffset);
+                RegionTag<TagBase> previousRegionTag(regionTag);
+                previousRegionTag.setOffset(startOffset);
+                previousRegionTag.setLength(clearStartOffset - startOffset);
+                regionTags->insert(regionTags->begin() + i++, previousRegionTag);
+                changed = true;
+            }
+            else if (regionTag.getEndOffset() <= clearEndOffset) {
+                // clear cuts end of region
+                prepareTagsVectorForUpdate();
+                auto& regionTag = (*regionTags)[i];
+                regionTag.setLength(clearStartOffset - regionTag.getStartOffset());
+                changed = true;
+            }
+            else if (clearStartOffset <= regionTag.getStartOffset()) {
+                // clear cuts beginning of region
+                prepareTagsVectorForUpdate();
+                auto& regionTag = (*regionTags)[i];
+                regionTag.setLength(regionTag.getEndOffset() - clearEndOffset);
+                regionTag.setOffset(clearEndOffset);
+                changed = true;
+            }
+            else
+                ASSERT(false);
+        }
+        if (changed)
+            sortTagsVector();
+    }
+}
+
 } // namespace
 

--- a/src/inet/common/packet/tag/SharingRegionTagSet.h
+++ b/src/inet/common/packet/tag/SharingRegionTagSet.h
@@ -137,6 +137,7 @@ class INET_API SharingRegionTagSet : public cObject
     int getTagIndex(const std::type_info& typeInfo, b offset, b length) const;
     template<typename T> int getTagIndex(b offset, b length) const;
 
+    void clearTags(const std::type_info& typeInfo, b offset, b length);
     void ensureTagsVectorAllocated();
     void prepareTagsVectorForUpdate();
     inline void sortTagsVector();
@@ -493,7 +494,7 @@ inline std::vector<SharingRegionTagSet::RegionTag<T>> SharingRegionTagSet::remov
 {
     SELFDOC_FUNCTION_T;
     auto result = getAllTags<T>(offset, length);
-    clearTags(offset, length);
+    clearTags(typeid(T), offset, length);
     return result;
 }
 

--- a/tests/packet/UnitTest.cc
+++ b/tests/packet/UnitTest.cc
@@ -1821,6 +1821,16 @@ static void testRegionTagSet()
     ASSERT(regionTagSet.getRegionTag(1).getOffset() == b(1500) && regionTagSet.getRegionTag(1).getLength() == b(500));
     }
 
+    { // 11b. removeTagsWherePresent only removes tags of the specified type
+    SharingRegionTagSet regionTagSet;
+    regionTagSet.addTag<CreationTimeTag>(b(0), b(1000));
+    regionTagSet.addTag<PropagationTimeTag>(b(0), b(1000));
+    const auto& removed = regionTagSet.removeTagsWherePresent<CreationTimeTag>(b(0), b(1000));
+    ASSERT(removed.size() == 1);
+    ASSERT(regionTagSet.getNumTags() == 1);
+    ASSERT(regionTagSet.findTag<PropagationTimeTag>(b(0), b(1000)) != nullptr);
+    }
+
     { // 12. copyTags
     SharingRegionTagSet regionTagSet1;
     SharingRegionTagSet regionTagSet2;


### PR DESCRIPTION
Fixes #1184

`removeTagsWherePresent<T>()` filtered its return value by `T` but called the untyped `clearTags(offset, length)`, which wipes every region tag intersecting the range regardless of type. This adds a type-aware `clearTags(typeInfo, offset, length)` overload — reusing the existing intersection logic with the same `typeInfo != typeid(*tagObject) -> continue` guard `getTagIndex()` already uses and calls it from `removeTagsWherePresent<T>()` via `clearTags(typeid(T), ...)`.

The untyped `clearTags(offset, length)` is unchanged, since it's type-blind by design and backs the public `clearTags()`/`clearRegionTags()`.

Added a regression test (`11b` in `testRegionTagSet()`) reproducing the exact scenario from the issue: two different tag types over the same region, removing one type by `T` no longer wipes the other.